### PR TITLE
Two issues in the lavTestLRT function

### DIFF
--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -116,7 +116,7 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
         scaled <- TRUE
         # which type?
         TEST <- object@test[[2]]$test
-    } else if(!all(mods.scaled)) {
+    } else if(!any(mods.scaled)) {
         scaled <- FALSE
         TEST <- "standard"
     } else {
@@ -138,19 +138,11 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
     # collect statistics for each model
     if(type == "chisq") {
         Df <- sapply(mods, function(x) slot(x, "test")[[1]]$df)
-    } else if(type == "cf") {
-        Df <- rep(as.numeric(NA), length(mods))
-    } else {
-        stop("lavaan ERROR: test type unknown: ", type)
-    }
-
-
-    if(type == "chisq") {
         STAT <- sapply(mods, function(x) slot(x, "test")[[1]]$stat)
     } else if(type == "cf") {
         tmp <- lapply(mods, lavTablesFitCf)
-        STAT <- unlist(tmp)
         Df  <- unlist(lapply(tmp, attr, "DF"))
+        STAT <- unlist(tmp)
     } else {
         stop("lavaan ERROR: test type unknown: ", type)
     }

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -137,8 +137,8 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
 
     # collect statistics for each model
     if(type == "chisq") {
-        Df <- sapply(mods, function(x) slot(x, "test")[[1]]$df)
-        STAT <- sapply(mods, function(x) slot(x, "test")[[1]]$stat)
+        Df <- sapply(mods, function(x) slot(x, "test")[[1 + scaled]]$df)
+        STAT <- sapply(mods, function(x) slot(x, "test")[[1 + scaled]]$stat)
     } else if(type == "cf") {
         tmp <- lapply(mods, lavTablesFitCf)
         Df  <- unlist(lapply(tmp, attr, "DF"))


### PR DESCRIPTION
When the logical variable "scaled" is assigned, there is a check if all models use a scaled statistic.
In the second if-statement, !all() had to be changed to !any() or else even if there were some scaled and some unscaled, it would have always evaluated to TRUE, which means that the stop()/error was never executed.

Secondly, if scaled == TRUE, the scaled chisq/df values are now extracted from the model objects.

The third is a cosmetic adjustment. If type == "Cf", there were two assignments to "Df" with the second one always overwriting the first. Now the STAT and Df assignments are combined in the same if-statement.