### PR TITLE
don't name 1-block list in lavTech("rsquare"), fixes #290

### DIFF
--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -1391,8 +1391,15 @@ lav_object_inspect_rsquare <- function(object, est.std.all=NULL,
         OUT[[b]] <- tmp
     }
 
-    if(nblocks == 1L && drop.list.single.group) {
-        OUT <- OUT[[1]]
+    if(nblocks == 1L) {
+        if(drop.list.single.group) {
+          OUT <- OUT[[1]]
+        } 
+          #TDJ: Would it make sense to provide a label for 1 block?
+          # else if(length(object@Data@block.label)) {
+          #   names(OUT) <- object@Data@block.label
+          # }
+
     } else {
         names(OUT) <- object@Data@block.label
     }


### PR DESCRIPTION
I left a comment on Lines 1399-1401 with some additional code to add a `block.label` even for single-block models, but I doubt that would ever be necessary.