### PR TITLE
allow coef() to work on classes that contain lavaan

### DIFF
--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -441,7 +441,7 @@ lavInspect.lavaan <- function(object,
 # been save somewhere)
 lav_object_inspect_est <- function(object) {
     
-    if(class(object) == "lavaan") {
+    if(inherits(object, "lavaan")) {
         # from 0.5-19, they are in the partable
         if(!is.null(object@ParTable$est)) {
             OUT <- object@ParTable$est


### PR DESCRIPTION
Here is a small change so that coef() works with objects of class blavaan and others that contain lavaan. Otherwise, there is an infinite recursion whereby coef() calls lav_object_inspect_est(), which calls coef(), etc...

Ed