### PR TITLE
extend lavTestLRT message about scaled diff test

### DIFF
--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -125,6 +125,7 @@ lavPredict <- function(object, type = "lv", newdata = NULL, method = "EBM",
                })
 
         # append original/new data? (also remove attr)
+        #FIXME: add condition level=1L (or add cluster.label to assist merging)
         if(append.data) {
             out <- lapply(seq_len(lavdata@ngroups), function(g) {
                        ret <- cbind(out[[g]], data.obs[[g]])
@@ -200,6 +201,8 @@ lavPredict <- function(object, type = "lv", newdata = NULL, method = "EBM",
                     gg <- g
                 }
                 if(append.data) {
+                    #FIXME: add condition level=1L (or name the cluster.label
+                    #       column after the cluster variable)
                     colnames(out[[g]]) <- c(lavpta$vnames$lv[[gg]],
                                             ov.names[[gg]])
                 } else {

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -55,7 +55,7 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
                           "Pr(>Chisq)" = c(NA, object@test[[1L]]$pvalue),
                           row.names = c("Saturated", "Model"),
                           check.names = FALSE)
-        attr(val, "heading") <- "Chi Square Test Statistic (unscaled)\n"
+        attr(val, "heading") <- "Chi-Squared Test Statistic (unscaled)\n"
         class(val) <- c("anova", class(val))
         return(val)
     }
@@ -274,10 +274,14 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
 
         if(scaled) {
             attr(val, "heading") <-
-                paste("Scaled Chi Square Difference Test (method = \"",
-                      method, "\")\n", sep="")
+                paste("Scaled Chi-Squared Difference Test (method = \"",
+                      method, "\")\n\nThe \"Chisq\" column contains standard ",
+                      "test statistics, not the robust test that should be ",
+                      "reported per model. A robust difference test is a ",
+                      "function of two standard (not robust) statistics.\n",
+                      sep="")
         } else {
-            attr(val, "heading") <- "Chi Square Difference Test\n"
+            attr(val, "heading") <- "Chi-Squared Difference Test\n"
         }
     } else if(type == "cf") {
         colnames(val)[c(3,4)] <- c("Cf", "Cf diff")


### PR DESCRIPTION
I forget when you would be on vacation, but this is the little change I remember we discussed at IMPS, in addition to anything else you would like to update before sending to CRAN so I can send semTools to CRAN (it relies on the new `@baseline` and `@baselineList` slots).

Additional change is just 2 FIXME comments in `lavPredict()`, about appending data to level-2 factor scores.  `semTools::plausibleValues()` currently returns level-2 factor scores with the `cluster.label` as an additional column, to facilitate a possible `merge()` with their original data. Perhaps you would want to do the same in `lavPredict()`, or perhaps you would want to already `merge()` into the full level-1 `@Data` (so the number or rows returned would differ if `append.data=TRUE` or `FALSE`) or `newdata`.  I'm happy to work on either approach and send another pull request.