### PR TITLE
update lavTestScore help page

### DIFF
--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -1289,12 +1289,12 @@ lav_fit_measures <- function(object, fit.measures="all",
 
     # ECVI - cross-validation index (Brown & Cudeck, 1989)
     # not defined for multiple groups and/or models with meanstructures
+    # TDJ: According to Dudgeon (2004, p. 317), "ECVI requires no adjustment
+    #      when a model is fitted simultaneously in multiple samples."
+    #      And I think the lack of mean structure in Brown & Cudeck (1989)
+    #      was a matter of habitual simplification back then, not necessity.
     if("ecvi" %in% fit.measures) {
-        if(G > 1 || meanstructure) {
-            ECVI <- as.numeric(NA)
-        } else {
-            ECVI <- X2/N + (2*npar)/N
-        }
+        ECVI <- X2/N + (2*npar)/N
         indices["ecvi"] <- ECVI
     }
 

--- a/man/lavTestScore.Rd
+++ b/man/lavTestScore.Rd
@@ -86,4 +86,16 @@ newpar = '
     textual =~ x3
 '
 lavTestScore(fit, add = newpar)
+
+# equivalently, "add" can be a parameter table specifying parameters to free,
+# but must include some additional information:
+PT.add <- data.frame(lhs = c("visual","textual"),
+                     op = c("=~","=~"),
+                     rhs = c("x9","x3"),
+                     user = 10L, # needed to identify new parameters
+                     free = 1, # arbitrary numbers > 0
+                     start = 0) # null-hypothesized value
+PT.add
+lavTestScore(fit, add = PT.add) # same result as above
+
 }


### PR DESCRIPTION
I added a parameter-table example to `lavTestScore(add=)` so users know what they need (may be more convenient that syntax in simulations).

I also think ECVI is valid in multigroup and MACS models.  I attached the paper discussing the multigroup issue, and I just don't think the mean-structure issue is relevant (just a simplification in the Browne & Cudeck article).

[Dudgeon.2004.MultipleSampleRMSEAadj.pdf](https://github.com/yrosseel/lavaan/files/1943827/Dudgeon.2004.MultipleSampleRMSEAadj.pdf)
