### PR TITLE
Keep the names, if any, in the output of bootstrapLavaan()

### DIFF
--- a/R/lav_bootstrap.R
+++ b/R/lav_bootstrap.R
@@ -496,7 +496,7 @@ lav_bootstrap_internal <- function(object          = NULL,
     }
 
     # fill in container
-    t.star <- do.call("rbind", res)
+    t.star[] <- do.call("rbind", res)
 
     # handle errors
     error.idx <- which(sapply(res, function(x) is.na(x[1L])))


### PR DESCRIPTION
I would like to propose this minor change to `lav_bootstrap_internal()`.

When users call `bootstrapLavaan()` using a function that returns named vectors, the names will not be kept in the output, as shown in the following example:

``` r
# Adapted from https://lavaan.ugent.be/tutorial/mediation.html

# Set the width
opt_old <- options(width = 100)

library(lavaan)
#> This is lavaan 0.6-14
#> lavaan is FREE software! Please report any bugs.
set.seed(1234)
X <- rnorm(100)
M <- 0.5*X + rnorm(100)
Y <- 0.7*M + rnorm(100)
Data <- data.frame(X = X, Y = Y, M = M)
model <- ' # direct effect
             Y ~ c*X
           # mediator
             M ~ a*X
             Y ~ b*M
           # indirect effect (a*b)
             ab := a*b
           # total effect
             total := c + (a*b)
         '
fit <- sem(model, data = Data)

get_std <- function(x, ...) {
    std <- lavaan::standardizedSolution(x, ...)
    out <- std$est.std
    names(out) <- lavaan::lav_partable_labels(std)
    out
  }

# Check the function
# Should equal to the column `est.std`
standardizedSolution(fit)
#>     lhs op     rhs label est.std    se      z pvalue ci.lower ci.upper
#> 1     Y  ~       X     c   0.028 0.080  0.348  0.728   -0.128    0.184
#> 2     M  ~       X     a   0.419 0.079  5.319  0.000    0.265    0.573
#> 3     Y  ~       M     b   0.679 0.063 10.865  0.000    0.557    0.802
#> 4     Y ~~       Y         0.522 0.072  7.268  0.000    0.381    0.663
#> 5     M ~~       M         0.825 0.066 12.497  0.000    0.695    0.954
#> 6     X ~~       X         1.000 0.000     NA     NA    1.000    1.000
#> 7    ab :=     a*b    ab   0.285 0.062  4.619  0.000    0.164    0.405
#> 8 total := c+(a*b) total   0.312 0.088  3.548  0.000    0.140    0.485
get_std(fit)
#>          c          a          b       Y~~Y       M~~M       X~~X         ab      total 
#> 0.02769268 0.41888560 0.67937899 0.52191562 0.82453486 1.00000000 0.28458207 0.31227475

# Do bootstrapping
# Set other arguments (e.g., ncpus, parallel, etc.) if necessary
# Increase R for the final results.
std_boot <- bootstrapLavaan(fit,
                            R = 50L,
                            FUN = get_std,
                            iseed = 1234)
# Inspect the estimates
head(std_boot)
#>             [,1]      [,2]      [,3]      [,4]      [,5] [,6]      [,7]      [,8]
#> [1,] -0.05174324 0.4539046 0.7189981 0.5141378 0.7939706    1 0.3263566 0.2746133
#> [2,]  0.02535236 0.4545628 0.7058346 0.4848863 0.7933727    1 0.3208462 0.3461985
#> [3,]  0.23895775 0.5102153 0.6013216 0.4346853 0.7396804    1 0.3068035 0.5457612
#> [4,]  0.03827328 0.4888300 0.6421786 0.5621126 0.7610452    1 0.3139162 0.3521895
#> [5,] -0.01751884 0.4111792 0.7357095 0.4690238 0.8309316    1 0.3025085 0.2849896
#> [6,] -0.02185791 0.6188300 0.7275512 0.4898736 0.6170494    1 0.4502305 0.4283726
get_std(fit)
#>          c          a          b       Y~~Y       M~~M       X~~X         ab      total 
#> 0.02769268 0.41888560 0.67937899 0.52191562 0.82453486 1.00000000 0.28458207 0.31227475
```

This is nconvenient because users need to add the names back to the output of `bootstrapLavaan()`.

When `t.star` is initialized, names are indeed added, if available:

https://github.com/yrosseel/lavaan/blob/17b67023c8816e041012da63ad57240f99c71ef3/R/lav_bootstrap.R#L156-L157

However, when storing the bootstrap results, instead of updating the content by the results, `t.star` is completely replaced by the results (`res`).

https://github.com/yrosseel/lavaan/blob/17b67023c8816e041012da63ad57240f99c71ef3/R/lav_bootstrap.R#L498-L499

It seems that this is an issue only when `lav_bootstrap_internal()` is not used by internal functions. A simple fix is to use `t.star[]` instead of `t.star`:

https://github.com/sfcheung/lavaan/blob/7ed3881b352def7885f2e6fcf7dfffe0311e8576/R/lav_bootstrap.R#L498-L499

With this change, the names will be kept in the output (actually, the names will not be unintentionally removed in the output):

```r
std_boot <- bootstrapLavaan(fit,
                            R = 50L,
                            FUN = get_std,
                            iseed = 1234)
# Inspect the estimates
head(std_boot)
#>                c         a         b      Y~~Y      M~~M X~~X        ab     total
#> [1,] -0.05174324 0.4539046 0.7189981 0.5141378 0.7939706    1 0.3263566 0.2746133
#> [2,]  0.02535236 0.4545628 0.7058346 0.4848863 0.7933727    1 0.3208462 0.3461985
#> [3,]  0.23895775 0.5102153 0.6013216 0.4346853 0.7396804    1 0.3068035 0.5457612
#> [4,]  0.03827328 0.4888300 0.6421786 0.5621126 0.7610452    1 0.3139162 0.3521895
#> [5,] -0.01751884 0.4111792 0.7357095 0.4690238 0.8309316    1 0.3025085 0.2849896
#> [6,] -0.02185791 0.6188300 0.7275512 0.4898736 0.6170494    1 0.4502305 0.4283726
```

I hope this improvement will be useful to the users of `bootstrapLavaan()`.

I am not sure whether it will break other things. If it will, feel free to reject this pull request. I will see if there are other solutions.