### PR TITLE
2-level model, centering within-only variables in Sigma.W

### DIFF
--- a/R/lav_samplestats.R
+++ b/R/lav_samplestats.R
@@ -1675,6 +1675,13 @@ lav_samplestats_cluster_patterns <- function(Y = NULL, Lp = NULL,
         # cluster-means
         Y2 <- rowsum.default(Y1, group = cluster.idx, reorder = FALSE,
                      na.rm = FALSE) / cluster.size
+
+        if(length(within.idx) > 0L) {
+            for(i in 1:length(within.idx)) {
+                Y2[, within.idx[i]] <- Y1.means[within.idx[i]]
+            }
+        }
+        
         Y2c <- t( t(Y2) - Y1.means )
 
         # compute S.w


### PR DESCRIPTION
I believe this fixes a bug that was a tricky one to find, related to observed variables that appear at the within level but not at the between level.

In computing Sigma.W, the within-only variables were being centered by group means. But I believe that all the variance of within-only variables should be attributed to the within level, so we should center by grand mean instead of group mean. The blavaan models under development also work better (better sampling and agreement with lavaan) with this change.

There might be some matrix trick to replace the loop that I added, but I couldn't immediately think of a good way to do it.