### PR TITLE
fix group.equal for multigroup, multilevel models

### DIFF
--- a/R/lav_partable_labels.R
+++ b/R/lav_partable_labels.R
@@ -43,19 +43,19 @@ lav_partable_labels <- function(partable,
            "residual.covariances" %in%  group.equal) {
             ov.names.nox <- vector("list", length=ngroups)
             for(g in 1:ngroups)
-                ov.names.nox[[g]] <- lav_partable_vnames(partable, "ov.nox", group=g)
+                ov.names.nox[[g]] <- unique( unlist(lav_partable_vnames(partable, "ov.nox", group=g)) )
         }
         if("thresholds" %in% group.equal) {
             ov.names.ord <- vector("list", length=ngroups)
             for(g in 1:ngroups)
-                ov.names.ord[[g]] <- lav_partable_vnames(partable, "ov.ord", group=g)
+                ov.names.ord[[g]] <- unique( unlist(lav_partable_vnames(partable, "ov.ord", group=g)) )
         }
         if("means" %in% group.equal ||
            "lv.variances" %in% group.equal ||
            "lv.covariances" %in% group.equal) {
             lv.names <- vector("list", length=ngroups)
             for(g in 1:ngroups)
-                lv.names[[g]] <- lav_partable_vnames(partable, "lv", group=g)
+                lv.names[[g]] <- unique( unlist(lav_partable_vnames(partable, "lv", group=g)) )
         }
 
         # g1.flag: TRUE if included, FALSE if not


### PR DESCRIPTION
For multigroup, multilevel models, the `group.equal` argument was being ignored due to some nested lists (for example, instead of a vector of ov.names for group 1, there was a list of length 2, containing within and between ov.names for group 1). This pull request fixes it so that something like `group.equal = "loadings"` constrains all loadings (within and between) to be equal across groups.

Here is an example of `group.equal` being ignored:

```r
model <- '
    group: 1
    level: within
        fw =~ y1 + y2 + y3
    level: between
        fb =~ y1 + y2 + y3

    group: 2
    level: within
        fw =~ y1 + y2 + y3
    level: between
        fb =~ y1 + y2 + y3
'

dtl <- Demo.twolevel
dtl$grp <- rep(c("a", "b"), each = nrow(dtl)/2)

fit <- cfa(model, data = dtl, cluster = "cluster", group = "grp", 
            group.equal=c('intercepts', 'residuals'), std.lv = TRUE)

cbind(coef(fit)[1:15], coef(fit)[16:30])
```