### PR TITLE
Import few more functions from methods. 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,3 +47,4 @@ License: GPL (>= 2)
 LazyData: yes
 ByteCompile: true
 URL: http://lavaan.org
+RoxygenNote: 6.0.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,10 +8,11 @@ importFrom("graphics",
 
 importFrom("methods",
            "is", "new", "slot", "slotNames", ".hasSlot",
+           "setClass", "representation", "setGeneric",  "setRefClass", "setMethod",
            # generics,
+           "show", "signature")
 
-           "show")
-importFrom("stats", 
+importFrom("stats",
            "as.formula", "complete.cases", "cor", "cov", "cov2cor", "cov.wt",
            "dnorm", "lm.fit", "na.omit", "nlminb", "optim", "pchisq",
            "plogis", "pnorm", "qchisq", "qnorm", "quantile", "rnorm", "runif",
@@ -162,7 +163,7 @@ export("lavaan", "cfa", "sem", "growth",
 # export Classes
 exportClasses(
               "lavaan",
-              "lavaanList" 
+              "lavaanList"
              )
 
 # export Methods


### PR DESCRIPTION
Hi there, 

When I installed (today) the package on my Debian machine (seeDetails below) I had a couple of issues related to functions that were not imported from `Methods`. I solved this by adding the ones included in this PR. Note that this PR is only few additions in the NAMESPACE and that the small addition is DESCRIPTION is totally up to you.

Anyway, many thanks for you work on this package! 


<details>
R version 3.5.1 (2018-07-02)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux buster/sid


Matrix products: default
BLAS: /usr/lib/x86_64-linux-gnu/openblas/libblas.so.3
LAPACK: /usr/lib/x86_64-linux-gnu/libopenblasp-r0.2.20.so

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_CA.UTF-8        LC_COLLATE=en_US.UTF-8     LC_MONETARY=en_CA.UTF-8
 [6] LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_CA.UTF-8       LC_NAME=C                  LC_ADDRESS=C               LC_TELEPHONE=C
[11] LC_MEASUREMENT=en_CA.UTF-8 LC_IDENTIFICATION=C

attached base packages:
[1] stats     graphics  grDevices utils     base

other attached packages:
[1] graphicsutils_1.2-0 knitr_1.20          rmarkdown_1.10      devtools_1.13.6     inSilecoMisc_0.1.2

loaded via a namespace (and not attached):
 [1] compiler_3.5.1  backports_1.1.2 magrittr_1.5    rprojroot_1.3-2 tools_3.5.1     htmltools_0.3.6 withr_2.1.2     Rcpp_0.12.17    memoise_1.1.0
[10] stringi_1.2.3   methods_3.5.1   stringr_1.3.1   digest_0.6.15   evaluate_0.10.1
</details>
