### PR TITLE
if rho.init is missing

### DIFF
--- a/R/lav_polychor.R
+++ b/R/lav_polychor.R
@@ -32,7 +32,7 @@ pc_PI <- function(rho, th.y1, th.y2) {
         PI.ij <- outer(rowPI, colPI)
         return(PI.ij)
     }
- 
+
     # prepare for a single call to pbinorm
     upper.y <- rep(th.y2, times=rep.int(nth.y1, nth.y2))
     upper.x <- rep(th.y1, times=ceiling(length(upper.y))/nth.y1)
@@ -129,16 +129,16 @@ pc_logl <- function(Y1, Y2, eXo=NULL, rho=NULL, fit.y1=NULL, fit.y2=NULL,
     if(length(fit.y1$slope.idx) == 0L) {
         if(is.null(freq)) freq <- pc_freq(fit.y1$y,fit.y2$y)
         # grouped lik
-        PI <- pc_PI(rho, th.y1=fit.y1$theta[fit.y1$th.idx], 
+        PI <- pc_PI(rho, th.y1=fit.y1$theta[fit.y1$th.idx],
                          th.y2=fit.y2$theta[fit.y2$th.idx])
-        if(all(PI > 0)) 
+        if(all(PI > 0))
             logl <- sum( freq * log(PI) )
         else logl <- -Inf
     } else {
         lik <- pc_lik(Y1=Y1, Y2=Y2, rho=rho, fit.y1=fit.y1, fit.y2=fit.y2)
         if(all(lik > 0, na.rm = TRUE))
             logl <- sum( log(lik), na.rm = TRUE )
-        else logl <- -Inf 
+        else logl <- -Inf
     }
 
     logl
@@ -174,7 +174,7 @@ pc_lik2 <- function(Y1, Y2, eXo=NULL, rho, fit.y1=NULL, fit.y2=NULL,
     if(missing(Y1)) Y1 <- fit.y1$y
     if(missing(Y2)) Y2 <- fit.y2$y
     if(missing(eXo) && length(fit.y1$slope.idx) > 0L) eXo <- fit.y1$X
-   
+
     # lik
     lik <- pc_lik(rho=rho, fit.y1=fit.y1, fit.y2=fit.y2)
 
@@ -188,7 +188,7 @@ pc_lik <- function(Y1, Y2, eXo=NULL, rho=NULL, fit.y1=NULL, fit.y2=NULL) {
 
     if(is.null(fit.y1)) fit.y1 <- lavProbit(y=Y1, X=eXo)
     if(is.null(fit.y2)) fit.y2 <- lavProbit(y=Y2, X=eXo)
-    
+
     # if no eXo, use shortcut (grouped)
     if(length(fit.y1$slope.idx) == 0L) {
         # probability per cell
@@ -220,7 +220,7 @@ pc_lik <- function(Y1, Y2, eXo=NULL, rho=NULL, fit.y1=NULL, fit.y2=NULL) {
             lik <- pbinorm(upper.x=fit.y1$z1, upper.y=fit.y2$z1,
                            lower.x=fit.y1$z2, lower.y=fit.y2$z2, rho=rho)
         }
-        
+
     }
 
     lik
@@ -283,7 +283,7 @@ pc_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL, freq=NULL,
     # thresholds
     th.y1 <- fit.y1$theta[fit.y1$th.idx]
     th.y2 <- fit.y2$theta[fit.y2$th.idx]
-    
+
     # freq
     if(!exo) {
         if(is.null(freq)) freq <- pc_freq(fit.y1$y,fit.y2$y)
@@ -302,7 +302,7 @@ pc_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL, freq=NULL,
             }
         }
 
-        # treat 2x2 tables 
+        # treat 2x2 tables
         if(nr == 2L && nc == 2L) {
             idx <- which(freq == 0L)
             # catch 2 empty cells: perfect correlation!
@@ -312,7 +312,7 @@ pc_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL, freq=NULL,
                     rho <- 1.0
                     if(zero.cell.flag) {
                         attr(rho, "zero.cell.flag") <- empty.cells
-                    } 
+                    }
                     return(rho)
                 } else {
                     rho <- -1.0
@@ -437,6 +437,10 @@ pc_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL, freq=NULL,
         rho.init <- cor(Y1,Y2, use="pairwise.complete.obs")
     #}
 
+    # if rho.init is missing, set starting value to zero
+    if(is.na(rho.init)) {
+      rho.init <- 0.0
+    }
     # check range of rho.init is within [-1,+1]
     if(abs(rho.init) >= 1.0) {
         rho.init <- 0.0
@@ -465,7 +469,7 @@ pc_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL, freq=NULL,
     } else if(method == "BFGS") {
         # NOTE: known to fail if rho.init is too far from final value
         # seems to be better with parscale = 0.1??
-        out <- optim(par = atanh(rho.init), fn = objectiveFunction, 
+        out <- optim(par = atanh(rho.init), fn = objectiveFunction,
                      gr = gradientFunction,
                      control = list(parscale = 0.1, reltol = 1e-10,
                                     trace = ifelse(verbose, 1L, 0L),
@@ -501,7 +505,7 @@ pc_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL, freq=NULL,
     rho
 }
 
-pc_cor_gradient_noexo <- function(Y1, Y2, rho, th.y1=NULL, th.y2=NULL, 
+pc_cor_gradient_noexo <- function(Y1, Y2, rho, th.y1=NULL, th.y2=NULL,
                                   freq=NULL) {
 
     R <- sqrt(1- rho*rho)
@@ -531,7 +535,7 @@ pc_cor_scores <- function(Y1, Y2, eXo=NULL, rho, fit.y1=NULL, fit.y2=NULL,
                           sl.y1=NULL, sl.y2=NULL,
                           na.zero=FALSE) {
 
-    # check if rho > 
+    # check if rho >
 
     R <- sqrt(1 - rho*rho)
     if(is.null(fit.y1)) fit.y1 <- lavProbit(y=Y1, X=eXo)
@@ -558,7 +562,7 @@ pc_cor_scores <- function(Y1, Y2, eXo=NULL, rho, fit.y1=NULL, fit.y2=NULL,
     if(missing(Y1)) Y1 <- fit.y1$y
     if(missing(Y2)) Y2 <- fit.y2$y
     if(missing(eXo) && length(fit.y1$slope.idx) > 0L) eXo <- fit.y1$X
-   
+
     # lik
     lik <- pc_lik(rho=rho, fit.y1=fit.y1, fit.y2=fit.y2)
 
@@ -608,7 +612,7 @@ pc_cor_scores <- function(Y1, Y2, eXo=NULL, rho, fit.y1=NULL, fit.y2=NULL,
 
     # rho
     if(length(fit.y1$slope.idx) == 0L) {
-        phi <- pc_PHI(rho, th.y1=fit.y1$theta[fit.y1$th.idx], 
+        phi <- pc_PHI(rho, th.y1=fit.y1$theta[fit.y1$th.idx],
                            th.y2=fit.y2$theta[fit.y2$th.idx])
         #PP <- phi/PI
         dx <- phi[cbind(Y1,Y2)]
@@ -623,6 +627,6 @@ pc_cor_scores <- function(Y1, Y2, eXo=NULL, rho, fit.y1=NULL, fit.y2=NULL,
         dx.rho[is.na(dx.rho)] <- 0
     }
 
-    list(dx.th.y1=dx.th.y1, dx.th.y2=dx.th.y2, 
+    list(dx.th.y1=dx.th.y1, dx.th.y2=dx.th.y2,
          dx.sl.y1=dx.sl.y1, dx.sl.y2=dx.sl.y2, dx.rho=dx.rho)
 }

--- a/R/lav_polyserial.R
+++ b/R/lav_polyserial.R
@@ -4,7 +4,7 @@
 ps_logl <- function(Y1, Y2, eXo=NULL, rho=NULL, fit.y1=NULL, fit.y2=NULL) {
 
     lik <- ps_lik(Y1=Y1, Y2=Y2, eXo=eXo, rho=rho, fit.y1=fit.y1, fit.y2=fit.y2)
-    if(all(lik > 0, na.rm = TRUE)) 
+    if(all(lik > 0, na.rm = TRUE))
         logl <- sum(log(lik), na.rm = TRUE)
     else
         logl <- -Inf
@@ -30,7 +30,7 @@ ps_lik <- function(Y1, Y2, eXo=NULL, var.y1 = NULL, eta.y1 = NULL,
     y1.SD  <- sqrt(var.y1)
     y1.ETA <- eta.y1
     Z <- (Y1 - y1.ETA) / y1.SD
-    
+
     # p(Y2|Y1)
     tauj.star  <- (fit.y2$z1 - rho*Z)/R
     tauj1.star <- (fit.y2$z2 - rho*Z)/R
@@ -90,7 +90,7 @@ ps_loglik_no_exo <- function(Y1, Y2, var.y1 = NULL, eta.y1 = NULL, rho=NULL,
 
     R <- sqrt(1 - rho*rho)
     Z <- (Y1 - eta.y1) / sqrt(var.y1)
-    
+
     # p(Y2|Y1)
     TH <- c(-Inf, th.y2, +Inf)
     z1 <- pmin( 100, TH[Y2 + 1L])
@@ -107,7 +107,7 @@ ps_loglik_no_exo <- function(Y1, Y2, var.y1 = NULL, eta.y1 = NULL, rho=NULL,
 
     # loglik
     loglik <- py1.log + py2y1.log
- 
+
     loglik
 }
 
@@ -119,7 +119,7 @@ ps_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL,
 
     if(is.null(fit.y1)) fit.y1 <- lavOLS(Y1, X=eXo)
     if(is.null(fit.y2)) fit.y2 <- lavProbit(Y2, X=eXo)
-    if(missing(Y1)) Y1 <- fit.y1$y 
+    if(missing(Y1)) Y1 <- fit.y1$y
     if(missing(Y2)) Y2 <- fit.y2$y else as.integer(Y2)
     if(missing(eXo) && length(fit.y2$slope.idx) > 0L) eXo <- fit.y2$X
 
@@ -169,6 +169,10 @@ ps_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL,
                       sum(dnorm(fit.y2$theta[fit.y2$th.idx])) )
     }
 
+    # if rho.init is missing, set starting value to zero
+    if(is.na(rho.init)) {
+      rho.init <- 0.0
+    }
     # check range of rho.init is within [-1,+1]
     if(abs(rho.init) >= 1.0) {
         rho.init <- 0.0
@@ -193,7 +197,7 @@ ps_cor_TS <- function(Y1, Y2, eXo=NULL, fit.y1=NULL, fit.y2=NULL,
     rho
 }
 
-ps_cor_scores <- function(Y1, Y2, eXo=NULL, rho=NULL, 
+ps_cor_scores <- function(Y1, Y2, eXo=NULL, rho=NULL,
                           fit.y1=NULL, fit.y2=NULL) {
 
     stopifnot(!is.null(rho))
@@ -251,7 +255,7 @@ ps_cor_scores <- function(Y1, Y2, eXo=NULL, rho=NULL,
 #       depends on var.y1, and this complicates the gradient
 ps_cor_scores_no_exo <- function(Y1, Y2,
                                  var.y1 = NULL, eta.y1 = NULL,
-                                 th.y2 = NULL, rho = NULL, 
+                                 th.y2 = NULL, rho = NULL,
                                  sigma.correction = FALSE) {
 
     R <- sqrt(1 - rho*rho)
@@ -299,10 +303,10 @@ ps_cor_scores_no_exo <- function(Y1, Y2,
 
         # sigma
         dx.rho <- dx.rho.orig / y1.SD
-   
+
         # var
         COV <- rho * y1.SD
-        dx.var.y1 <- ( dx.var.y1.orig - 
+        dx.var.y1 <- ( dx.var.y1.orig -
                        1/2 * COV/var.y1 * 1/y1.SD * dx.rho.orig )
     }
 


### PR DESCRIPTION
Following the [lavaan-forum post](https://groups.google.com/d/msg/lavaan/b27N4UTT9is/IDI2cO3rAgAJ), I added a starting value of zero for polyserial and polychoric correlations that have no observations:
```
if(is.na(rho.init)) {
  rho.init <- 0.0
}
```
But if `rho.init` is missing because there is no observed data (or only n=1) for a pair of variables, then I imagine the `lavCor()` estimation will probably fail anyway.  If that is the case, let me know if I should change the pull request to this:
```
if(is.na(rho.init)) {
  stop('lavaan ERROR: The following pair of variables have no joint observations, ',
      'so their polyserial/polychoric correlation cannot be estimated:\n', 
      deparse(substitute(Y1)), ' and ', deparse(substitute(Y2)), "\n)
}
```