### PR TITLE
allow header/footer printing for vector/matrix

### DIFF
--- a/R/lav_cor.R
+++ b/R/lav_cor.R
@@ -12,6 +12,7 @@ lavCor <- function(object,
                    group      = NULL,
                    missing    = "listwise",
                    ov.names.x = NULL,
+                   sampling.weights = NULL,
                    # lavaan options
                    se         = "none",
                    test       = "none",
@@ -43,6 +44,14 @@ lavCor <- function(object,
             se <- "none"
         }
     }
+    
+    # extract sampling.weights.normalization from dots (for lavData() call)
+    dots <- list(...)
+    sampling.weights.normalization <- "total"
+    if (!is.null(dots$sampling.weights.normalization)) {
+        sampling.weights.normalization <- dots$sampling.weights.normalization
+    }
+    
 
     # check object class
     if(inherits(object, "lavData")) {
@@ -53,6 +62,9 @@ lavCor <- function(object,
         NAMES <- names(object)
         if(!is.null(group)) {
             NAMES <- NAMES[- match(group, NAMES)]
+        }
+        if(!is.null(sampling.weights)) {
+            NAMES <- NAMES[- match(sampling.weights, NAMES)]
         }
         if(is.logical(ordered)) {
             ordered.flag <- ordered
@@ -81,8 +93,10 @@ lavCor <- function(object,
         }
         lav.data <- lavData(data = object, group = group,
                             ov.names = NAMES, ordered = ordered,
+                            sampling.weights = sampling.weights,
                             ov.names.x = ov.names.x,
-                            lavoptions = list(missing = missing))
+                            lavoptions = list(missing = missing,
+                                              sampling.weights.normalization = sampling.weights.normalization))
     } else {
         stop("lavaan ERROR: lavCor can not handle objects of class ",
              paste(class(object), collapse= " "))
@@ -98,8 +112,7 @@ lavCor <- function(object,
         }
     }
 
-    # extract partable options from dots
-    dots <- list(...)
+    # extract more partable options from dots
     meanstructure <- FALSE
     fixed.x       <- FALSE
     mimic         <- "lavaan"
@@ -120,7 +133,6 @@ lavCor <- function(object,
         conditional.x <- dots$conditional.x
     }
 
-
     # override, only for backwards compatibility (eg moments() in JWileymisc)
     #if(missing %in% c("ml", "fiml")) {
     #    meanstructure = TRUE
@@ -133,6 +145,7 @@ lavCor <- function(object,
                                   lavoptions    = list(meanstructure = meanstructure,
                                                        fixed.x = fixed.x,
                                                        conditional.x = conditional.x,
+                                                       # sampling.weights.normalization = sampling.weights.normalization,
                                                        group.w.free = FALSE,
                                                        missing = missing,
                                                        correlation = categorical,

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -52,6 +52,7 @@ print.lavaan.matrix.symmetric <- function(x, ..., nd = 3L, shift = 0L,
     # in package nlme
     x <- as.matrix(x) # just in case
     y <- x; y <- unclass(y)
+    attributes(y)[c("header","footer")] <- NULL
     ll <- lower.tri(x, diag = TRUE)
     y[ ll] <- format(round(x[ll], digits = nd))
     y[!ll] <- ""
@@ -74,7 +75,17 @@ print.lavaan.matrix.symmetric <- function(x, ..., nd = 3L, shift = 0L,
             rownames(y) <- empty.string
         }
     }
+    
+    if(!is.null(attr(x, "header"))) {
+      cat("\n", attr(x, "header"), "\n\n", sep = "")
+    }
+    
     print(y, ..., quote = FALSE, right = TRUE)
+    
+    if(!is.null(attr(x, "footer"))) {
+      cat("\n", attr(x, "footer"), "\n\n", sep = "")
+    }
+    
     invisible(x)
 }
 
@@ -82,6 +93,7 @@ print.lavaan.matrix.symmetric <- function(x, ..., nd = 3L, shift = 0L,
 print.lavaan.matrix <- function(x, ..., nd = 3L, shift = 0L) {
     x <- as.matrix(x) # just in case
     y <- unclass(x)
+    attributes(y)[c("header","footer")] <- NULL
     if(!is.null(colnames(x))) {
       colnames(y) <- abbreviate(colnames(x), minlength = nd + 3L)
     }
@@ -93,15 +105,29 @@ print.lavaan.matrix <- function(x, ..., nd = 3L, shift = 0L) {
             rownames(y) <- empty.string
         }
     }
+    if(!is.null(attr(x, "header"))) {
+      cat("\n", attr(x, "header"), "\n\n", sep = "")
+    }
+    
     print( round(y, nd), right = TRUE, ... )
+    
+    if(!is.null(attr(x, "footer"))) {
+      cat("\n", attr(x, "footer"), "\n\n", sep = "")
+    }
+    
     invisible(x)
 }
 
 print.lavaan.vector <- function(x, ..., nd = 3L, shift = 0L) {
     y <- unclass(x)
+    attributes(y)[c("header","footer")] <- NULL
     #if(!is.null(names(x))) {
     #    names(y) <- abbreviate(names(x), minlength = nd + 3)
     #}
+    if(!is.null(attr(x, "header"))) {
+      cat("\n", attr(x, "header"), "\n\n", sep = "")
+    }
+    
     if(shift > 0L) {
         empty.string <- strrep(x = " ", times = shift)
         tmp <- format(y, digits = nd, width = 2L + nd)
@@ -110,6 +136,11 @@ print.lavaan.vector <- function(x, ..., nd = 3L, shift = 0L) {
     } else {
         print( round(y, nd), right = TRUE, ... )
     }
+    
+    if(!is.null(attr(x, "footer"))) {
+      cat("\n", attr(x, "footer"), "\n\n", sep = "")
+    }
+    
     invisible(x)
 }
 

--- a/man/lavCor.Rd
+++ b/man/lavCor.Rd
@@ -6,8 +6,8 @@ Fit an unrestricted model to compute polychoric, polyserial and/or Pearson
 correlations.}
 \usage{
 lavCor(object, ordered = NULL, group = NULL, missing = "listwise", 
-       sampling.weights = NULL,
-       ov.names.x = NULL, se = "none", test = "none", 
+       ov.names.x = NULL, sampling.weights = NULL,
+       se = "none", test = "none", 
        estimator = "two.step", baseline = FALSE, ..., 
        cor.smooth = FALSE, cor.smooth.tol = 1e-04, output = "cor")
 }

--- a/man/lavCor.Rd
+++ b/man/lavCor.Rd
@@ -6,6 +6,7 @@ Fit an unrestricted model to compute polychoric, polyserial and/or Pearson
 correlations.}
 \usage{
 lavCor(object, ordered = NULL, group = NULL, missing = "listwise", 
+       sampling.weights = NULL,
        ov.names.x = NULL, se = "none", test = "none", 
        estimator = "two.step", baseline = FALSE, ..., 
        cor.smooth = FALSE, cor.smooth.tol = 1e-04, output = "cor")
@@ -28,6 +29,8 @@ lavCor(object, ordered = NULL, group = NULL, missing = "listwise",
     (and mean vector). If \code{"pairwise"}, pairwise deletion is used. If
     \code{"default"}, the value is set depending on the estimator and the
     mimic option.}
+\item{sampling.weights}{Only used if \code{object} is a \code{data.frame}. 
+    Specify a variable containing sampling weights.}
 \item{ov.names.x}{Only used if \code{object} is a \code{data.frame}. Specify
     variables that need to be treated as exogenous. Only used if at least
     one variable is declared as ordered.}


### PR DESCRIPTION
Would you be opposed to this feature?  I would find it useful for both `lavaan.mi` and `lavaan.srm`, so adding it here would save me the trouble of writing separate `print()` methods for each.  I basically just copied your code in `print.lavaan.list()`, but use `attributes()` rather than `attr()` to simultaneous delete both header and footer from the copy `y <- x`.
