### PR TITLE
update(fit, add=...) calls lav_object_extended()

### DIFF
--- a/R/lav_partable_merge.R
+++ b/R/lav_partable_merge.R
@@ -111,7 +111,7 @@ lav_partable_merge <- function(pt1 = NULL, pt2 = NULL,
         if(length(idx)) {
             if(warn) {
                 warning("lavaan WARNING: duplicated parameters are ignored:\n",
-                paste(apply(pt1[idx, c("lhs","op","rhs")], 1,
+                paste(apply(TMP[idx, c("lhs","op","rhs")], 1,
                       paste, collapse=" "), collapse="\n"))
             }
             if(fromLast) {

--- a/R/xxx_lavaan.R
+++ b/R/xxx_lavaan.R
@@ -96,7 +96,7 @@ lavaan <- function(# user-specified model: can be syntax, parameter Table, ...
         FLAT <- slotParTable
     } else if(is.character(model)) {
         FLAT <- lavParseModelString(model)
-    } else if( class(model) == "formula" ) {
+    } else if( inherits(model, "formula") ) {
         # two typical cases:
         # 1. regression type formula
         # 2. no quotes, eg f =~ x1 + x2 + x3
@@ -457,7 +457,7 @@ lavaan <- function(# user-specified model: can be syntax, parameter Table, ...
     if(!is.null(slotParTable)) {
         lavpartable <- slotParTable
     } else if(is.character(model) || 
-              class(model) == "formula") {
+              inherits(model, "formula")) {
         # check FLAT before we proceed
         if(lavoptions$debug) {
             print(as.data.frame(FLAT))


### PR DESCRIPTION
`lav_object_extended(..., do.fit = FALSE)` returns a parameter table that is meant for use in `lavTestScore()` and `modindices()`, so in the added rows, it has:

- `group == ""`
- `plabel == ""`
- `user == 10`, except existing parameters are `user == 0`

I borrow `group` labels from the `block` column, and delete the `user` column so that it is automatically repopulated.  Not sure if the empty strings in `plabel` have any consequence.
