### PR TITLE
handle between-only ovs when predicting level 2 lvs

### DIFF
--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -607,6 +607,11 @@ lav_predict_eta_normal <- function(lavobject = NULL,  # for convenience
                 Data.B <- matrix(0, nrow = nrow(MB.j),
                                     ncol = ncol(data.obs[[g]]))
                 Data.B[, ov.idx[[1]] ] <- MB.j
+                between.idx <- Lp$between.idx[[2*g]]
+                if(length(between.idx) > 0L) {
+                  Data.B[, between.idx] <- data.obs[[g]][!duplicated(Lp$cluster.idx[[2]]),
+                                                         between.idx]
+                }
                 data.obs.g <- Data.B[, ov.idx[[2]] ]
             } else {
                 stop("lavaan ERROR: only 2 levels are supported")
@@ -885,6 +890,11 @@ lav_predict_eta_bartlett <- function(lavobject = NULL, # for convenience
                 Data.B <- matrix(0, nrow = nrow(MB.j),
                                     ncol = ncol(data.obs[[g]]))
                 Data.B[, ov.idx[[1]] ] <- MB.j
+                between.idx <- Lp$between.idx[[2*g]]
+                if(length(between.idx) > 0L) {
+                  Data.B[, between.idx] <- data.obs[[g]][!duplicated(Lp$cluster.idx[[2]]),
+                                                         between.idx]
+                }
                 data.obs.g <- Data.B[, ov.idx[[2]] ]
             } else {
                 stop("lavaan ERROR: only 2 levels are supported")


### PR DESCRIPTION
The blavaan multilevel testing continues! This pr addresses a lavPredict() bug when there are between-only variables. The data from those variables were not being included in the level 2 lv predictions.

The example below uses the data from "school.dat". It has a negative variance estimate, and I should probably add a third between-only variable. But it should be enough to demonstrate the problem.

```r
model <- '
    level: within
        fw =~ y6 + y7 + y8 + y9

    level: between
        fb =~ y6 + y7 + y8 + y9
        fb2 =~ x3 + x4 '

fit <- sem(model, data = Data, cluster = "school")

out <- lavPredict(fit, level = 2)
cor(out) # lv correlation is 1
```