### PR TITLE
flagged source code lavaan.mi relies on

### DIFF
--- a/R/lav_fit_srmr.R
+++ b/R/lav_fit_srmr.R
@@ -232,8 +232,8 @@ lav_fit_srmr_lavobject <- function(lavobject = NULL, fit.measures = "rmsea") {
     attr(srmr_mplus.group, "nomean") <- NULL
 
     # adjust for group sizes
-    ng <- unlist(lavobject@SampleStats@nobs)
-    ntotal <- lavobject@SampleStats@ntotal
+    ng <- unlist(lavobject@SampleStats@nobs)  # if this changes, tag @TDJorgensen in commit message
+    ntotal <- lavobject@SampleStats@ntotal    # if this changes, tag @TDJorgensen in commit message
     RMR <- sum(ng / ntotal * rmr.group)
     RMR_NOMEAN <- sum(ng / ntotal * rmr_nomean.group)
     SRMR_BENTLER <- sum(ng / ntotal * srmr.group)

--- a/R/lav_fit_srmr.R
+++ b/R/lav_fit_srmr.R
@@ -94,13 +94,13 @@ lav_fit_srmr_twolevel <- function(lavobject = NULL) {
     b.within <- (g - 1L) * nlevels + 1L
     b.between <- (g - 1L) * nlevels + 2L
 
-    # observed
+    # OBSERVED        # if these change, tag @TDJorgensen in commit message
     S.within <- lavobject@h1$implied$cov[[b.within]]
     M.within <- lavobject@h1$implied$mean[[b.within]]
     S.between <- lavobject@h1$implied$cov[[b.between]]
     M.between <- lavobject@h1$implied$mean[[b.between]]
 
-    # estimated
+    # ESTIMATED       # if these change, tag @TDJorgensen in commit message
     implied <- lav_model_implied_cond2uncond(lavobject@implied)
     Sigma.within <- implied$cov[[b.within]]
     Mu.within <- implied$mean[[b.within]]
@@ -139,8 +139,8 @@ lav_fit_srmr_twolevel <- function(lavobject = NULL) {
   }
 
   # adjust for group sizes
-  ng <- unlist(lavobject@SampleStats@nobs)
-  ntotal <- lavobject@SampleStats@ntotal
+  ng <- unlist(lavobject@SampleStats@nobs)  # if this changes, tag @TDJorgensen in commit message
+  ntotal <- lavobject@SampleStats@ntotal    # if this changes, tag @TDJorgensen in commit message
   SRMR_WITHIN <- sum(ng / ntotal * SRMR.within)
   SRMR_BETWEEN <- sum(ng / ntotal * SRMR.between)
   SRMR_TOTAL <- SRMR_WITHIN + SRMR_BETWEEN

--- a/R/lav_fit_srmr.R
+++ b/R/lav_fit_srmr.R
@@ -21,6 +21,8 @@ lav_fit_srmr_mplus <- function(lavobject) {
   srmr_mplus.group <- numeric(G)
   srmr_mplus_nomean.group <- numeric(G)
 
+  # If you change how any of the observed/estimated moments below are retrieved,
+  # please tag @TDJorgensen at the end of the commit message.
   for (g in 1:G) {
     # observed
     if (!lavobject@SampleStats@missing.flag) {
@@ -52,7 +54,7 @@ lav_fit_srmr_mplus <- function(lavobject) {
       implied$mean[[g]]
     }
 
-    # Bollen approach: simply using cov2cor ('residual correlations')
+    # Bollen approach: simply using cov2cor ('correlation residuals')
     S.cor <- cov2cor(S)
     Sigma.cor <- cov2cor(Sigma.hat)
     R.cor <- (S.cor - Sigma.cor)

--- a/R/lav_model_h1_information.R
+++ b/R/lav_model_h1_information.R
@@ -14,6 +14,16 @@
 # - YR 03 Jan 2018: add support for clustered data: expected
 # - YR 23 Aug 2018: lav_model_h1_acov (0.6-3)
 
+
+## For the lavaan.mi package, TDJ provides pooled versions of all the
+## sample moments called in these functions.  If any updates to these functions
+## require NEW information (from @SampleStats or @implied or @h1), 
+## PLEASE ADD A TAG     @TDJorgensen
+## at the end of the commit message on GitHub, so TDJ can check whether 
+## lavaan.mi::lavResiduals.mi() needs to be updated accordingly.
+
+
+
 lav_model_h1_information <- function(lavobject = NULL,
                                      lavmodel = NULL,
                                      lavsamplestats = NULL,

--- a/R/lav_model_utils.R
+++ b/R/lav_model_utils.R
@@ -10,7 +10,7 @@ lav_model_get_parameters <- function(lavmodel = NULL, GLIST = NULL,
   # type == "user": all parameters listed in User model
 
   # state or final?
-  if (is.null(GLIST)) GLIST <- lavmodel@GLIST
+  if (is.null(GLIST)) GLIST <- lavmodel@GLIST # if this changes, tag @TDJorgensen in commit message
 
   if (type == "free") {
     N <- lavmodel@nx.free

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -639,7 +639,7 @@ lav_object_inspect_est <- function(object, unrotated = FALSE) {
       if (unrotated) {
         return.value <- object@ParTable$est.unrotated
       } else {
-        return.value <- object@ParTable$est
+        return.value <- object@ParTable$est # if this changes, tag @TDJorgensen in commit message
       }
     } else if (.hasSlot(object, "Fit")) {
       # in < 0.5-19, we should look in @Fit@est
@@ -2498,7 +2498,7 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
     # if( !inherits(tmp, "try-error") && !is.null(object@vcov$vcov)
     #   && !(rotation && standardized)) {
     if (.hasSlot(object, "vcov") && !is.null(object@vcov$vcov)) {
-      return.value <- object@vcov$vcov
+      return.value <- object@vcov$vcov # if this changes, tag @TDJorgensen in commit message
     } else {
       # compute it again
       # if(rotation && standardized) {

--- a/R/lav_residuals.R
+++ b/R/lav_residuals.R
@@ -446,7 +446,7 @@ lav_residuals_acov <- function(object, type = "raw", z.type = "standardized",
 
   # compute ACOV for observed h1 sample statistics (ACOV == Gamma/N)
   if (!is.null(lavsamplestats@NACOV[[1]])) {
-    NACOV.obs <- lavsamplestats@NACOV
+    NACOV.obs <- lavsamplestats@NACOV # if this changes, tag @TDJorgensen in commit message
     ACOV.obs <- lapply(NACOV.obs, function(x) x / lavsamplestats@ntotal)
   } else {
     ACOV.obs <- lav_model_h1_acov(
@@ -478,7 +478,7 @@ lav_residuals_acov <- function(object, type = "raw", z.type = "standardized",
   # for each group, compute ACOV
   for (g in seq_len(lavdata@ngroups)) {
     # group weight
-    gw <- object@SampleStats@nobs[[g]] / object@SampleStats@ntotal
+    gw <- object@SampleStats@nobs[[g]] / object@SampleStats@ntotal  # if this changes, tag @TDJorgensen in commit message
 
     if (z.type == "standardized.mplus") { # simplified formula
       # also used by LISREL?

--- a/R/lav_standardize.R
+++ b/R/lav_standardize.R
@@ -19,7 +19,7 @@ lav_standardize_lv_x <- function(x, lavobject, partable = NULL, cov.std = TRUE,
     attributes(est.rot) <- NULL
     est <- est.rot
   } else {
-    GLIST <- lavmodel@GLIST
+    GLIST <- lavmodel@GLIST # if this changes, tag @TDJorgensen in commit message
     est <- lav_model_get_parameters(lavmodel, type = "user")
   }
 
@@ -52,7 +52,7 @@ lav_standardize_all_x <- function(x, lavobject, partable = NULL, cov.std = TRUE,
     attributes(est.rot) <- NULL
     est <- est.rot
   } else {
-    GLIST <- lavmodel@GLIST
+    GLIST <- lavmodel@GLIST # if this changes, tag @TDJorgensen in commit message
     est <- lav_model_get_parameters(lavmodel, type = "user")
   }
 
@@ -84,7 +84,7 @@ lav_standardize_all_nox_x <- function(x, lavobject, partable = NULL,
     attributes(est.rot) <- NULL
     est <- est.rot
   } else {
-    GLIST <- lavmodel@GLIST
+    GLIST <- lavmodel@GLIST # if this changes, tag @TDJorgensen in commit message
     est <- lav_model_get_parameters(lavmodel, type = "user")
   }
 
@@ -117,7 +117,7 @@ lav_standardize_lv <- function(lavobject = NULL,
     stopifnot(!is.null(lavpartable))
     if (is.null(est)) {
       if (!is.null(lavpartable$est)) {
-        est <- lavpartable$est
+        est <- lavpartable$est # if this changes, tag @TDJorgensen in commit message
       } else {
         stop("lavaan ERROR: could not find `est' in lavpartable")
       }
@@ -310,7 +310,7 @@ lav_standardize_all <- function(lavobject = NULL,
     stopifnot(!is.null(lavpartable))
     if (is.null(est)) {
       if (!is.null(lavpartable$est)) {
-        est <- lavpartable$est
+        est <- lavpartable$est # if this changes, tag @TDJorgensen in commit message
       } else {
         stop("lavaan ERROR: could not find `est' in lavpartable")
       }
@@ -327,7 +327,7 @@ lav_standardize_all <- function(lavobject = NULL,
         # if("SampleStats" %in% slotNames(lavobject)) {
         #    cov.x <- lavobject@SampleStats@cov.x
         if (!is.null(lavobject@implied$cov.x[[1]])) {
-          cov.x <- lavobject@implied$cov.x
+          cov.x <- lavobject@implied$cov.x # if this changes, tag @TDJorgensen in commit message
         } else {
           # perhaps lavaanList object
           # extract it from GLIST per block
@@ -546,7 +546,7 @@ lav_standardize_all_nox <- function(lavobject = NULL,
     stopifnot(!is.null(lavpartable))
     if (is.null(est)) {
       if (!is.null(lavpartable$est)) {
-        est <- lavpartable$est
+        est <- lavpartable$est # if this changes, tag @TDJorgensen in commit message
       } else {
         stop("lavaan ERROR: could not find `est' in lavpartable")
       }
@@ -563,7 +563,7 @@ lav_standardize_all_nox <- function(lavobject = NULL,
         # if("SampleStats" %in% slotNames(lavobject)) {
         #    cov.x <- lavobject@SampleStats@cov.x
         if (!is.null(lavobject@implied$cov.x[[1]])) {
-          cov.x <- lavobject@implied$cov.x
+          cov.x <- lavobject@implied$cov.x # if this changes, tag @TDJorgensen in commit message
         } else {
           # perhaps lavaanList object
           # extract it from GLIST per block


### PR DESCRIPTION
These commits are only to add comments to source code that (if changed) could disrupt how lavaan.mi depends on lavaan to do the following:

- calculate `lavResiduals()`
- calculate `standardizedSolution()`
- calculate residual-based `fitMeasures()`

GitHub's diff-report makes it look like I changed the entire file, lav_object_inspect.R, when I only added 2 comments.  When I save a file in RStudio, my settings automatically remove trailing whitespace.  When I tell the diff report to ignore whitespace in RStudio, I verified that the only changes were the 2 added comments.
