### PR TITLE
try(solve(Gamma[[g]])) for Browne's test with constraints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lavaan
 Title: Latent Variable Analysis
-Version: 0.6-13.1775
+Version: 0.6-13.1776
 Authors@R: c(person(given   = "Yves", family = "Rosseel",
                     role    = c("aut", "cre"),
                     email   = "Yves.Rosseel@UGent.be",

--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -275,6 +275,7 @@ lav_fit_measures <- function(object, fit.measures = "all",
         indices <- c(indices,
                      lav_fit_cfi_lavobject(lavobject    = object,
                                            fit.measures = fit.measures,
+                                           baseline.model = baseline.model,
                                            scaled       = scaled,
                                            test         = test))
     }

--- a/R/lav_test_browne.R
+++ b/R/lav_test_browne.R
@@ -153,7 +153,16 @@ lav_test_browne <- function(lavobject      = NULL,
             } else {
                 Ng <- nobs[[g]]
             }
-            Gamma.inv.weighted[[g]] <- solve(Gamma[[g]]) * Ng/ntotal
+            Gamma.inv.temp <- try(solve(Gamma[[g]]), silent = TRUE)
+            if (inherits(Gamma.inv.temp, "try-error")) {
+                # TDJ: This will happen whenever an (otherwise) unrestricted
+                #      covariance matrix has a structure to it, such as equal
+                #      variances (and certain covariances) for 2 members of an
+                #      indistinguishable dyad (represented as 2 columns).  In
+                #      such cases, their (N)ACOV elements are also identical.
+                Gamma.inv.temp <- MASS::ginv(Gamma[[g]])
+            }
+            Gamma.inv.weighted[[g]] <- Gamma.inv.temp * Ng/ntotal
         }
         GI <- lav_matrix_bdiag(Gamma.inv.weighted)
         q1 <- drop( t(RES.all) %*% GI %*% RES.all)


### PR DESCRIPTION
I left comments in the syntax I changed.  Essentially, sometimes the "unrestricted" (N)ACOV will have structure.  Not just in the dyad-level SRM matrix I am working on, but even in models for independent dyads (e.g., APIM), there will be certain (co)variances that are equal.  Thus, their (N)ACOV elements will be identical, making it NPD.  I hope you agree that using `MASS::ginv()` in this case is acceptable.  I can't think of a reason to add a general warning about doing so, since this would probably never happen in a context where we weren't aware of the structure in the h1 model.

I also noticed `baseline.model=` wasn't getting passed to the new CFI function.
