### PR TITLE
add inspect options for cluster sizes, count(s), and IDs

### DIFF
--- a/R/lav_lavaanList_inspect.R
+++ b/R/lav_lavaanList_inspect.R
@@ -95,6 +95,8 @@ lavListInspect <- function(object,
         object@Data@ngroups
     } else if(what == "group") {
         object@Data@group
+    } else if(what == "nlevels") {
+        object@Data@nlevels
     } else if(what == "cluster") {
         object@Data@cluster
     } else if(what == "ordered") {

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -1095,7 +1095,7 @@ lav_object_inspect_case_idx <- function(object, level = 1L,
 
     if (level == 2L) {
         # level-2 (cluster) IDs
-        OUT <- lapply(object@Data@Lp, function(gg) gg$cluster.idx[[2]])
+        OUT <- lapply(object@Data@Lp, function(gg) gg$cluster.id[[2]][ gg$cluster.idx[[2]] ])
         #FIXME: update if lavaan ever accepts 3-level or cross-classified models
 
     } else OUT <- object@Data@case.idx # level-1 (casewise) IDs

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -180,8 +180,17 @@ lavInspect.lavaan <- function(object,
         object@Data@group
     } else if(what == "cluster") {
       object@Data@cluster
+    } else if(what == "cluster.idx") {
+        lav_object_inspect_case_idx(object, level = 2L,
+            drop.list.single.group = drop.list.single.group)
     } else if(what == "nlevels") {
       object@Data@nlevels
+    } else if(what == "nclusters") {
+        lav_object_inspect_ncluster(object, sizes = FALSE,
+              drop.list.single.group = drop.list.single.group)
+    } else if(what == "cluster.size") {
+        lav_object_inspect_ncluster(object, sizes = TRUE,
+              drop.list.single.group = drop.list.single.group)
     } else if(what == "ordered") {
         object@Data@ordered
     } else if(what == "group.label") {
@@ -1075,11 +1084,21 @@ lav_object_inspect_data <- function(object, add.labels = FALSE,
     OUT
 }
 
-lav_object_inspect_case_idx <- function(object,
+lav_object_inspect_case_idx <- function(object, level = 1L,
                                         drop.list.single.group = FALSE) {
+    #FIXME: if lavaan every allows 3-level or cross-classifed models,
+    #      "level=" should be a character indicating the clustering variable
 
     G <- object@Data@ngroups
-    OUT <- object@Data@case.idx
+    nlevels <- object@Data@nlevels
+    if (nlevels == 1L) level <- 1L # if what="cluster.idx" for single-level model
+
+    if (level == 2L) {
+        # level-2 (cluster) IDs
+        OUT <- lapply(object@Data@Lp, function(gg) gg$cluster.idx[[2]])
+        #FIXME: update if lavaan ever accepts 3-level or cross-classified models
+
+    } else OUT <- object@Data@case.idx # level-1 (casewise) IDs
 
     if(G == 1L && drop.list.single.group) {
         OUT <- OUT[[1]]
@@ -1088,10 +1107,36 @@ lav_object_inspect_case_idx <- function(object,
             names(OUT) <- unlist(object@Data@group.label)
         }
     }
-
     OUT
 }
 
+# count the number of clusters, or obtain N within each cluster
+lav_object_inspect_ncluster <- function(object, sizes = FALSE, #level = 2L,
+                                        drop.list.single.group = FALSE) {
+    G <- object@Data@ngroups
+    nlevels <- object@Data@nlevels
+
+    if (nlevels == 1L) {
+      # single-level model, return sample size(s) or count 1 cluster per group
+      OUT <- if (sizes) unlist(object@Data@nobs) else rep(1L, G)
+
+    } else if (sizes) {
+      # for each group, a vector of cluster sizes
+      OUT <- lapply(object@Data@Lp, function(gg) gg$cluster.size[[2]])
+      #FIXME: update if lavaan ever accepts 3-level or cross-classified models
+
+      if (G == 1L && drop.list.single.group) OUT <- OUT[[1]]
+
+    } else {
+      # number of clusters in each group
+      OUT <- sapply(object@Data@Lp, function(gg) gg$nclusters[[2]])
+      #FIXME: update if lavaan ever accepts 3-level or cross-classified models
+    }
+
+    # assign group names, if applicable
+    if (G > 1L) names(OUT) <- unlist(object@Data@group.label)
+    OUT
+}
 
 lav_object_inspect_rsquare <- function(object, est.std.all=NULL,
     add.labels = FALSE, add.class = FALSE, drop.list.single.group = FALSE) {

--- a/man/lavInspect.Rd
+++ b/man/lavInspect.Rd
@@ -110,8 +110,13 @@ Information about the data (including missing patterns):
     \item{\code{"ngroups"}:}{Integer. The number of groups.}
     \item{\code{"group.label"}:}{A character vector. The group labels.}
     \item{\code{"cluster"}:}{A character vector. The cluster variable(s)
-       in the data.frame (if any).}
+        in the data.frame (if any).}
     \item{\code{"nlevels"}:}{Integer. The number of levels.}
+    \item{\code{"nclusters"}:}{Integer vector. The number of clusters
+        in each group that were used in the analysis.}
+    \item{\code{"cluster.size"}:}{Integer vector. The number of observations
+        within each cluster. For multigroup multilevel models, a list of
+        integer vectors, indicating cluster sizes within each group.}
     \item{\code{"ordered"}:}{A character vector. The ordered variables.}
     \item{\code{"nobs"}:}{Integer vector. The number of observations
         in each group that were used in the analysis.}
@@ -123,7 +128,12 @@ Information about the data (including missing patterns):
         this is the sum of the \code{"nobs"} numbers for each group.}
     \item{\code{"case.idx"}:}{The case/observation numbers that were used
         in the analysis.
-        In the case of multiple groups: a list of numbers.}
+        In the case of multiple groups: a list of numbers.
+        In the case of multilevel models, these are Level-1 IDs.}
+    \item{\code{"cluster.idx"}:}{In multilevel models, the Level-2 IDs for each
+        Level-1 case/observation used in the analysis.
+        In the case of multiple groups: a list of numbers.
+        For single-level models, output will match \code{"case.idx"}.}
     \item{\code{"empty.idx"}:}{The case/observation numbers of those
         cases/observations that contained missing values only
         (at least for the observed variables that were included in the model).
@@ -188,7 +198,7 @@ Model-implied sample statistics:
 \describe{
     \item{\code{"implied"}:}{The model-implied summary statistics.
         Alias: \code{"fitted"}, \code{"expected"}, \code{"exp"}.}
-    \item{\code{"resid"}:}{The difference between observed and model-implied 
+    \item{\code{"resid"}:}{The difference between observed and model-implied
         summary statistics.
         Alias: \code{"residuals"}, \code{"residual"}, \code{"res"}.}
     \item{\code{"cov.lv"}:}{The model-implied variance-covariance matrix
@@ -303,18 +313,18 @@ Variance covariance matrix of the model parameters:
         matrix of the standardized user-defined parameters. Standardization
         is done with respect to both observed and latent variables, but
         ignoring any exogenous observed covariates.}
-    \item{\code{"vcov.def.joint"}:}{Matrix containing the joint variance 
+    \item{\code{"vcov.def.joint"}:}{Matrix containing the joint variance
         covariance matrix of both the estimated model parameters and
         the defined (using the := operator) parameters.}
     \item{\code{"vcov.def.joint.std.all"}:}{Matrix containing the joint
         variance covariance matrix of both the standardized model parameters
         and the user-defined parameters. Standardization
         is done with respect to both observed and latent variables.}
-    \item{\code{"vcov.def.joint.std.lv"}:}{Matrix containing the joint 
+    \item{\code{"vcov.def.joint.std.lv"}:}{Matrix containing the joint
         variance covariance matrix of both the standardized model parameters
         and the user-defined parameters. Standardization
-        is done with respect to the latent variables only.}   
-    \item{\code{"vcov.def.joint.std.nox"}:}{Matrix containing the joint 
+        is done with respect to the latent variables only.}
+    \item{\code{"vcov.def.joint.std.nox"}:}{Matrix containing the joint
         variance covariance matrix of both the standardized model parameters
         and the user-defined parameters. Standardization
         is done with respect to both observed and latent variables, but
@@ -351,7 +361,7 @@ Miscellaneous:
         \code{lavInspect(fit, "theta")} return a non-positive definite matrix.}
     \item{\code{"zero.cell.tables"}:}{List. List of bivariate frequency tables
         where at least one cell is empty.}
-    \item{\code{"version"}:}{The lavaan version number that was used to 
+    \item{\code{"version"}:}{The lavaan version number that was used to
         construct the fitted lavaan object.}
 }
 
@@ -365,7 +375,7 @@ HS.model <- ' visual  =~ x1 + x2 + x3
               textual =~ x4 + x5 + x6
               speed   =~ x7 + x8 + x9 '
 
-     
+
 fit <- cfa(HS.model, data = HolzingerSwineford1939, group = "school")
 
 # extract information

--- a/man/lavListInspect.Rd
+++ b/man/lavListInspect.Rd
@@ -8,11 +8,11 @@ inspect/extract information that is stored inside (or can be computed from) a
 lavaanList object.
 }
 \usage{
-lavListInspect(object, what = "free", add.labels = TRUE, 
+lavListInspect(object, what = "free", add.labels = TRUE,
                add.class = TRUE, list.by.group = TRUE,
                drop.list.single.group = TRUE)
 
-lavListTech(object, what = "free", add.labels = FALSE, 
+lavListTech(object, what = "free", add.labels = FALSE,
             add.class = FALSE, list.by.group = FALSE,
             drop.list.single.group = FALSE)
 }
@@ -55,11 +55,11 @@ Model matrices:
         of for example \code{coef()} and \code{vcov()}.}
     \item{\code{"partable"}:}{A list of model matrices. The non-zero integers
         represent both the fixed parameters (for example, factor loadings
-        fixed at 1.0), and the free parameters if we ignore any equality 
-        constraints. They correspond with all entries (fixed or free) 
+        fixed at 1.0), and the free parameters if we ignore any equality
+        constraints. They correspond with all entries (fixed or free)
         in the parameter table. See \code{\link{parTable}}.}
     \item{\code{"start"}:}{A list of model matrices. The values represent
-        the starting values for all model parameters. 
+        the starting values for all model parameters.
         Alias: \code{"starting.values"}.}
 }
 
@@ -70,8 +70,9 @@ Information about the data (including missing patterns):
         the data.frame (if any).}
     \item{\code{"ngroups"}:}{Integer. The number of groups.}
     \item{\code{"group.label"}:}{A character vector. The group labels.}
-    \item{\code{"cluster"}:}{A character vector. The cluster variable(s) 
+    \item{\code{"cluster"}:}{A character vector. The cluster variable(s)
        in the data.frame (if any).}
+    \item{\code{"nlevels"}:}{Integer. The number of levels.}
     \item{\code{"ordered"}:}{A character vector. The ordered variables.}
     \item{\code{"nobs"}:}{Integer vector. The number of observations
         in each group that were used in the analysis (in each dataset).}
@@ -101,7 +102,7 @@ Model features:
     \item{\code{"list"}:}{The parameter table. The same output as given
         by \code{parTable()}.}
     \item{\code{"options"}:}{List. The option list.}
-    \item{\code{"call"}:}{List. The call as returned by match.call, coerced to 
+    \item{\code{"call"}:}{List. The call as returned by match.call, coerced to
         a list.}
 }
 
@@ -114,10 +115,10 @@ Model features:
 HS.model <- ' visual  =~ x1 + x2 + x3
               textual =~ x4 + x5 + x6
               speed   =~ x7 + x8 + x9 '
-     
+
 # a data generating function
 generateData <- function() simulateData(HS.model, sample.nobs = 100)
-     
+
 set.seed(1234)
 fit <- semList(HS.model, dataFunction = generateData, ndat = 5,
                store.slots = "partable")


### PR DESCRIPTION
These will be useful in general, but I will need these options as I update `semTools` to work with MSEMs if I want to avoid referencing the `@Data` slot.