### PR TITLE
lavTestScore updates

### DIFF
--- a/R/lav_test_score.R
+++ b/R/lav_test_score.R
@@ -169,6 +169,7 @@ lavTestScore <- function(object, add = NULL, release = NULL,
 
     if(univariate) {
         TS <- numeric( nrow(R) )
+        EPC.uni <- numeric( nrow(R) ) # ignored in release= mode
         for(r in r.idx) {
             R1 <- R[-r,,drop = FALSE]
             Z1 <- cbind( rbind(Information, R1),
@@ -176,12 +177,19 @@ lavTestScore <- function(object, add = NULL, release = NULL,
             Z1.plus <- MASS::ginv(Z1)
             Z1.plus1 <- Z1.plus[ 1:nrow(Information), 1:nrow(Information) ]
             TS[r] <- as.numeric(N * t(score) %*%  Z1.plus1 %*% score)
+            if (epc && !is.null(add)) {
+              EPC.uni[r] <- -1 * utils::tail(as.numeric(score %*%  Z1.plus1),
+                                             n = nrow(R))[r]
+            }
         }
 
         Table2 <- Table
         Table2$X2 <- TS[r.idx]
         Table2$df <- rep(1, length(r.idx))
         Table2$p.value <- 1 - pchisq(Table2$X2, df = Table2$df)
+        if (epc && !is.null(add)) {
+          Table2$epc <- EPC.uni[r.idx]
+        }
         attr(Table2, "header") <- "univariate score tests:"
         OUT$uni <- Table2
     }

--- a/R/lav_test_score.R
+++ b/R/lav_test_score.R
@@ -200,7 +200,7 @@ lavTestScore <- function(object, add = NULL, release = NULL,
             TS[r] <- as.numeric(N * t(score) %*%  Z1.plus1 %*% score)
         }
 
-        Table3 <- Table
+        Table3 <- Table[TS.order,]
         Table3$X2 <- TS
         Table3$df <- seq_len( length(TS) )
         Table3$p.value <- 1 - pchisq(Table3$X2, df = Table3$df)

--- a/man/lavTestScore.Rd
+++ b/man/lavTestScore.Rd
@@ -10,7 +10,8 @@ Score test (or Lagrange Multiplier test) for releasing one or more
 fixed or constrained parameters in model.}
 \usage{
 lavTestScore(object, add = NULL, release = NULL,
-             univariate = TRUE, cumulative = FALSE, epc = FALSE,
+             univariate = TRUE, cumulative = FALSE,
+             epc = FALSE, standardized = epc, cov.std = epc,
              verbose = FALSE, warn = TRUE, information = "expected")
 }
 \arguments{
@@ -29,6 +30,14 @@ multivariate score statistics, each time adding an additional constraint.}
 \item{epc}{Logical. If \code{TRUE}, and we are releasing existing constraints,
 compute the expected parameter changes for the existing (free) parameters,
 for each released constraint.}
+\item{standardized}{If \code{TRUE}, two extra columns (sepc.lv and sepc.all)
+in the \code{$epc} table
+will contain standardized values for the EPCs. In the first column (sepc.lv),
+standardization is based on the variances of the (continuous) latent
+variables. In the second column (sepc.all), standardization is based
+on both the variances of both (continuous) observed and latent variables.
+(Residual) covariances are standardized using (residual) variances.}
+\item{cov.std}{Logical. See \code{\link{standardizedSolution}}.}
 \item{verbose}{Logical. Not used for now.}
 \item{warn}{Logical. If \code{TRUE}, print out warnings if they occur.}
 \item{information}{\code{character} indicating the type of information matrix
@@ -55,7 +64,10 @@ information is the default, which provides better control of Type I errors.}
       test statistic (\code{X2}), the degrees of freedom (\code{df}), and
       a \emph{p} value under the \eqn{\chi^2} distribution (\code{p.value}).}
     \item{\code{$uni}: Optional (if \code{univariate=TRUE}).
-      Each 1-\emph{df} score test, equivalent to modification indices.}
+      Each 1-\emph{df} score test, equivalent to modification indices.
+      If \code{epc=TRUE} when \code{add}ing parameters (not when releasing
+      constraints), an unstandardized EPC is provided for each added parameter,
+      as would be returned by \code{\link{modificationIndices}}.}
     \item{\code{$cumulative}: Optional (if \code{cumulative=TRUE}).
       Cumulative score tests.}
     \item{\code{$epc}: Optional (if \code{epc=TRUE}). Parameter estimates,

--- a/man/modificationIndices.Rd
+++ b/man/modificationIndices.Rd
@@ -23,8 +23,8 @@ modindices(object, standardized = TRUE, cov.std = TRUE, information = "expected"
 \arguments{
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
 \item{standardized}{If \code{TRUE}, two extra columns (sepc.lv and sepc.all)
-will contain standardized values for the epc's. In the first column (sepc.lv),
-standardizization is based on the variances of the (continuous) latent
+will contain standardized values for the EPCs. In the first column (sepc.lv),
+standardization is based on the variances of the (continuous) latent
 variables. In the second column (sepc.all), standardization is based
 on both the variances of both (continuous) observed and latent variables.
 (Residual) covariances are standardized using (residual) variances.}


### PR DESCRIPTION
Only one of these is necessary: the `$cumulative` table used the same order of rows as the `$uni` table, instead of sorting it, so the constraint labels did not match the tests.

The other changes are just things I would like to see :-)  

- Standardized EPCs in the `$epc` table
- An `epc` column in the `$uni` table when `add`ing parameters and `epc=TRUE` (matches `modindices()`).

It would take more cleverness than I have time for right now to add standardized EPCs to the `$uni` output, which would be nice, but I'd rather wait to see if you agree to add EPCs to `$uni` at all.