### PR TITLE
avoid PML warnings when there are multiple groups

### DIFF
--- a/R/lav_model_gradient.R
+++ b/R/lav_model_gradient.R
@@ -108,7 +108,7 @@ lav_model_gradient <- function(lavmodel       = NULL,
             PI <- computePI(lavmodel = lavmodel, GLIST = GLIST)
         }
         if(estimator == "PML") {
-            if(lavmodel@nexo > 0L) {
+            if(any(lavmodel@nexo > 0L)) {
                 PI <- computePI(lavmodel = lavmodel)
             } else {
                 PI <- vector("list", length = lavmodel@nblocks)

--- a/R/lav_model_information.R
+++ b/R/lav_model_information.R
@@ -355,7 +355,7 @@ lav_model_information_firstorder <- function(lavmodel       = NULL,
         Delta <- computeDelta(lavmodel = lavmodel)
         Sigma.hat <- computeSigmaHat(lavmodel = lavmodel)
         TH <- computeTH(lavmodel = lavmodel)
-        if(lavmodel@nexo > 0L) {
+        if(any(lavmodel@nexo > 0L)) {
             PI <- computePI(lavmodel = lavmodel)
         } else {
             PI <- vector("list", length = lavsamplestats@ngroups)

--- a/R/lav_model_objective.R
+++ b/R/lav_model_objective.R
@@ -77,7 +77,7 @@ lav_model_objective <- function(lavmodel       = NULL,
             PI <- computePI(lavmodel = lavmodel, GLIST = GLIST)
         }
         if(estimator == "PML") {
-            if(lavmodel@nexo > 0L) {
+            if(any(lavmodel@nexo > 0L)) {
                 PI <- computePI(lavmodel = lavmodel)
             } else {
                 PI <- vector("list", length = lavsamplestats@ngroups)


### PR DESCRIPTION
When using estimator PML with multiple groups, there is a minor warning related to the fact that there is more than one entry in `lavmodel@nexo`.

So I added any() in the appropriate places.

Ed