### PR TITLE
deal with delta/theta parameterization in lav_model_implied

### DIFF
--- a/R/lav_model_implied.R
+++ b/R/lav_model_implied.R
@@ -8,7 +8,7 @@ lav_model_implied <- function(lavmodel = NULL, GLIST = NULL) {
     if(is.null(GLIST)) GLIST <- lavmodel@GLIST
 
     # model-implied variance/covariance matrix ('sigma hat')
-    Sigma.hat <- computeSigmaHat(lavmodel = lavmodel, GLIST = GLIST)
+    Sigma.hat <- computeSigmaHat(lavmodel = lavmodel, GLIST = GLIST, delta = (lavmodel@parameterization == "delta"))
 
     # model-implied mean structure ('mu hat')
     if(lavmodel@meanstructure) {


### PR DESCRIPTION
lav_model_implied() currently only works with the delta parameterization, but blavaan will use theta parameterization for ordinal data. This change allows for theta parameterization.