### PR TITLE
add ETA argument to lavPredict(), for specified lv values

### DIFF
--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -21,7 +21,7 @@ function(object, newdata = NULL) {
 # main function
 lavPredict <- function(object, type = "lv", newdata = NULL, method = "EBM",
                        se.fit = FALSE, label = TRUE, fsm = FALSE,
-                       optim.method = "bfgs") {
+                       optim.method = "bfgs", ETA = NULL) {
 
     stopifnot(inherits(object, "lavaan"))
     lavmodel       <- object@Model
@@ -65,7 +65,10 @@ lavPredict <- function(object, type = "lv", newdata = NULL, method = "EBM",
     }
 
     if(type == "lv") {
-
+        if(!is.null(ETA)) {
+            warning("lavaan WARNING: lvs will be predicted here; supplying ETA has no effect")
+        }
+            
         # post fit check (lv pd?)
         ok <- lav_object_post_check(object)
         #if(!ok) {
@@ -123,7 +126,7 @@ lavPredict <- function(object, type = "lv", newdata = NULL, method = "EBM",
                    lavdata = lavdata, lavsamplestats = lavsamplestats,
                    lavimplied = lavimplied,
                    data.obs = data.obs, eXo = eXo,
-                   ETA = NULL, method = method, optim.method = optim.method)
+                   ETA = ETA, method = method, optim.method = optim.method)
 
         # label?
         if(label) {
@@ -137,7 +140,7 @@ lavPredict <- function(object, type = "lv", newdata = NULL, method = "EBM",
         out <- lav_predict_fy(lavobject = NULL, lavmodel = lavmodel,
                    lavdata = lavdata, lavsamplestats = lavsamplestats,
                    data.obs = data.obs, eXo = eXo,
-                   ETA = NULL, method = method, optim.method = optim.method)
+                   ETA = ETA, method = method, optim.method = optim.method)
 
         # label?
         if(label) {
@@ -658,8 +661,8 @@ lav_predict_yhat <- function(lavobject = NULL, # for convience
     } else {
         # list
         if(is.matrix(ETA)) { # user-specified?
-            tmp <- ETA; ETA <- vector("list", length=lavdata@ngroups)
-            ETA[seq_len(lavdata@ngroups)] <- list(tmp)
+            tmp <- ETA
+            ETA <- lapply(1:lavdata@ngroups, function(i) tmp[lavdata@case.idx[[i]],])
         } else if(is.list(ETA)) {
             stopifnot(lavdata@ngroups == length(ETA))
         }

--- a/man/lavPredict.Rd
+++ b/man/lavPredict.Rd
@@ -9,7 +9,7 @@ values for the indicators of these latent variables.}
 \usage{
 lavPredict(object, type = "lv", newdata = NULL, method = "EBM",
            se.fit = FALSE, label = TRUE, fsm = FALSE, 
-           optim.method = "bfgs")
+           optim.method = "bfgs", ETA = NULL)
 }
 \arguments{
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
@@ -31,6 +31,8 @@ the Empirical Bayes Modal approach.}
 If \code{"nlminb"} (the default in 0.5), the \code{"nlminb()"} function is used 
 for the optimization. If \code{"bfgs"} or \code{"BFGS"} (the default in 0.6), 
 the \code{"optim()"} function is used with the BFGS method.}
+\item{ETA}{An optional matrix or list, containing latent variable values
+  for each observation. Used for computations when \code{type = "ov"}.}
 }
 \details{
 The \code{predict()} function calls the \code{lavPredict()} function 


### PR DESCRIPTION
This exposes the ETA argument to users in lavPredict(), so that it is possible to obtain ov predictions that include custom values of ETA. It seems like the underlying function, lav_predict_yhat, was already set up to do this, and the user just needs a way to get there via an exported function. And this will be personally helpful for evaluating some marginal likelihoods in the non-normal case.

Also, fwiw, it looks like lavPredict() with type="fy" is broken. I started to look at fixing it, but then I wasn't sure whether it was supposed to work (especially because type="fy" is not documented). I can go back to try and fix it if you want.

Thanks,
Ed