### PR TITLE
Corrects 2 typos

### DIFF
--- a/R/ctr_estfun.R
+++ b/R/ctr_estfun.R
@@ -24,7 +24,7 @@ estfun.lavaan <- lavScores <- function(object, scaling = FALSE,
   # what if estimator != ML?
   # avoid hard error (using stop); throw a warning, and return an empty matrix
   if(object@Options$estimator != "ML") {
-      warning("lavaan WARNING: scores only availalbe if estimator is ML")
+      warning("lavaan WARNING: scores only available if estimator is ML")
       return(matrix(0,0,0))
   }
 

--- a/man/model.syntax.Rd
+++ b/man/model.syntax.Rd
@@ -258,7 +258,7 @@ There can be seven types of formula-like expressions in the model syntax:
 
     \item Formative factors: The \code{"<~"} operator can be used to define
       a formative factor (on the right hand side of the operator), in a
-      similar why as a reflexive factor is defined (using the \code{"=~"}
+      similar way to how a reflexive factor is defined (using the \code{"=~"}
       operator). This is just syntax sugar to define a phantom latent
       variable (equivalent to using \code{"f =~ 0"}). And in addition, the
       (residual) variance of the formative factor is fixed to zero.


### PR DESCRIPTION
Corrected "availalbe" to "available" in R/ctr_estfun.R.

Corrected "in a similar why" to "in a similar way" in man/model.syntax.Rd at line 261.