### PR TITLE
updates for lavaan.mi score tests

### DIFF
--- a/R/lav_modification.R
+++ b/R/lav_modification.R
@@ -83,7 +83,7 @@ modindices <- function(object,
     I22 <- information[model.idx, model.idx, drop = FALSE]
 
     # ALWAYS use *expected* information (for now)
-    I22.inv <- lavTech(object, "inverted.information.expected")
+    I22.inv <- try(lavTech(object, "inverted.information.expected"), silent = TRUE)
     # just in case...
     if(inherits(I22.inv, "try-error")) {
         stop("lavaan ERROR: could not compute modification indices; information matrix is singular")

--- a/R/lav_object_generate.R
+++ b/R/lav_object_generate.R
@@ -150,7 +150,7 @@ lav_object_extended <- function(object, add = NULL,
     } else if(is.character(add)) {
         ngroups <- lav_partable_ngroups(partable)
         ADD <- lavaanify(add, ngroups = ngroups)
-        ADD <- ADD[,c("lhs","op","rhs","block","user","label")]
+        ADD <- ADD[,c("lhs","op","rhs","block","group","user","label")]
         remove.idx <- which(ADD$user == 0)
         if(length(remove.idx) > 0L) {
             ADD <- ADD[-remove.idx,]

--- a/R/lav_object_generate.R
+++ b/R/lav_object_generate.R
@@ -127,6 +127,17 @@ lav_object_extended <- function(object, add = NULL,
     # partable original model
     partable <- object@ParTable[c("lhs","op","rhs","block","group","free",
                                   "exo","label","plabel")] # do we need 'exo'?
+    
+    # TDJ: Added to prevent error when lav_partable_merge() is called below.
+    #      Problematic if object@ParTable is missing one of the requested slots,
+    #      which returns a NULL slot with a missing <NA> name.  For example: 
+    #        example(cfa)
+    #        lav_partable_independence(lavdata = fit@Data, lavpta = fit@pta,
+    #                                  lavoptions = lavInspect(fit, "options"))
+    #     Has no "label" or "plabel" elements.
+    empties <- which(sapply(partable, is.null))
+    if (length(empties)) partable[empties] <- NULL
+    
     if(all.free) {
         partable$user <- rep(1L, length(partable$lhs))
         non.free.idx <- which(partable$free == 0L & partable$op != "==" &

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -209,6 +209,13 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
             if(!is.null(x$pvalue)) {
                 m[se.idx, "pvalue"] <- ""
             }
+            ## for lavaan.mi-class objects (semTools)
+            if(!is.null(x$t)) {
+                m[se.idx, "t"] <- ""
+            }
+            if(!is.null(x$df)) {
+                m[se.idx, "df"] <- ""
+            }
         }
 
         # handle se == NA
@@ -220,6 +227,13 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
             if(!is.null(x$pvalue)) {
                 m[se.idx, "pvalue"] <- ""
             }
+            ## for lavaan.mi-class objects (semTools)
+            if(!is.null(x$t)) {
+                m[se.idx, "t"] <- ""
+            }
+            if(!is.null(x$df)) {
+                m[se.idx, "df"] <- ""
+            }
         }
     }
 
@@ -228,6 +242,10 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
         se.idx <- which(x$se == 0)
         if(length(se.idx) > 0L) {
             m[se.idx, "fmi"] <- ""
+            ## for lavaan.mi-class objects (semTools)
+            m[se.idx, "fmi1"] <- ""
+            m[se.idx, "fmi2"] <- ""
+            m[se.idx, "riv"] <- ""
         }
 
         not.idx <- which(x$op %in% c(":=", "<", ">", "=="))
@@ -276,7 +294,15 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
     colnames(m)[ colnames(m) == "std.nox"] <- "Std.nox"
     colnames(m)[ colnames(m) == "prior"  ] <- "Prior"
     colnames(m)[ colnames(m) == "fmi"    ] <- "FMI"
- 
+    ## for lavaan.mi-class objects (semTools)
+    if ("t" %in% colnames(m)) {
+      colnames(m)[ colnames(m) == "t"      ] <- "t-value"
+      colnames(m)[ colnames(m) == "P(>|z|)"] <- "P(>|t|)"
+      colnames(m)[ colnames(m) == "fmi1"   ] <- "FMI-1"
+      colnames(m)[ colnames(m) == "fmi2"   ] <- "FMI-2"
+      colnames(m)[ colnames(m) == "riv"    ] <- "RIV"
+    }
+    
     # format column names
     colnames(m) <- sprintf(char.format, colnames(m))
 

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -243,13 +243,15 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
         if(length(se.idx) > 0L) {
             m[se.idx, "fmi"] <- ""
             ## for lavaan.mi-class objects (semTools)
-            m[se.idx, "riv"] <- ""
+            if (!is.null(x$riv)) m[se.idx, "riv"] <- ""
         }
 
         not.idx <- which(x$op %in% c(":=", "<", ">", "=="))
         if(length(not.idx) > 0L) {
             if(!is.null(x$fmi)) {
                 m[not.idx, "fmi"] <- ""
+                ## for lavaan.mi-class objects (semTools)
+                if (!is.null(x$riv)) m[not.idx, "riv"] <- ""
             }
         }
     }

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -243,8 +243,6 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
         if(length(se.idx) > 0L) {
             m[se.idx, "fmi"] <- ""
             ## for lavaan.mi-class objects (semTools)
-            m[se.idx, "fmi1"] <- ""
-            m[se.idx, "fmi2"] <- ""
             m[se.idx, "riv"] <- ""
         }
 

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -298,8 +298,6 @@ print.lavaan.parameterEstimates <- function(x, ..., nd = 3L) {
     if ("t" %in% colnames(m)) {
       colnames(m)[ colnames(m) == "t"      ] <- "t-value"
       colnames(m)[ colnames(m) == "P(>|z|)"] <- "P(>|t|)"
-      colnames(m)[ colnames(m) == "fmi1"   ] <- "FMI-1"
-      colnames(m)[ colnames(m) == "fmi2"   ] <- "FMI-2"
       colnames(m)[ colnames(m) == "riv"    ] <- "RIV"
     }
     

--- a/man/lavInspect.Rd
+++ b/man/lavInspect.Rd
@@ -230,7 +230,7 @@ Gradient, Hessian, observed, expected and first.order information matrices:
         parameters.}
     \item{\code{"information"}:}{Matrix containing either the observed or
         the expected information matrix (depending on the information option
-        of the fitted model.}
+        of the fitted model). This is unit-information, not total-information.}
     \item{\code{"information.expected"}:}{Matrix containing the expected
         information matrix for the free model parameters.}
     \item{\code{"information.observed"}:}{Matrix containing the observed

--- a/man/lavTestScore.Rd
+++ b/man/lavTestScore.Rd
@@ -46,14 +46,19 @@ for each released constraint.}
     constraint.
 }
 \value{
-  A list containing at least three elements: the Score test statistic 
-  (stat), the degrees of freedom (df), and a p-value under the 
-  chi-square distribution (p.value). If univariate tests were requested,
-  an additional element (TS.univariate) containing a numeric vector of
-  univariate score statistics. If cumulative tests were requested,
-  an additional element (TS.order) showing the order of the univariate
-  test statistics, and an element (TS.cumulative) containing a numeric
-  vector of cumulative multivariate score statistics.
+  A list containing at least one \code{data.frame}:
+  \itemize{
+    \item{\code{$test}: The total score test, with columns for the score
+      test statistic (\code{X2}), the degrees of freedom (\code{df}), and
+      a \emph{p} value under the \eqn{\chi^2} distribution (\code{p.value}).}
+    \item{\code{$uni}: Optional (if \code{univariate=TRUE}).
+      Each 1-\emph{df} score test, equivalent to modification indices.}
+    \item{\code{$cumulative}: Optional (if \code{cumulative=TRUE}).
+      Cumulative score tests.}
+    \item{\code{$epc}: Optional (if \code{epc=TRUE}). Parameter estimates, 
+      expected parameter changes, and expected parameter values if all
+      the tested constraints were freed.}
+  }
 }
 \references{
 Bentler, P. M., & Chou, C. P. (1993). Some new covariance structure model

--- a/man/lavaan-class.Rd
+++ b/man/lavaan-class.Rd
@@ -109,11 +109,14 @@ the independence model) (if available).}
       are compared in a sequential order. Test statistics are based on the 
       likelihood ratio test. For more details and
       further options, see the \code{\link{lavTestLRT}} page.} 
