### PR TITLE
bug fix for the polyserial correlation code, which causes errors

### DIFF
--- a/R/lav_bvmix.R
+++ b/R/lav_bvmix.R
@@ -78,15 +78,6 @@ lav_bvmix_cor_twostep_fit <- function(Y1, Y2, eXo = NULL, wt = NULL,
                     cache = cache)
     }
 
-    # try 4 -- new in 0.6-8
-    if(optim$convergence != 0L) {
-        optim <- optimize(f = minObjective, interval = c(-0.995, +0.995),
-                     cache = cache, tol = .Machine$double.eps)
-        if(is.finite(optim$minimum)) {
-            optim$convergence <- 0L
-        }
-    }
-
     # check convergence
     if(optim$convergence != 0L) {
         if(!is.null(Y1.name) && !is.null(Y2.name)) {


### PR DESCRIPTION
Hi,

I have a weird error when fitting a lavaan CFA model when I include an "ordered" variable. The error only happens with a specific dataset I have, but I was able to track down the exact bug.

The error happens at https://github.com/yrosseel/lavaan/blob/6e3e89f63a12ea2b6bdb9d5572b69ceb5c82226a/R/lav_samplestats_step2.R#L49 due to "rho" being NULL, which means that it cannot be assigned to COR[i,j]. 

The reason why "rho" is null is because inlav_bvmix_cor_twostep_fit is unable to converge in the four optimization tries and reach "try 4" in https://github.com/yrosseel/lavaan/blob/6e3e89f63a12ea2b6bdb9d5572b69ceb5c82226a/R/lav_bvmix.R#L81. But try 4 is bugged and doesn't work properly. 

try 4 use the "optimize" function which returns  a list containing
$minimum
[1] -0.3043362
$objective
[1] 1.48367

As you can see, it does not return a "$par" value! This means that rho is assigned to a NULL at https://github.com/yrosseel/lavaan/blob/6e3e89f63a12ea2b6bdb9d5572b69ceb5c82226a/R/lav_bvmix.R#L103. And then the NULL is returned.

So the error is because try 4 at https://github.com/yrosseel/lavaan/blob/6e3e89f63a12ea2b6bdb9d5572b69ceb5c82226a/R/lav_bvmix.R#L81 does not return a "par" value and thus doesn't work. It also pretends that it converges when it doesn't, which means that the warnings are never shown. A simple solution is to just remove "try 4" and stop at "try 3". I have done just that.
