### PR TITLE
handle NaN values in missing ordinal data

### DIFF
--- a/R/lav_data.R
+++ b/R/lav_data.R
@@ -833,9 +833,12 @@ lav_data_full <- function(data          = NULL,          # data.frame
         user.ordered.names <- ov$name[ov$type == "ordered" & ov$user == 1L]
         user.ordered.idx <- which(ov.names[[g]] %in% user.ordered.names)
         if(length(user.ordered.idx) > 0L) {
-            for(i in user.ordered.idx) {
+          for(i in user.ordered.idx) {
+                X[[g]][,i][is.na(X[[g]][,i])] <- NA # change NaN to NA
                 X[[g]][,i] <- as.numeric(as.factor(X[[g]][,i]))
-            }
+                # possible alternative to the previous two lines:
+                # X[[g]][,i] <- as.numeric(factor(X[[g]][,i], exclude = c(NA, NaN)))
+          }
         }
 
         ## FIXME:


### PR DESCRIPTION
Somebody sent me a data file with missing data coded as `NaN` instead of `NA`. I found that `NaN` causes ordinal models to fail if you are not using listwise deletion. This is because `as.factor()` treats `NaN` as an extra level, which is different from `NA` entries. This pull request fixes the issue. An example of the problem appears below.

```r
library(lavaan)

orddat <- sample(1:5, 300, replace = TRUE)
orddat <- orddat * rbinom(300, 1, prob = .8)
orddat[orddat == 0L] <- NaN

orddat <- matrix(orddat, 100, 3)
colnames(orddat) <- paste0("x", 1:3)

m1 <- 'f1 =~ x1 + x2 + x3 '

## fails:
m1fit <- cfa(m1, data = orddat, ordered = TRUE, missing = "pairwise", do.fit = FALSE)

## works:
orddat[is.na(orddat)] <- NA
m1fit <- cfa(m1, data = orddat, ordered = TRUE, missing = "pairwise", do.fit = FALSE)
```