-    \item{update}{\code{signature(object = "lavaan", model, ..., 
+    \item{update}{\code{signature(object = "lavaan", model, add, ..., 
         evaluate=TRUE)}: update a fitted lavaan object and evaluate it
         (unless \code{evaluate=FALSE}). Note that we use the environment
         that is stored within the lavaan object, which is not necessarily
-        the parent frame.}
+        the parent frame. The \code{add} argument is analogous to the one
+        described in the \code{\link{lavTestScore}} page, and can be used to
+        add parameters to the specified model rather than passing an entirely
+        new \code{model} argument.}
     \item{nobs}{\code{signature(object = "lavaan")}: returns the effective
       number of observations used when fitting the model. In a multiple group
       analysis, this is the sum of all observations per group.}

--- a/man/standardizedSolution.Rd
+++ b/man/standardizedSolution.Rd
@@ -6,9 +6,9 @@
 Standardized solution of a latent variable model.}
 \usage{
 standardizedSolution(object, type = "std.all", se = TRUE, zstat = TRUE, 
-                     pvalue = TRUE, ci = TRUE, level = 0.95, 
-                     cov.std = TRUE, remove.eq = TRUE, remove.ineq = TRUE, 
-                     remove.def = FALSE, GLIST = NULL, est = NULL)
+                     pvalue = TRUE, ci = TRUE, level = 0.95, cov.std = TRUE,
+                     remove.eq = TRUE, remove.ineq = TRUE, remove.def = FALSE,
+                     GLIST = NULL, est = NULL, partable = NULL)
 }
 \arguments{
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
@@ -49,6 +49,14 @@ instead of the GLIST inside the object@Model slot.}
 \item{est}{Numeric. Parameter values (as in the `est' column of a
 parameter table). If provided, they will be used instead of 
 the parameters that can be extract from object.}
+\item{partable}{A custom \code{list} or \code{data.frame} in which to store
+the standardized parameter values. If provided, it will be used instead of 
+the parameter table inside the object@ParTable slot.}
+}
+\note{
+The \code{est}, \code{GLIST}, and \code{partable} arguments are not meant for
+everyday users, but for authors of external R packages that depend on
+\code{lavaan}. Only to be used with great caution.
 }
 \value{
   A data.frame containing standardized model parameters.


### PR DESCRIPTION
I was not able to hack the `update()` function, so I simply borrowed source code from `lavaan:::lav_object_extended()`. But I did notice that `update()` should check whether `slot*` arguments were used in the `@call`.

Here are the other changes I made for score tests with multiple imputations:
- I added a `partable=` argument to `standardizedSolution()` so I could add SEPCs
- I need `ADD` to have a `group` column in `lavaan:::lav_object_extended()`
- I check for columns in `lavaan:::print.lavaan.parameterEstimates()` associated with lavaan.mi objects
- I assign an extended parameter table to `LIST` in lav_test_score.R so that an EPC will also be calculated for any added parameters

On line 87 of lav_test_score.R, I note that an assignment might belong within an `if` scope. And there are a couple other small, self-explanatory changes that seemed logical. 
