### PR TITLE
missing_h1 EM, avoid overwriting tol

### DIFF
--- a/R/lav_mvnorm_missing_h1.R
+++ b/R/lav_mvnorm_missing_h1.R
@@ -103,8 +103,8 @@ lav_mvnorm_missing_h1_estimate_moments <- function(Y           = NULL,
 
         # check if Sigma is near-pd (+ poor fix)
         ev <- eigen(Sigma, symmetric = TRUE, only.values = TRUE)
-        tol <- 1e-6 # FIXME!
-        if(any(ev$values < tol)) {
+        evtol <- 1e-6 # FIXME!
+        if(any(ev$values < evtol)) {
             #too.small <- which( ev$values < tol )
             #ev$values[too.small] <- tol
             #ev$values <- ev$values + tol


### PR DESCRIPTION
This is for the EM algorithm that finds the "H1" implied Mu and Sigma. In that code, there is a double use of the "tol" variable so that the tol argument supplied to the function gets overwritten later on.

I think this means that, if we are happy with tol=1e-05 as default, this bit of code will speed up after the fix. (and I might be sending more requests related to this code, because I have to run this repeatedly in blavaan when there is missing data.)