### PR TITLE
Add header used in summary() by lavaan.mi

### DIFF
--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -547,6 +547,11 @@ print.lavaan.fitMeasures <- function(x, ..., nd = 3L, add.h0 = TRUE) {
 
         # container three columns
         c1 <- c2 <- c3 <- character(0L)
+        
+        #TDJ: Add header used in summary() by lavaan.mi
+        if (scaled.flag) {
+          c1 <- c("", c1); c2 <- c("Standard", c2); c3 <- c("Scaled", c3)
+        }
 
         c1 <- c(c1, "Test statistic")
         c2 <- c(c2, sprintf(num.format, x["chisq"]))


### PR DESCRIPTION
lavaan's print methods never set `add.h0=TRUE`, so this will not affect lavaan output.  This is only to make lavaan.mi output look consistent with lavaan output.