### PR TITLE
lavaanList wrappers and information for score tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Authors@R: c(person(given   = "Yves", family = "Rosseel",
                     role = "ctb",
                     email = "machow@princeton.edu"),
              person(given = c("Terrence","D."), family = "Jorgensen",
-                    role = "ctb")
+                    role = "ctb",
+                    comment = c(ORCID = "0000-0001-5111-6773"))
             )
 Description: Fit a variety of latent variable models, including confirmatory
    factor analysis, structural equation modeling and latent growth curve models.

--- a/R/00generic.R
+++ b/R/00generic.R
@@ -1,9 +1,10 @@
 # for blavaan
+# TDJ: add "..." to make the generic actually generic, for lavaan.mi objects
 setGeneric("fitMeasures",
-    function(object, fit.measures = "all", baseline.model = NULL)
+    function(object, fit.measures = "all", baseline.model = NULL, ...)
     standardGeneric("fitMeasures"))
 setGeneric("fitmeasures",
-    function(object, fit.measures = "all", baseline.model = NULL)
+    function(object, fit.measures = "all", baseline.model = NULL, ...)
     standardGeneric("fitmeasures"))
 
 

--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -1,11 +1,15 @@
+# TDJ: add "..." to make the method generic, so lavaan.mi can add arguments to
+#      pass to lavTestLRT() and lavTestLRT.mi() about how to pool chi-squared.
+#      NOT sure this is necessary for the lavaan-method, perhaps only the
+#      generic needs "..."?
 setMethod("fitMeasures", signature(object = "lavaan"),
-function(object, fit.measures = "all", baseline.model = NULL) {
+function(object, fit.measures = "all", baseline.model = NULL, ...) {
     lav_fit_measures(object = object, fit.measures = fit.measures,
                      baseline.model = baseline.model)
 })
 
 setMethod("fitmeasures", signature(object = "lavaan"),
-function(object, fit.measures = "all", baseline.model = NULL) {
+function(object, fit.measures = "all", baseline.model = NULL, ...) {
     lav_fit_measures(object = object, fit.measures = fit.measures,
                      baseline.model = baseline.model)
 })

--- a/R/lav_modification.R
+++ b/R/lav_modification.R
@@ -4,6 +4,7 @@
 modindices <- function(object,
                        standardized = TRUE,
                        cov.std = TRUE,
+                       use.exp.info = TRUE,
 
                        # power statistics?
                        power = FALSE,
@@ -51,7 +52,11 @@ modindices <- function(object,
 
     # compute information matrix 'extended model'
     # ALWAYS use *expected* information (for now)
-    information <- lavTech(FIT, "information.expected")
+    if (use.exp.info) {
+      information <- lavTech(FIT, "information.expected")
+    } else {
+      information <- lavTech(FIT, "information")
+    }
 
     # compute gradient 'extended model'
     score <- lavTech(FIT, "gradient.logl")
@@ -85,7 +90,11 @@ modindices <- function(object,
     I22 <- information[model.idx, model.idx, drop = FALSE]
 
     # ALWAYS use *expected* information (for now)
-    I22.inv <- try(lavTech(object, "inverted.information.expected"), silent = TRUE)
+    if (use.exp.info) {
+      I22.inv <- try(lavTech(object, "inverted.information.expected"), silent = TRUE)
+    } else {
+      I22.inv <- try(lavTech(object, "inverted.information"), silent = TRUE)
+    }
     # just in case...
     if(inherits(I22.inv, "try-error")) {
         stop("lavaan ERROR: could not compute modification indices; information matrix is singular")

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -179,7 +179,9 @@ lavInspect.lavaan <- function(object,
     } else if(what == "group") {
         object@Data@group
     } else if(what == "cluster") {
-        object@Data@cluster
+      object@Data@cluster
+    } else if(what == "nlevels") {
+      object@Data@nlevels
     } else if(what == "ordered") {
         object@Data@ordered
     } else if(what == "group.label") {

--- a/R/lav_options.R
+++ b/R/lav_options.R
@@ -83,10 +83,17 @@ lav_options_default <- function(mimic = "lavaan") {
                 group.w.free       = FALSE,
 
                 # clusters
+                #FIXME: Is this meant to be the logical "clustered"?
+                #       Variable name stored in @Data, not @Options.
+                #       Also not on ?lavOptions help page.
                 cluster            = NULL,
                 level.label        = NULL,
 
                 # sampling weights
+                #FIXME: Is this meant to be logical too?
+                #       Perhaps call it "any.sampling.weights" or "use.sampling.weights"
+                #       Variable name stored in @Data, not @Options.
+                #       Also not on ?lavOptions help page.
                 sampling.weights   = NULL,
 
                 # estimation

--- a/R/lav_test_score.R
+++ b/R/lav_test_score.R
@@ -11,7 +11,8 @@
 #
 lavTestScore <- function(object, add = NULL, release = NULL,
                          univariate = TRUE, cumulative = FALSE,
-                         epc = FALSE, verbose = FALSE, warn = TRUE) {
+                         epc = FALSE, verbose = FALSE, warn = TRUE,
+                         use.exp.info = TRUE) {
 
     # check object
     stopifnot(inherits(object, "lavaan"))
@@ -44,7 +45,11 @@ lavTestScore <- function(object, add = NULL, release = NULL,
         FIT <- lav_object_extended(object, add = add)
 
         score <- lavTech(FIT, "gradient.logl")
-        information <- lavTech(FIT, "information.expected")
+        if (use.exp.info) {
+          information <- lavTech(FIT, "information.expected")
+        } else {
+          information <- lavTech(FIT, "information")
+        }
 
         npar <- object@Model@nx.free
         nadd <- FIT@Model@nx.free - npar
@@ -84,7 +89,11 @@ lavTestScore <- function(object, add = NULL, release = NULL,
         }
 
         score <- lavTech(object, "gradient.logl")
-        information <- lavTech(object, "information.expected")
+        if (use.exp.info) {
+          information <- lavTech(FIT, "information.expected")
+        } else {
+          information <- lavTech(FIT, "information")
+        }
         J.inv <- MASS::ginv(information) #FIXME: move into if(is.null(release))?
         #                 else written over with Z1.plus if(is.numeric(release))
         #R <- object@Model@con.jac[,]

--- a/R/xxx_lavaanList.R
+++ b/R/xxx_lavaanList.R
@@ -1,6 +1,7 @@
 # lavaanList: fit the *same* model, on different datasets
 # YR - 29 Jun 2016
 # YR - 27 Jan 2017: change lavoptions; add dotdotdot to each call
+# TDJ - 23 Aug 2018: change wrappers to preserve arguments from match.call()
 
 lavaanList <- function(model         = NULL,             # model
                        dataList      = NULL,             # list of datasets
@@ -420,14 +421,10 @@ semList <- function(model         = NULL,
                     cl            = NULL,
                     iseed         = NULL) {
 
-    lavaanList(model = model, dataList = dataList,
-               dataFunction = dataFunction,
-               dataFunction.args = dataFunction.args, ndat = ndat,
-               cmd = "sem",
-               ..., store.slots = store.slots,
-               FUN = FUN, show.progress = show.progress,
-               store.failed = store.failed,
-               parallel = parallel, ncpus = ncpus, cl = cl, iseed = iseed)
+  mc <- match.call(expand.dots = TRUE)
+  mc$cmd <- "sem"
+  mc[[1L]] <- quote(lavaan::lavaanList)
+  eval(mc, parent.frame())
 }
 
 cfaList <- function(model         = NULL,
@@ -445,14 +442,9 @@ cfaList <- function(model         = NULL,
                     cl            = NULL,
                     iseed         = NULL) {
 
-    lavaanList(model = model, dataList = dataList,
-               dataFunction = dataFunction,
-               dataFunction.args = dataFunction.args, ndat = ndat,
-               cmd = "cfa",
-               ..., store.slots = store.slots,
-               FUN = FUN, show.progress = show.progress,
-               store.failed = store.failed,
-               parallel = parallel, ncpus = ncpus, cl = cl,
-               iseed = iseed)
+  mc <- match.call(expand.dots = TRUE)
+  mc$cmd <- "cfa"
+  mc[[1L]] <- quote(lavaan::lavaanList)
+  eval(mc, parent.frame())
 }
 

--- a/man/fitMeasures.Rd
+++ b/man/fitMeasures.Rd
@@ -9,19 +9,21 @@
 This function computes a variety of fit measures to assess the global
 fit of a latent variable model.}
 \usage{
-fitMeasures(object, fit.measures = "all", baseline.model = NULL)
-fitmeasures(object, fit.measures = "all", baseline.model = NULL)
+fitMeasures(object, fit.measures = "all", baseline.model = NULL, ...)
+fitmeasures(object, fit.measures = "all", baseline.model = NULL, ...)
 }
 \arguments{
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
 \item{fit.measures}{If \code{"all"}, all fit measures available will be
 returned. If only a single or a few fit measures are specified by name,
 only those are computed and returned.}
-\item{baseline.model}{If not NULL, an object of class 
+\item{baseline.model}{If not NULL, an object of class
 \code{\linkS4class{lavaan}}, representing a user-specified baseline model.
-If a baseline model is provided, all fit indices relying on a 
-baseline model (eg. CFI or TLI) will use the test statistics from 
+If a baseline model is provided, all fit indices relying on a
+baseline model (eg. CFI or TLI) will use the test statistics from
 this user-specified baseline model, instead of the default baseline model.}
+\item{...}{Further arguments passed to or from other methods. Not currently
+used for \code{lavaan} objects.}
 }
 \value{
 A named numeric vector of fit measures.

--- a/man/lavInspect.Rd
+++ b/man/lavInspect.Rd
@@ -61,16 +61,16 @@ Model matrices:
         of for example \code{coef()} and \code{vcov()}.}
     \item{\code{"partable"}:}{A list of model matrices. The non-zero integers
         represent both the fixed parameters (for example, factor loadings
-        fixed at 1.0), and the free parameters if we ignore any equality 
-        constraints. They correspond with all entries (fixed or free) 
+        fixed at 1.0), and the free parameters if we ignore any equality
+        constraints. They correspond with all entries (fixed or free)
         in the parameter table. See \code{\link{parTable}}.}
     \item{\code{"se"}:}{A list of model matrices. The non-zero numbers
         represent the standard errors for the free parameters in the model.
         If two parameters are constrained to be equal, they will have the
-        same standard error for both parameters. 
+        same standard error for both parameters.
         Aliases: \code{"std.err"} and \code{"standard.errors"}.}
     \item{\code{"start"}:}{A list of model matrices. The values represent
-        the starting values for all model parameters. 
+        the starting values for all model parameters.
         Alias: \code{"starting.values"}.}
     \item{\code{"est"}:}{A list of model matrices. The values represent
         the estimated model parameters. Aliases:
@@ -82,7 +82,7 @@ Model matrices:
     \item{\code{"dx.all"}:}{A list of model matrices. The values represent
         the first derivative with respect to all possible matrix elements.
         Currently, this is only available when the estimator is \code{"ML"}
-        or \code{"GLS"}.} 
+        or \code{"GLS"}.}
     \item{\code{"std"}:}{A list of model matrices. The values represent
         the (completely) standardized model parameters (the variances of
         both the observed and the latent variables are set to unity).
@@ -103,14 +103,15 @@ Information about the data (including missing patterns):
     \item{\code{"data"}:}{A matrix containing the observed variables
         that have been used to fit the model. No column/row names are provided.
         Column names correspond to the output of \code{lavNames(object)},
-        while the rows correspond to the output of 
+        while the rows correspond to the output of
         \code{lavInspect(object, "case.idx"}.}
     \item{\code{"group"}:}{A character string. The group variable in
         the data.frame (if any).}
     \item{\code{"ngroups"}:}{Integer. The number of groups.}
     \item{\code{"group.label"}:}{A character vector. The group labels.}
-    \item{\code{"cluster"}:}{A character vector. The cluster variable(s) 
+    \item{\code{"cluster"}:}{A character vector. The cluster variable(s)
        in the data.frame (if any).}
+    \item{\code{"nlevels"}:}{Integer. The number of levels.}
     \item{\code{"ordered"}:}{A character vector. The ordered variables.}
     \item{\code{"nobs"}:}{Integer vector. The number of observations
         in each group that were used in the analysis.}
@@ -123,29 +124,29 @@ Information about the data (including missing patterns):
     \item{\code{"case.idx"}:}{The case/observation numbers that were used
         in the analysis.
         In the case of multiple groups: a list of numbers.}
-    \item{\code{"empty.idx"}:}{The case/observation numbers of those 
-        cases/observations that contained missing values only 
+    \item{\code{"empty.idx"}:}{The case/observation numbers of those
+        cases/observations that contained missing values only
         (at least for the observed variables that were included in the model).
         In the case of multiple groups: a list of numbers.}
-    \item{\code{"patterns"}:}{A binary matrix. The rows of the matrix 
+    \item{\code{"patterns"}:}{A binary matrix. The rows of the matrix
         are the missing data patterns where 1 and 0 denote non-missing
         and missing values for the corresponding observed variables
         respectively (or
-        \code{TRUE} and \code{FALSE} if \code{lavTech()} is used.) 
-        If the data is complete (no missing values), there will be only 
-        a single pattern. In the case of multiple groups: a list of 
+        \code{TRUE} and \code{FALSE} if \code{lavTech()} is used.)
+        If the data is complete (no missing values), there will be only
+        a single pattern. In the case of multiple groups: a list of
         pattern matrices.}
     \item{\code{"coverage"}:}{A symmetric matrix where each element contains
-        the proportion of observed datapoints for the corresponding 
-        pair of observed variables. 
+        the proportion of observed datapoints for the corresponding
+        pair of observed variables.
         In the case of multiple groups: a list of coverage matrices.}
 }
 
 Observed sample statistics:
 
 \describe{
-    \item{\code{"sampstat"}:}{Observed sample statistics. Aliases:  
-         \code{"obs"}, \code{"observed"}, \code{"samp"}, \code{"sample"}, 
+    \item{\code{"sampstat"}:}{Observed sample statistics. Aliases:
+         \code{"obs"}, \code{"observed"}, \code{"samp"}, \code{"sample"},
          \code{"samplestatistics"}. Since
          0.6-3, we always check if an h1 slot is available (the estimates
          for the unrestricted model); if present, we extract the sample
@@ -153,10 +154,10 @@ Observed sample statistics:
          continuous, and \code{missing = "ml"} (or \code{"fiml"}), we
          return the covariance matrix (and mean vector) as computed by
          the EM algorithm under the unrestricted (h1) model. If the h1 is
-         not present (perhaps, because the model was fitted with 
+         not present (perhaps, because the model was fitted with
          \code{h1 = FALSE}), we return the sample statistics from the
          SampleStats slot. Here, pairwise deletion is used for the elements
-         of the covariance matrix (or correlation matrix), and 
+         of the covariance matrix (or correlation matrix), and
          listwise deletion for all univariate statistics (means, intercepts
          and thresholds).}
     \item{\code{"sampstat.h1"}:}{Deprecated. Do not use any longer.}
@@ -187,22 +188,22 @@ Model-implied sample statistics:
 \describe{
     \item{\code{"cov.lv"}:}{The model-implied variance-covariance matrix
         of the latent variables. Alias: \code{"veta"} [for V(eta)].}
-    \item{\code{"cor.lv"}:}{The model-implied correlation matrix of the 
+    \item{\code{"cor.lv"}:}{The model-implied correlation matrix of the
         latent variables.}
     \item{\code{"mean.lv"}:}{The model-implied mean vector of the latent
         variables. Alias: \code{"eeta"} [for E(eta)].}
     \item{\code{"cov.ov"}:}{The model-implied variance-covariance matrix
-        of the observed variables. 
+        of the observed variables.
         Aliases: \code{"sigma"}, \code{"sigma.hat"}.}
     \item{\code{"cor.ov"}:}{The model-implied correlation matrix
         of the observed variables.}
     \item{\code{"mean.ov"}:}{The model-implied mean vector of the observed
         variables. Aliases: \code{"mu"}, \code{"mu.hat"}.}
-    \item{\code{"cov.all"}:}{The model-implied variance-covariance matrix 
+    \item{\code{"cov.all"}:}{The model-implied variance-covariance matrix
         of both the observed and latent variables.}
     \item{\code{"cor.all"}:}{The model-implied correlation matrix
         of both the observed and latent variables.}
-    \item{\code{"th"}:}{The model-implied thresholds. 
+    \item{\code{"th"}:}{The model-implied thresholds.
         Alias: \code{"thresholds"}.}
     \item{\code{"wls.est"}:}{The model-implied sample statistics (covariance
         elements, intercepts/thresholds, etc.) in a single vector.}
@@ -242,31 +243,31 @@ Gradient, Hessian, observed, expected and first.order information matrices:
     \item{\code{"information.observed"}:}{Matrix containing the observed
         information matrix for the free model parameters.}
     \item{\code{"information.first.order"}:}{Matrix containing the first.order
-        information matrix for the free model parameters. This is the 
-        outer product of the gradient elements (the first derivative of 
+        information matrix for the free model parameters. This is the
+        outer product of the gradient elements (the first derivative of
         the discrepancy function with respect to the (free) model parameters).
         Alias: \code{"first.order"}.}
-    \item{\code{"augmented.information"}:}{Matrix containing either the 
-        observed or the expected augmented (or bordered) information 
+    \item{\code{"augmented.information"}:}{Matrix containing either the
+        observed or the expected augmented (or bordered) information
         matrix (depending on the information option of the fitted model.
         Only relevant if constraints have been used in the model.}
-    \item{\code{"augmented.information.expected"}:}{Matrix containing the 
+    \item{\code{"augmented.information.expected"}:}{Matrix containing the
         expected augmented (or bordered) information matrix.
         Only relevant if constraints have been used in the model.}
-    \item{\code{"augmented.information.observed"}:}{Matrix containing the      
+    \item{\code{"augmented.information.observed"}:}{Matrix containing the
         observed augmented (or bordered) information matrix.
         Only relevant if constraints have been used in the model.}
-    \item{\code{"augmented.information.first.order"}:}{Matrix containing 
+    \item{\code{"augmented.information.first.order"}:}{Matrix containing
         the first.order augmented (or bordered) information matrix.
         Only relevant if constraints have been used in the model.}
-    \item{\code{"inverted.information"}:}{Matrix containing either the 
-        observed or the expected inverted information matrix 
+    \item{\code{"inverted.information"}:}{Matrix containing either the
+        observed or the expected inverted information matrix
         (depending on the information option of the fitted model.}
-    \item{\code{"inverted.information.expected"}:}{Matrix containing the 
-        inverted expected information matrix for the free model parameters.} 
-    \item{\code{"inverted.information.observed"}:}{Matrix containing the 
+    \item{\code{"inverted.information.expected"}:}{Matrix containing the
+        inverted expected information matrix for the free model parameters.}
+    \item{\code{"inverted.information.observed"}:}{Matrix containing the
         inverted observed information matrix for the free model parameters.}
-    \item{\code{"inverted.information.first.order"}:}{Matrix containing the 
+    \item{\code{"inverted.information.first.order"}:}{Matrix containing the
         inverted first.order information matrix for the free model parameters.}
 }
 
@@ -275,15 +276,15 @@ Variance covariance matrix of the model parameters:
 \describe{
     \item{\code{"vcov"}:}{Matrix containing the variance covariance matrix
         of the estimated model parameters.}
-    \item{\code{"vcov.std.all"}:}{Matrix containing the variance covariance 
-        matrix of the standardized estimated model parameters. Standardization  
+    \item{\code{"vcov.std.all"}:}{Matrix containing the variance covariance
+        matrix of the standardized estimated model parameters. Standardization
         is done with respect to both observed and latent variables.}
-    \item{\code{"vcov.std.lv"}:}{Matrix containing the variance covariance 
-        matrix of the standardized estimated model parameters. Standardization  
+    \item{\code{"vcov.std.lv"}:}{Matrix containing the variance covariance
+        matrix of the standardized estimated model parameters. Standardization
         is done with respect to the latent variables only.}
-    \item{\code{"vcov.std.nox"}:}{Matrix containing the variance covariance 
-        matrix of the standardized estimated model parameters. Standardization  
-        is done with respect to both observed and latent variables, but 
+    \item{\code{"vcov.std.nox"}:}{Matrix containing the variance covariance
+        matrix of the standardized estimated model parameters. Standardization
+        is done with respect to both observed and latent variables, but
         ignoring any exogenous observed covariates.}
 }
 
@@ -292,7 +293,7 @@ Miscellaneous:
 \describe{
     \item{\code{"UGamma"}:}{Matrix containing the product of 'U' and 'Gamma'
         matrices as used by the Satorra-Bentler correction. The trace of
-        this matrix, divided by the degrees of freedom, gives the scaling 
+        this matrix, divided by the degrees of freedom, gives the scaling
         factor.}
     \item{\code{"UfromUGamma"}:}{Matrix containing the 'U' matrix
         as used by the Satorra-Bentler correction. Alias: \code{"U"}.}
@@ -305,17 +306,17 @@ Miscellaneous:
         \code{"modification.indices"}. The same output as given
         by \code{modindices()}.}
     \item{\code{"options"}:}{List. The option list.}
-    \item{\code{"call"}:}{List. The call as returned by match.call, coerced to 
+    \item{\code{"call"}:}{List. The call as returned by match.call, coerced to
         a list.}
-    \item{\code{"timing"}:}{List. The timing (in milliseconds) of various 
+    \item{\code{"timing"}:}{List. The timing (in milliseconds) of various
         lavaan subprocedures.}
     \item{\code{"test"}:}{List. All available information regarding the
         (goodness-of-fit) test statistic(s).}
-    \item{\code{"post.check"}:}{Post-fitting check if the solution is 
-        admissible. A warning is raised if negative variances are found, or if 
-        either \code{lavInspect(fit, "cov.lv")} or 
+    \item{\code{"post.check"}:}{Post-fitting check if the solution is
+        admissible. A warning is raised if negative variances are found, or if
+        either \code{lavInspect(fit, "cov.lv")} or
         \code{lavInspect(fit, "theta")} return a non-positive definite matrix.}
-    \item{\code{"zero.cell.tables"}:}{List. List of bivariate frequency tables 
+    \item{\code{"zero.cell.tables"}:}{List. List of bivariate frequency tables
         where at least one cell is empty.}
 }
 
@@ -328,7 +329,7 @@ Miscellaneous:
 HS.model <- ' visual  =~ x1 + x2 + x3
               textual =~ x4 + x5 + x6
               speed   =~ x7 + x8 + x9 '
-     
+
 fit <- cfa(HS.model, data=HolzingerSwineford1939, group = "school")
 
 # extract information

--- a/man/lavPredict.Rd
+++ b/man/lavPredict.Rd
@@ -3,8 +3,8 @@
 \alias{lavpredict}
 \title{Predict the values of latent variables (and their indicators).}
 \description{
-The main purpose of the \code{lavPredict()} function is to compute (or 
-`predict') estimated values for the latent variables in the model 
+The main purpose of the \code{lavPredict()} function is to compute (or
+`predict') estimated values for the latent variables in the model
 (`factor scores'). NOTE: the goal of this
 function is NOT to predict future values of dependent variables as in the
 regression framework!}
@@ -28,29 +28,29 @@ the data.frame used when fitting the model in object.}
 \item{method}{A character string. In the linear case (when the indicators are
 continuous), the possible options are \code{"regression"} or \code{"Bartlett"}.
 In the categorical case, the two options are \code{"EBM"} for
-the Empirical Bayes Modal approach, and \code{"ML"} for the maximum 
+the Empirical Bayes Modal approach, and \code{"ML"} for the maximum
 likelihood approach.}
-\item{se}{Character. If \code{"none"}, no standard errors are computed. 
+\item{se}{Character. If \code{"none"}, no standard errors are computed.
 If \code{"standard"}, naive standard errors are computed (assuming the
 parameters of the measurement model are known). The standard errors are
 returned as an attribute.}
 \item{label}{Logical. If TRUE, the columns are labeled.}
-\item{fsm}{Logical. If TRUE, return the factor score matrix as an attribute. 
+\item{fsm}{Logical. If TRUE, return the factor score matrix as an attribute.
            Only for numeric data.}
 \item{level}{Integer. Only used in a multilevel SEM.
 If \code{level = 1}, only factor scores for latent variable
 defined at the first (within) level are computed; if \code{level = 2},
 only factor scores for latent variables defined at the second (between) level
 are computed.}
-\item{optim.method}{Character string. Only used in the categorical case. 
-If \code{"nlminb"} (the default in 0.5), the \code{"nlminb()"} function is used 
-for the optimization. If \code{"bfgs"} or \code{"BFGS"} (the default in 0.6), 
+\item{optim.method}{Character string. Only used in the categorical case.
+If \code{"nlminb"} (the default in 0.5), the \code{"nlminb()"} function is used
+for the optimization. If \code{"bfgs"} or \code{"BFGS"} (the default in 0.6),
 the \code{"optim()"} function is used with the BFGS method.}
 \item{ETA}{An optional matrix or list, containing latent variable values
   for each observation. Used for computations when \code{type = "ov"}.}
 }
 \details{
-The \code{predict()} function calls the \code{lavPredict()} function 
+The \code{predict()} function calls the \code{lavPredict()} function
 with its default options.
 
 If there are no latent variables in the model, \code{type = "ov"} will
@@ -63,12 +63,40 @@ the structural component is completely ignored (for now).
 \code{\link{lavaan}}
 }
 \examples{
-# fit model
+data(HolzingerSwineford1939)
+
+## fit model
 HS.model <- ' visual  =~ x1 + x2 + x3
               textual =~ x4 + x5 + x6
               speed   =~ x7 + x8 + x9 '
-     
-fit <- cfa(HS.model, data=HolzingerSwineford1939)
+
+fit <- cfa(HS.model, data = HolzingerSwineford1939)
 head(lavPredict(fit))
 head(lavPredict(fit, type = "ov"))
+
+
+## merge factor scores to original data.frame
+idx <- lavInspect(fit, "case.idx")
+fscores <- lavPredict(fit)
+## loop over factors
+for (fs in colnames(fscores)) {
+  HolzingerSwineford1939[idx, fs] <- fscores[ , fs]
+}
+head(HolzingerSwineford1939)
+
+
+## multigroup models return a list of factor scores (one per group)
+data(HolzingerSwineford1939)
+mgfit <- update(fit, group = "school", group.equal = c("loadings","intercepts"))
+
+idx <- lavInspect(mgfit, "case.idx") # list: 1 vector per group
+fscores <- lavPredict(mgfit)         # list: 1 matrix per group
+## loop over groups and factors
+for (g in seq_along(fscores)) {
+  for (fs in colnames(fscores[[g]])) {
+    HolzingerSwineford1939[ idx[[g]], fs] <- fscores[[g]][ , fs]
+  }
+}
+head(HolzingerSwineford1939)
+
 }

--- a/man/lavTestScore.Rd
+++ b/man/lavTestScore.Rd
@@ -11,7 +11,7 @@ fixed or constrained parameters in model.}
 \usage{
 lavTestScore(object, add = NULL, release = NULL,
              univariate = TRUE, cumulative = FALSE, epc = FALSE,
-             verbose = FALSE, warn = TRUE)
+             verbose = FALSE, warn = TRUE, use.exp.info = TRUE)
 }
 \arguments{
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
@@ -24,24 +24,28 @@ constraints as they appear in the parameter table.}
 \item{univariate}{Logical. If \code{TRUE}, compute the univariate score
 statistics, one for each constraints.}
 \item{cumulative}{Logical. If \code{TRUE}, order the univariate score
-statistics from large to small, and compute a series of 
+statistics from large to small, and compute a series of
 multivariate score statistics, each time adding an additional constraint.}
 \item{epc}{Logical. If \code{TRUE}, and we are releasing existing constraints,
 compute the expected parameter changes for the existing (free) parameters,
 for each released constraint.}
-\item{verbose}{Logical. Not used for now.} 
+\item{verbose}{Logical. Not used for now.}
 \item{warn}{Logical. If \code{TRUE}, print out warnings if they occur.}
+\item{use.exp.info}{Logical, indicating whether to use the expected information
+matrix (default: \code{TRUE}, which provides better control of Type I errors)
+or whichever type of information was used to estimate the standard errors
+(check \code{\link{lavInspect}(object, "options")$information}).}
 }
 \details{
     This function can be used to compute both multivariate and univariate
     score tests. There are two modes: 1) releasing fixed-to-zero parameters
-    (using the \code{add} argument), and 2) releasing existing equality 
+    (using the \code{add} argument), and 2) releasing existing equality
     constraints (using the \code{release} argument). The two modes can not
     be used simultaneously.
 
     When adding new parameters, they should not already be part of the model
-    (i.e. not listed in the parameter table). If you want to test for 
-    a parameter that was explicitly fixed to a constant (say to zero), 
+    (i.e. not listed in the parameter table). If you want to test for
+    a parameter that was explicitly fixed to a constant (say to zero),
     it is better to label the parameter, and use an explicit equality
     constraint.
 }
@@ -55,7 +59,7 @@ for each released constraint.}
       Each 1-\emph{df} score test, equivalent to modification indices.}
     \item{\code{$cumulative}: Optional (if \code{cumulative=TRUE}).
       Cumulative score tests.}
-    \item{\code{$epc}: Optional (if \code{epc=TRUE}). Parameter estimates, 
+    \item{\code{$epc}: Optional (if \code{epc=TRUE}). Parameter estimates,
       expected parameter changes, and expected parameter values if all
       the tested constraints were freed.}
   }

--- a/man/lavaan-class.Rd
+++ b/man/lavaan-class.Rd
@@ -30,7 +30,7 @@ Objects can be created via the
   \describe{
     \item{\code{version}:}{The lavaan package version used to create this objects}
     \item{\code{call}:}{The function call as returned by \code{match.call()}.}
-    \item{\code{timing}:}{The elapsed time (user+system) for various parts of 
+    \item{\code{timing}:}{The elapsed time (user+system) for various parts of
       the program as a list, including the total time.}
     \item{\code{Options}:}{Named list of options that were provided by
       the user, or filled-in automatically.}
@@ -38,12 +38,12 @@ Objects can be created via the
     \item{\code{pta}:}{Named list containing parameter table attributes.}
     \item{\code{Data}:}{Object of internal class \code{"Data"}: information
 about the data.}
-    \item{\code{SampleStats}:}{Object of internal class \code{"SampleStats"}: sample 
+    \item{\code{SampleStats}:}{Object of internal class \code{"SampleStats"}: sample
       statistics}
-    \item{\code{Model}:}{Object of internal class \code{"Model"}: the 
+    \item{\code{Model}:}{Object of internal class \code{"Model"}: the
       internal (matrix) representation of the model}
     \item{\code{Cache}:}{List using objects that we try to compute only once, and reuse many times.}
-    \item{\code{Fit}:}{Object of internal class \code{"Fit"}: the 
+    \item{\code{Fit}:}{Object of internal class \code{"Fit"}: the
       results of fitting the model. No longer used.}
     \item{\code{boot}:}{List. Results and information about the bootstrap.}
     \item{\code{optim}:}{List. Information about the optimization.}
@@ -59,28 +59,28 @@ the independence model) (if available).}
 }
 \section{Methods}{
   \describe{
-    \item{coef}{\code{signature(object = "lavaan", type = "free")}: Returns 
+    \item{coef}{\code{signature(object = "lavaan", type = "free")}: Returns
       the estimates of the parameters in the model as a named numeric vector.
       If \code{type="free"}, only the free parameters are returned.
       If \code{type="user"}, all parameters listed in the parameter table
       are returned, including constrained and fixed parameters.}
-    \item{fitted.values}{\code{signature(object = "lavaan")}: Returns the 
-      implied moments of the model as a list with two elements (per group): 
-      \code{cov} for the implied covariance matrix, 
-      and \code{mean} for the implied mean 
-      vector. If only the covariance matrix was analyzed, the implied mean 
+    \item{fitted.values}{\code{signature(object = "lavaan")}: Returns the
+      implied moments of the model as a list with two elements (per group):
+      \code{cov} for the implied covariance matrix,
+      and \code{mean} for the implied mean
+      vector. If only the covariance matrix was analyzed, the implied mean
       vector will be zero.}
     \item{fitted}{\code{signature(object = "lavaan")}: an alias for
         \code{fitted.values}.}
-    \item{residuals}{\code{signature(object = "lavaan", type="raw")}: 
+    \item{residuals}{\code{signature(object = "lavaan", type="raw")}:
       If \code{type="raw"}, this function returns the raw (=unstandardized)
-      difference between the implied moments and the observed moments as 
-      a list of two elements: \code{cov} for the residual covariance matrix, 
-      and \code{mean} for the residual mean vector. 
-      If only the covariance matrix was analyzed, the residual mean vector 
-      will be zero. 
-      If \code{type="cor"}, the observed and model implied covariance matrix 
-      is first transformed to a correlation matrix (using \code{cov2cor}), 
+      difference between the implied moments and the observed moments as
+      a list of two elements: \code{cov} for the residual covariance matrix,
+      and \code{mean} for the residual mean vector.
+      If only the covariance matrix was analyzed, the residual mean vector
+      will be zero.
+      If \code{type="cor"}, the observed and model implied covariance matrix
+      is first transformed to a correlation matrix (using \code{cov2cor}),
       before the residuals are computed.
       If \code{type="normalized"}, the residuals are
       divided by the square root of an asymptotic variance estimate of the
@@ -101,16 +101,16 @@ the independence model) (if available).}
     \item{predict}{\code{signature(object = "lavaan")}: compute
       factor scores for all cases that are provided in the data frame. For
       complete data only.}
-    \item{anova}{\code{signature(object = "lavaan")}: returns 
+    \item{anova}{\code{signature(object = "lavaan")}: returns
       model comparison statistics. This method is just a wrapper around
       the function \code{\link{lavTestLRT}}.
       If only a single argument (a fitted
       model) is provided, this model is compared to the unrestricted
       model. If two or more arguments (fitted models) are provided, the models
-      are compared in a sequential order. Test statistics are based on the 
+      are compared in a sequential order. Test statistics are based on the
       likelihood ratio test. For more details and
-      further options, see the \code{\link{lavTestLRT}} page.} 
-    \item{update}{\code{signature(object = "lavaan", model, add, ..., 
+      further options, see the \code{\link{lavTestLRT}} page.}
+    \item{update}{\code{signature(object = "lavaan", model, add, ...,
         evaluate=TRUE)}: update a fitted lavaan object and evaluate it
         (unless \code{evaluate=FALSE}). Note that we use the environment
         that is stored within the lavaan object, which is not necessarily
@@ -125,35 +125,38 @@ the independence model) (if available).}
       returns the log-likelihood of the fitted model, if maximum likelihood estimation
       was used. The \code{\link[stats]{AIC}} and \code{\link[stats]{BIC}}
       methods automatically work via \code{logLik()}.}
-    \item{show}{\code{signature(object = "lavaan")}: Print a short summary 
+    \item{show}{\code{signature(object = "lavaan")}: Print a short summary
       of the model fit}
-    \item{summary}{\code{signature(object = "lavaan", header = TRUE, 
-     fit.measures = FALSE, estimates = TRUE, ci = FALSE, fmi = FALSE, 
-     standardized = FALSE, cov.std = TRUE, rsquare = FALSE, std.nox = FALSE, 
-     modindices = FALSE, ci = FALSE, nd = 3L)}: 
-      Print a nice summary of the model estimates. 
+    \item{summary}{\code{signature(object = "lavaan", header = TRUE,
+     fit.measures = FALSE, estimates = TRUE, ci = FALSE, fmi = FALSE,
+     standardized = FALSE, cov.std = TRUE, rsquare = FALSE, std.nox = FALSE,
+     modindices = FALSE, ci = FALSE, nd = 3L)}:
+      Print a nice summary of the model estimates.
       If \code{header = TRUE}, the header section (including fit measures) is
-      printed.  
+      printed.
       If \code{fit.measures = TRUE}, additional fit measures are added to the
       header section.
       If \code{estimates = TRUE}, print the parameter estimates section.
       If \code{ci = TRUE}, add confidence intervals to the parameter estimates
       section.
-      If \code{fmi = TRUE}, add the fmi (fraction of missing information) 
+      If \code{fmi = TRUE}, add the fmi (fraction of missing information)
       column, if it is available.
       If \code{standardized=TRUE},
-      the standardized solution is also printed.  
+      the standardized solution is also printed.  Note that \emph{SE}s and
+      tests are still based on unstandardized estimates. Use
+      \code{\link{standardizedSolution}} to obtain \emph{SE}s and test
+      statistics for standardized estimates.
       If \code{rsquare=TRUE}, the R-Square values for the dependent variables
-      in the model are printed. 
-      If \code{std.nox = TRUE}, the \code{std.all} column contains the 
+      in the model are printed.
+      If \code{std.nox = TRUE}, the \code{std.all} column contains the
       the \code{std.nox} column from the parameterEstimates() output.
       If \code{modindices=TRUE}, modification indices
-      are printed for all fixed parameters. 
+      are printed for all fixed parameters.
       The argument \code{nd} determines the number of digits after the
       decimal point to be printed (currently only in the parameter estimates
       section.)
-      Nothing is returned (use 
-      \code{lavInspect} or another extractor function 
+      Nothing is returned (use
+      \code{lavInspect} or another extractor function
       to extract information from a fitted model).}
   }
 }
@@ -166,7 +169,7 @@ Standardized Residuals in Mplus. Document retrieved from URL
 http://www.statmodel.com/download/StandardizedResiduals.pdf
 }
 \seealso{
-\code{\link{cfa}}, \code{\link{sem}}, \code{\link{growth}}, 
+\code{\link{cfa}}, \code{\link{sem}}, \code{\link{growth}},
 \code{\link{fitMeasures}}, \code{\link{standardizedSolution}},
 \code{\link{parameterEstimates}}, \code{\link{lavInspect}},
 \code{\link{modindices}}

--- a/man/modificationIndices.Rd
+++ b/man/modificationIndices.Rd
@@ -4,46 +4,51 @@
 \alias{modindices}
 \title{Modification Indices}
 \description{
-Given a fitted lavaan object, compute the modification indices 
+Given a fitted lavaan object, compute the modification indices
 (= univariate score tests) for a selected set of fixed-to-zero parameters.
 }
 \usage{
 modificationIndices(object, standardized = TRUE, cov.std = TRUE,
-                    power = FALSE, delta = 0.1, alpha = 0.05, 
-                    high.power = 0.75, sort. = FALSE, minimum.value = 0, 
+                    use.exp.info = TRUE,
+                    power = FALSE, delta = 0.1, alpha = 0.05,
+                    high.power = 0.75, sort. = FALSE, minimum.value = 0,
                     maximum.number = nrow(LIST), free.remove = TRUE,
                     na.remove = TRUE, op = NULL)
-modindices(object, standardized = TRUE, cov.std = TRUE, power = FALSE,
-                    delta = 0.1, alpha = 0.05, high.power = 0.75,
-                    sort. = FALSE, minimum.value = 0, 
+modindices(object, standardized = TRUE, cov.std = TRUE, use.exp.info = TRUE,
+                    power = FALSE, delta = 0.1, alpha = 0.05, high.power = 0.75,
+                    sort. = FALSE, minimum.value = 0,
                     maximum.number = nrow(LIST), free.remove = TRUE,
                     na.remove = TRUE, op = NULL)
 }
 \arguments{
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
-\item{standardized}{If \code{TRUE}, two extra columns (sepc.lv and sepc.all) 
+\item{standardized}{If \code{TRUE}, two extra columns (sepc.lv and sepc.all)
 will contain standardized values for the epc's. In the first column (sepc.lv),
 standardizization is based on the variances of the (continuous) latent
 variables. In the second column (sepc.all), standardization is based
 on both the variances of both (continuous) observed and latent variables.
 (Residual) covariances are standardized using (residual) variances.}
 \item{cov.std}{Logical. See \code{\link{standardizedSolution}}.}
+\item{use.exp.info}{Logical, indicating whether to use the expected information
+matrix (default: \code{TRUE}, which provides better control of Type I errors)
+or whichever type of information was used to estimate the standard errors
+(check \code{\link{lavInspect}(object, "options")$information}).}
 \item{power}{If \code{TRUE}, the (post-hoc) power is computed for each
 modification index, using the values of \code{delta} and \code{alpha}.}
-\item{delta}{The value of the effect size, as used in the post-hoc power 
+\item{delta}{The value of the effect size, as used in the post-hoc power
 computation, currently using the unstandardized metric of the epc column.}
 \item{alpha}{The significance level used for deciding if the modification
 index is statistically significant or not.}
 \item{high.power}{If the computed power is higher than this cutoff value,
-the power is considered `high'. If not, the power is considered `low'. 
+the power is considered `high'. If not, the power is considered `low'.
 This affects the values in the 'decision' column in the output.}
-\item{sort.}{Logical. If TRUE, sort the output using the values of 
+\item{sort.}{Logical. If TRUE, sort the output using the values of
 the modification index values. Higher values appear first.}
-\item{minimum.value}{Numeric. Filter output and only show rows with a 
+\item{minimum.value}{Numeric. Filter output and only show rows with a
 modification index value equal or higher than this minimum value.}
 \item{maximum.number}{Integer. Filter output and only show the first
 maximum number rows. Most useful when combined with the \code{sort.} option.}
-\item{free.remove}{Logical. If TRUE, filter output by removing all rows 
+\item{free.remove}{Logical. If TRUE, filter output by removing all rows
 corresponding to free (unconstrained) parameters in the original model.}
 \item{na.remove}{Logical. If TRUE, filter output by removing all rows with
 NA values for the modification indices.}
@@ -55,16 +60,16 @@ operator \code{op}.}
 }
 \details{
   Modification indices are just 1-df (or univariate) score tests. The
-  modification index (or score test) for a single parameter reflects 
+  modification index (or score test) for a single parameter reflects
   (approximately) the improvement in model fit (in terms of the chi-square
-  test statistic), if we would refit the model but allow this parameter to 
+  test statistic), if we would refit the model but allow this parameter to
   be free.
-  This function is a convenience function in the sense that it produces a 
+  This function is a convenience function in the sense that it produces a
   (hopefully sensible) table of currently fixed-to-zero (of fixed to another
   constant) parameters. For each of these parameters, a modification index
   is computed, together with an expected parameter change (epc) value.
-  It is important to realize that this function will only consider 
-  fixed-to-zero parameters. If you have equality constraints in the model, 
+  It is important to realize that this function will only consider
+  fixed-to-zero parameters. If you have equality constraints in the model,
   and you wish to examine what happens if you release all (or some) of these
   equality constraints, use the \code{\link{lavTestScore}} function.
 }

--- a/man/parameterEstimates.Rd
+++ b/man/parameterEstimates.Rd
@@ -5,11 +5,11 @@
 \description{
 Parameter estimates of a latent variable model.}
 \usage{
-parameterEstimates(object, se = TRUE, zstat = TRUE, pvalue = TRUE, 
-                   ci = TRUE, level = 0.95, boot.ci.type = "perc", 
-                   standardized = FALSE, cov.std = TRUE, fmi = FALSE, 
-                   remove.system.eq = TRUE, remove.eq = TRUE, 
-                   remove.ineq = TRUE, remove.def = FALSE, 
+parameterEstimates(object, se = TRUE, zstat = TRUE, pvalue = TRUE,
+                   ci = TRUE, level = 0.95, boot.ci.type = "perc",
+                   standardized = FALSE, cov.std = TRUE, fmi = FALSE,
+                   remove.system.eq = TRUE, remove.eq = TRUE,
+                   remove.ineq = TRUE, remove.def = FALSE,
                    rsquare = FALSE, add.attributes = FALSE, header = TRUE)
 }
 \arguments{
@@ -26,14 +26,16 @@ normal distribution.}
 \item{ci}{If \code{TRUE}, confidence intervals are added to the output}
 \item{level}{The confidence level required.}
 \item{boot.ci.type}{If bootstrapping was used, the type of interval required.
-  The value should be one of \code{"norm"}, \code{"basic"}, \code{"perc"}, 
+  The value should be one of \code{"norm"}, \code{"basic"}, \code{"perc"},
   or \code{"bca.simple"}. For the first three options, see the help page of
-  the \code{boot.ci} function in the boot package. The 
+  the \code{boot.ci} function in the boot package. The
   \code{"bca.simple"} option produces intervals using the adjusted bootstrap
-  percentile (BCa) method, but with no correction for acceleration (only for 
+  percentile (BCa) method, but with no correction for acceleration (only for
   bias).}
-\item{standardized}{Logical. If \code{TRUE}, standardized estimates are 
-added to the output}
+\item{standardized}{Logical. If \code{TRUE}, standardized estimates are
+added to the output. Note that \emph{SE}s and tests are still based on
+unstandardized estimates. Use \code{\link{standardizedSolution}} to obtain
+\emph{SE}s and test statistics for standardized estimates.}
 \item{cov.std}{Logical. If TRUE, the (residual) observed
 covariances are scaled by the square root of the `Theta' diagonal elements, and
 the (residual) latent covariances are scaled by the square root of the `Psi'
@@ -44,25 +46,25 @@ are scaled by the square root of diagonal elements of the model-implied
 covariance matrix of the latent variables.}
 \item{fmi}{Logical. If \code{TRUE}, an extra column is added containing the
 fraction of missing information for each estimated parameter. Only
-available if 
+available if
 \code{estimator="ML"}, \code{missing="(fi)ml"}, and \code{se="standard"}.
 See references for more information.}
-\item{remove.eq}{Logical. If \code{TRUE}, filter the output by removing all 
+\item{remove.eq}{Logical. If \code{TRUE}, filter the output by removing all
 rows containing user-specified equality constraints, if any.}
-\item{remove.system.eq}{Logical. If \code{TRUE}, filter the output by 
+\item{remove.system.eq}{Logical. If \code{TRUE}, filter the output by
 removing all rows containing system-generated equality constraints, if any.}
 \item{remove.ineq}{Logical. If \code{TRUE}, filter the output by removing all
 rows containing inequality constraints, if any.}
 \item{remove.def}{Logical. If \code{TRUE}, filter the ouitput by removing all
 rows containing parameter definitions, if any.}
 \item{rsquare}{Logical. If \code{TRUE}, add additional rows containing
-the rsquare values (in the \code{est} column) of all endogenous variables 
+the rsquare values (in the \code{est} column) of all endogenous variables
 in the model. Both the \code{lhs} and \code{rhs} column contain the
-name of the endogenous variable, while the code{op} column contains \code{r2}, 
+name of the endogenous variable, while the code{op} column contains \code{r2},
 to indicate that the values in the \code{est} column are rsquare values.}
 \item{add.attributes}{Logical. If \code{TRUE}, add a class attribute
 (class \code{lavaan.parameterEstimates}) and other attributes to be used by
-the print function for this class (\code{print.lavaan.parameterEstimates}). 
+the print function for this class (\code{print.lavaan.parameterEstimates}).
 This is used by the \code{summary()} function, to prettify the output.}
 \item{header}{Logical. Only used if \code{add.attributes = TRUE}. If
 \code{TRUE}, print a header at the top of the parameter list. This header
@@ -72,7 +74,7 @@ in the output.}
 }
 \value{
   A data.frame containing the estimated parameters,
-  parameters, standard errors, and (by default) z-values , p-values, and 
+  parameters, standard errors, and (by default) z-values , p-values, and
   the lower and upper values of the confidence intervals. If requested,
   extra columns are added with standardized versions of the parameter
   estimates.


### PR DESCRIPTION
In order to preserve the original values of the arguments specified by the user to `cfaList()` or `semList()` when storing the `@call` slot, I used `match.call()` instead of directly calling `lavaanList()` with eponymous argument names. 

To facilitate performing simulation studies that can compare the use of different information matrices when calculating score tests (I am involved with such a study by one of Craig Enders' grad students), I added an option to use the information requested when fitting the model.  By default, the expected information is requested, to preserve the current behavior (which is ideal, but it is still nice to be able to empirically verify that).