### PR TITLE
lav_mvnorm_missing_h1, ensure non-NaN starting values for Mu

### DIFF
--- a/R/lav_mvnorm_missing_h1.R
+++ b/R/lav_mvnorm_missing_h1.R
@@ -86,6 +86,7 @@ lav_mvnorm_missing_h1_estimate_moments <- function(Y           = NULL,
     }
     bad.idx <- which(!is.finite(Mu0))
     if(length(bad.idx) > 0L) {
+        Mu0[bad.idx] <- 0  
     }
     Sigma0 <- diag(x = var0, nrow = P)
     Mu <- Mu0; Sigma <- Sigma0


### PR DESCRIPTION
I imagine you are busy this week, but whenever you get to it:

I recently saw a multiple-group model from @albertostefanelli where one group is only observed on a single variable, which led to an error. The example below reproduces the error, and the pull request fixes it. (There was already an empty if() statement in the code that made me think it was forgotten.)

```r
hs39 <- HolzingerSwineford1939
hs39[hs39$school == 'Pasteur', c('x2', 'x3')] <- NA

msyn <- 'lv =~ x1 + x2 + x3'
m1 <- cfa(msyn, data = hs39, group = "school", missing = "ml", 
          group.equal = c("intercepts", "loadings", "residuals"), start = "simple")
```

Actually, I am not sure that you would often be able to fit a meaningful model in this situation. But the current error makes the problem tough to diagnose.