### PR TITLE
Add h1.model= argument to fitMeasures()

### DIFF
--- a/R/00generic.R
+++ b/R/00generic.R
@@ -2,7 +2,8 @@
 # TDJ: add "..." to make the generic actually generic, for lavaan.mi objects
 
 # S3 generic for S3 dispatch
-fitMeasures <- function(object, fit.measures = "all", baseline.model = NULL,
+fitMeasures <- function(object, fit.measures = "all",
+                        baseline.model = NULL, h1.model = NULL,
                         fm.args = list(
                           standard.test = "default",
                           scaled.test = "default",
@@ -15,7 +16,8 @@ fitMeasures <- function(object, fit.measures = "all", baseline.model = NULL,
                         output = "vector", ...) {
   UseMethod("fitMeasures", object)
 }
-fitmeasures <- function(object, fit.measures = "all", baseline.model = NULL,
+fitmeasures <- function(object, fit.measures = "all",
+                        baseline.model = NULL, h1.model = NULL,
                         fm.args = list(
                           standard.test = "default",
                           scaled.test = "default",
@@ -33,7 +35,8 @@ fitmeasures <- function(object, fit.measures = "all", baseline.model = NULL,
 # S4 generic for S4 dispatch
 setGeneric(
   "fitMeasures",
-  function(object, fit.measures = "all", baseline.model = NULL,
+  function(object, fit.measures = "all",
+           baseline.model = NULL, h1.model = NULL,
            fm.args = list(
              standard.test = "default",
              scaled.test = "default",
@@ -49,7 +52,8 @@ setGeneric(
 )
 setGeneric(
   "fitmeasures",
-  function(object, fit.measures = "all", baseline.model = NULL,
+  function(object, fit.measures = "all",
+           baseline.model = NULL, h1.model = NULL,
            fm.args = list(
              standard.test = "default",
              scaled.test = "default",

--- a/R/lav_fit_cfi.R
+++ b/R/lav_fit_cfi.R
@@ -683,6 +683,15 @@ lav_fit_measures_check_baseline <- function(fit.indep = NULL, object = NULL) {
       TEST <- fit.indep@test
     }
   } # converged lavaan object
-
+  
+  
+  ## TDJ: Check for user-supplied h1 model in object (maybe in fit.indep, too?)
+  if (!is.null(object@external$h1.model)) {
+    stopifnot(inherits(object@external$h1.model, "lavaan"))
+    ## update @test slot
+    TEST <- lav_update_test_custom_h1(lav_obj_h0 = fit.indep,
+                                      lav_obj_h1 = object@external$h1.model)@test
+  }
+  
   TEST
 }

--- a/R/lav_fit_cfi.R
+++ b/R/lav_fit_cfi.R
@@ -416,9 +416,9 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit.measures = "cfi",
     stopifnot(inherits(h1.model, "lavaan"))
 
     # 2. h1 model in @external slot
-  } else if (!is.null(object@external$h1.model)) {
-    stopifnot(inherits(object@external$h1.model, "lavaan"))
-    h1.model <- object@external$h1.model
+  } else if (!is.null(lavobject@external$h1.model)) {
+    stopifnot(inherits(lavobject@external$h1.model, "lavaan"))
+    h1.model <- lavobject@external$h1.model
   } # else is.null
   
   # 1. user-provided baseline model

--- a/R/lav_fit_cfi.R
+++ b/R/lav_fit_cfi.R
@@ -411,7 +411,8 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit.measures = "cfi",
     baseline.test <-
       lav_fit_measures_check_baseline(
         fit.indep = baseline.model,
-        object = lavobject
+        object = lavobject,
+        fit.h1 = lavobject@external$h1.model # okay if NULL
       )
     # 2. baseline model in @external slot
   } else if (!is.null(lavobject@external$baseline.model)) {
@@ -419,12 +420,15 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit.measures = "cfi",
     baseline.test <-
       lav_fit_measures_check_baseline(
         fit.indep = fit.indep,
-        object = lavobject
+        object = lavobject,
+        fit.h1 = lavobject@external$h1.model # okay if NULL
       )
     # 3. internal @baseline slot
   } else if (.hasSlot(lavobject, "baseline") &&
     length(lavobject@baseline) > 0L &&
-    !is.null(lavobject@baseline$test)) {
+    !is.null(lavobject@baseline$test) &&
+    ## if there is a custom h1 model, need  _check_baseline() to update @test
+    is.null(lavobject@external$h1.model)) {
     baseline.test <- lavobject@baseline$test
     # 4. (re)compute independence model
   } else {
@@ -432,7 +436,8 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit.measures = "cfi",
     baseline.test <-
       lav_fit_measures_check_baseline(
         fit.indep = fit.indep,
-        object = lavobject
+        object = lavobject,
+        fit.h1 = lavobject@external$h1.model # okay if NULL
       )
   }
 
@@ -611,7 +616,8 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit.measures = "cfi",
 # new in 0.6-5
 # internal function to check the (external) baseline model, and
 # return baseline 'test' list if everything checks out (and NULL otherwise)
-lav_fit_measures_check_baseline <- function(fit.indep = NULL, object = NULL) {
+lav_fit_measures_check_baseline <- function(fit.indep = NULL, object = NULL,
+                                            fit.h1 = NULL) {
   TEST <- NULL
 
   # check if everything is in order
@@ -685,12 +691,31 @@ lav_fit_measures_check_baseline <- function(fit.indep = NULL, object = NULL) {
   } # converged lavaan object
   
   
-  ## TDJ: Check for user-supplied h1 model in object (maybe in fit.indep, too?)
-  if (!is.null(object@external$h1.model)) {
+  
+  # TDJ: Check for user-supplied h1.model (here, the fit.h1= argument)
+  #      Similar to BASELINE model, use the following priority:
+  #        1. user-provided h1 model
+  #        2. h1 model in @external slot
+  #        3. default h1 model (already in @h1 slot, no update necessary)
+  #FIXME? user-supplied h1 model in object might be in fit.indep, too
+  
+  user_h1_exists <- FALSE
+  # 1. user-provided h1 model
+  if (!is.null(fit.h1)) {
+    stopifnot(inherits(fit.h1, "lavaan"))
+    user_h1_exists <- TRUE
+    
+    # 2. h1 model in @external slot
+  } else if (!is.null(object@external$h1.model)) {
     stopifnot(inherits(object@external$h1.model, "lavaan"))
+    fit.h1 <- object@external$h1.model
+    user_h1_exists <- TRUE
+  }
+  
+  if (user_h1_exists) {
     ## update @test slot
     TEST <- lav_update_test_custom_h1(lav_obj_h0 = fit.indep,
-                                      lav_obj_h1 = object@external$h1.model)@test
+                                      lav_obj_h1 = fit.h1)@test
   }
   
   TEST

--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -250,7 +250,7 @@ lav_fit_measures <- function(object, fit.measures = "all",
     FIT <- lav_update_test_custom_h1(lav_obj_h0 = object, lav_obj_h1 = h1.model)
 
     ## re-assign TEST object that is used below
-    TEST <- FIT@test
+    object@test <- TEST <- FIT@test
     test.names <- unname(sapply(TEST, "[[", "test"))
   }
 

--- a/R/lav_object_summary.R
+++ b/R/lav_object_summary.R
@@ -145,6 +145,13 @@ lav_object_summary <- function(object, header = TRUE,
 
       # 5. test statistics
       TEST <- object@test
+      # TDJ: check for user-supplied h1 model
+      if (!is.null(object@external$h1.model)) {
+        stopifnot(inherits(object@external$h1.model, "lavaan"))
+        ## update @test slot
+        TEST <- lav_update_test_custom_h1(lav_obj_h0 = object,
+                                          lav_obj_h1 = object@external$h1.model)@test
+      }
       # double check if we have attr(TEST, "info") (perhaps old object?)
       if (is.null(attr(TEST, "info"))) {
         lavdata <- object@Data

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -760,8 +760,12 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
     }
     if (!is.null(newTEST[[tn]]$shift.parameter)) {
       newTEST[[tn]]$shift.parameter <- attr(ANOVA, "shift")[2] # first row is NA
+    } else {
+      ## unless scaled.shifted, RMSEA is calculated from $standard$stat and
+      ## df == sum($trace.UGamma).  Reverse-engineer from $scaling factor:
+      newTEST[[tn]]$trace.UGamma <- newTEST[[tn]]$df * newTEST[[tn]]$scaling.factor
     }
-    ## should not be necessary to replace $trace.UGamma(2)
+    ## should not be necessary to replace $trace.UGamma2
     ## nor to replace $scaling.factor.h0/h1
   } # end loop over tests
   

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -700,8 +700,8 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
   stopifnot(lav_obj_h0@test[[1]]$df >= lav_obj_h1@test[[1]]$df)
   
   ## remove any other (potentially hidden) h1 model from BOTH objects
-  lav_obj_h0@external$h1 <- NULL
-  lav_obj_h1@external$h1 <- NULL
+  lav_obj_h0@external$h1.model <- NULL
+  lav_obj_h1@external$h1.model <- NULL
   
   ## save old @test slot as template
   ## (so the @test[[1]]$df don't change while looping over tests to update)
@@ -741,7 +741,14 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
     }
     
     ## get new test
-    ANOVA <- eval(as.call(lrtCall))
+    if (lav_obj_h0@test[[1]]$df == lav_obj_h1@test[[1]]$df) {
+      ## suppress warning about == df
+      ANOVA <- suppressWarnings(eval(as.call(lrtCall)))
+    } else {
+      ## maybe some other informative warning would be important to see
+      ANOVA <- eval(as.call(lrtCall))
+    }
+    
     
     ## replace old @test[[tn]] values
     newTEST[[tn]]$stat.group <- NULL # avoid wrong stats in summary() header?

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -1,5 +1,8 @@
 # chi-square test statistic:
 # comparing the current model versus the saturated/unrestricted model
+# TDJ 9 April 2024: Add a (hidden) function to update the @test slot
+#                   when the user provides a custom h1 model.  Called by 
+#                   lav_object_summary and lav_fit_measures(_check_baseline)
 
 lavTest <- function(lavobject, test = "standard",
                     scaled.test = "standard",
@@ -688,3 +691,76 @@ lav_model_test <- function(lavobject = NULL,
 
   TEST
 }
+
+lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
+  stopifnot(inherits(lav_obj_h0, "lavaan"))
+  stopifnot(inherits(lav_obj_h1, "lavaan"))
+  
+  ## this breaks if object not nested in (df >=) h1, so check df
+  stopifnot(lav_obj_h0@test[[1]]$df >= lav_obj_h1@test[[1]]$df)
+  
+  ## remove any other (potentially hidden) h1 model from BOTH objects
+  lav_obj_h0@external$h1 <- NULL
+  lav_obj_h1@external$h1 <- NULL
+  
+  ## save old @test slot as template
+  ## (so the @test[[1]]$df don't change while looping over tests to update)
+  newTEST <- lav_obj_h0@test
+  
+  ## assemble a call to lavTestLRT()
+  lrtCallTemplate <- list(quote(lavTestLRT), object = quote(lav_obj_h1), 
+                          quote(lav_obj_h0)) # in ...
+
+  ## can only update tests available in both objects
+  testNames0 <- names(lav_obj_h0@test)
+  testNames1 <- names(lav_obj_h1@test)
+  testNames <- intersect(testNames0, testNames1)
+  
+  ## loop over those tests
+  for (tn in testNames) {
+    lrtCall <- lrtCallTemplate
+    ## conditional arguments:
+    if (tn == "standard") {
+      lrtCall$method <- "standard"
+    } else if (tn %in% c("scaled.shifted","mean.var.adjusted")) {
+      if (lav_obj_h0@Options$estimator == "PML") {
+        lrtCall$method <- "mean.var.adjusted.PLRT"
+      } else {
+        lrtCall$method <- "satorra.2000"
+      }
+      lrtCall$scaled.shifted <- tn == "scaled.shifted"
+    } else if (tn %in% c("satorra.bentler",
+                         "yuan.bentler","yuan.bentler.mplus")) {
+      lrtCall$test <- tn
+    } else if (grepl(pattern = "browne", x = tn)) {
+      lrtCall$type <- tn
+    } else {
+      #TODO?
+      #   - if (tn %in% c("bootstrap", "bollen.stine")) next
+      #   - any other possibilities in @test?
+    }
+    
+    ## get new test
+    ANOVA <- eval(as.call(lrtCall))
+    
+    ## replace old @test[[tn]] values
+    newTEST[[tn]]$stat.group <- NULL # avoid wrong stats in summary() header?
+    newTEST[[tn]]$stat   <- ANOVA["lav_obj_h0" , "Chisq diff"]
+    newTEST[[tn]]$df     <- ANOVA["lav_obj_h0" , "Df diff"   ]
+    newTEST[[tn]]$pvalue <- ANOVA["lav_obj_h0" , "Pr(>Chisq)"]
+    if (!is.null(newTEST[[tn]]$scaling.factor)) {
+      newTEST[[tn]]$scaling.factor <- attr(ANOVA, "scale")[2] # first row is NA
+    }
+    if (!is.null(newTEST[[tn]]$shift.parameter)) {
+      newTEST[[tn]]$shift.parameter <- attr(ANOVA, "shift")[2] # first row is NA
+    }
+    ## should not be necessary to replace $trace.UGamma(2)
+    ## nor to replace $scaling.factor.h0/h1
+  } # end loop over tests
+  
+  ## assign updated @test slot and return
+  lav_obj_h0@test <- newTEST
+  lav_obj_h0
+}
+
+

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -281,6 +281,9 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
   Df.delta <- c(NA, diff(Df))
   if (method == "satorra.2000" && scaled.shifted) {
     a.delta <- b.delta <- rep(as.numeric(NA), length(STAT))
+  } else if (method %in% c("satorra.bentler.2001","satorra.bentler.2010",
+                           "satorra.2000")) {
+    c.delta <- rep(as.numeric(NA), length(STAT))
   }
   # new in 0.6-13
   if (!scaled) {
@@ -313,6 +316,7 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
                                                 test = TEST)
         STAT.delta[m + 1] <- out$T.delta
         Df.delta[m + 1] <- out$df.delta
+        c.delta[m + 1] <- out$scaling.factor
       }
     } else if (method == "mean.var.adjusted.PLRT") {
       for (m in seq_len(length(mods) - 1L)) {
@@ -329,6 +333,7 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
 
         STAT.delta[m + 1] <- out$T.delta
         Df.delta[m + 1] <- out$df.delta
+        c.delta[m + 1] <- out$scaling.factor
       }
     } else if (method == "satorra.2000") {
       for (m in seq_len(length(mods) - 1L)) {
@@ -351,6 +356,8 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
         if (scaled.shifted) {
           a.delta[m + 1] <- out$a
           b.delta[m + 1] <- out$b
+        } else {
+          c.delta[m + 1] <- out$scaling.factor
         }
       }
     }
@@ -446,6 +453,9 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
       if (method == "satorra.2000" && scaled.shifted) {
         attr(val, "scale") <- a.delta
         attr(val, "shift") <- b.delta
+      } else if (method %in% c("satorra.bentler.2001","satorra.bentler.2010",
+                               "satorra.2000")) {
+        attr(val, "scale") <- c.delta
       }
     } else {
       attr(val, "heading") <- "\nChi-Squared Difference Test\n"

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -5,6 +5,7 @@
 # - in 0.5-18, SB.classic is replaced by 'method', with the following
 #   options:
 #     method = "default" (we choose a default method, based on the estimator)
+#     method = "standard" (option to explicitly avoid robust adjustment)
 #     method = "Satorra.2000"
 #     method = "Satorra.Bentler.2001"
 #     method = "Satorra.Bentler.2010"
@@ -137,7 +138,10 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
   if (type %in% c("browne.residual.adf", "browne.residual.nt")) {
     scaled <- FALSE
   }
-
+  if (method == "standard") {
+    scaled <- FALSE
+  }
+  
   # select method
   if (method == "default") {
     if (estimator == "PML") {
@@ -164,7 +168,9 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
     method <- "satorra.bentler.2001"
   } else if (method == "satorrabentler2010") {
     method <- "satorra.bentler.2010"
-  } else {
+    
+    ## only option left:
+  } else if (method != "standard") {
     stop("lavaan ERROR: unknown method for scaled difference test: ", method)
   }
 
@@ -182,7 +188,7 @@ lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
       "\n\t switching to the standard chi-square difference test"
     )
 
-    method <- "default"
+    method <- "standard"
   }
 
 

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -18,7 +18,7 @@
 
 lavTestLRT <- function(object, ..., method = "default", A.method = "delta",
                        scaled.shifted = TRUE,
-                       H1 = TRUE, type = "Chisq", model.names = NULL) {
+                       type = "Chisq", model.names = NULL) {
   type <- tolower(type)
   method <- tolower(gsub("[-_\\.]", "", method))
   if (type %in% c("browne", "browne.residual.adf", "browne.residual.nt")) {

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -56,8 +56,8 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
 
   # TDJ: check for user-supplied h1 model
   user_h1_exists <- FALSE
-  if (!is.null(object@external$h1)) {
-    if (inherits(object@external$h1, "lavaan")) {
+  if (!is.null(object@external$h1.model)) {
+    if (inherits(object@external$h1.model, "lavaan")) {
       user_h1_exists <- TRUE
     }
   }
@@ -81,7 +81,7 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",
     )
   }
   # TDJ: Add user-supplied h1 model, if it exists
-  if (user_h1_exists) mods$user_h1 <- object@external$h1
+  if (user_h1_exists) mods$user_h1 <- object@external$h1.model
 
   # put them in order (using degrees of freedom)
   ndf <- sapply(mods, function(x) x@test[[1]]$df)

--- a/R/lav_test_diff.R
+++ b/R/lav_test_diff.R
@@ -201,18 +201,18 @@ lav_test_diff_Satorra2000 <- function(m1, m0, H1 = TRUE, A.method = "delta",
   )
 }
 
-lav_test_diff_SatorraBentler2001 <- function(m1, m0) {
+lav_test_diff_SatorraBentler2001 <- function(m1, m0, test = 2) {
   # extract information from m1 and m2
   T1 <- m1@test[[1]]$stat
   r1 <- m1@test[[1]]$df
-  c1 <- m1@test[[2]]$scaling.factor
+  c1 <- m1@test[[test]]$scaling.factor
   if (r1 == 0) { # saturated model
     c1 <- 1
   }
 
   T0 <- m0@test[[1]]$stat
   r0 <- m0@test[[1]]$df
-  c0 <- m0@test[[2]]$scaling.factor
+  c0 <- m0@test[[test]]$scaling.factor
 
   # m = difference between the df's
   m <- r0 - r1
@@ -240,20 +240,21 @@ lav_test_diff_SatorraBentler2001 <- function(m1, m0) {
   list(T.delta = T.delta, scaling.factor = cd, df.delta = m)
 }
 
-lav_test_diff_SatorraBentler2010 <- function(m1, m0, H1 = FALSE) {
+lav_test_diff_SatorraBentler2010 <- function(m1, m0, test = 2,
+                                             H1 = FALSE) {
   ### FIXME: check if models are nested at the parameter level!!!
 
   # extract information from m1 and m2
   T1 <- m1@test[[1]]$stat
   r1 <- m1@test[[1]]$df
-  c1 <- m1@test[[2]]$scaling.factor
+  c1 <- m1@test[[test]]$scaling.factor
   if (r1 == 0) { # saturated model
     c1 <- 1
   }
 
   T0 <- m0@test[[1]]$stat
   r0 <- m0@test[[1]]$df
-  c0 <- m0@test[[2]]$scaling.factor
+  c0 <- m0@test[[test]]$scaling.factor
   if (r0 == 0) { # should never happen
     c0 <- 1
   }
@@ -273,7 +274,7 @@ lav_test_diff_SatorraBentler2010 <- function(m1, m0, H1 = FALSE) {
   if (H1) {
     # M0 with M1 parameters
     M01 <- lav_test_diff_m10(m0, m1, test = TRUE)
-    c01 <- M01@test[[2]]$scaling.factor
+    c01 <- M01@test[[test]]$scaling.factor
 
     # check if vcov is positive definite (new in 0.6)
     # if not, we may get negative values
@@ -294,7 +295,7 @@ lav_test_diff_SatorraBentler2010 <- function(m1, m0, H1 = FALSE) {
   } else {
     # M1 with M0 parameters (as in Satorra & Bentler 2010)
     M10 <- lav_test_diff_m10(m1, m0, test = TRUE)
-    c10 <- M10@test[[2]]$scaling.factor
+    c10 <- M10@test[[test]]$scaling.factor
 
     # check if vcov is positive definite (new in 0.6)
     # if not, we may get negative values

--- a/R/lav_test_yuan_bentler.R
+++ b/R/lav_test_yuan_bentler.R
@@ -243,7 +243,9 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
         scaling.factor.h0 = scaling.factor.h0,
         label = "Yuan-Bentler correction",
         trace.UGamma = trace.UGamma,
-        trace.UGamma2 = trace.UGamma2
+        trace.UGamma2 = trace.UGamma2,
+        scaled.test.stat = TEST$standard$stat,
+        scaled.test = TEST$standard$test
       )
   } else if ("yuan.bentler.mplus" %in% test) {
     TEST$yuan.bentler.mplus <-
@@ -260,7 +262,9 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
         label =
           "Yuan-Bentler correction (Mplus variant)",
         trace.UGamma = trace.UGamma,
-        trace.UGamma2 = as.numeric(NA)
+        trace.UGamma2 = as.numeric(NA),
+        scaled.test.stat = TEST$standard$stat,
+        scaled.test = TEST$standard$test
       )
   }
 

--- a/man/lavTestLRT.Rd
+++ b/man/lavTestLRT.Rd
@@ -11,7 +11,7 @@ LRT test for comparing (nested) lavaan models.}
 \usage{
 lavTestLRT(object, ..., method = "default", A.method = "delta",
            scaled.shifted = TRUE,
-           H1 = TRUE, type = "Chisq", model.names = NULL)
+           type = "Chisq", model.names = NULL)
 anova(object, ...)
 }
 \arguments{
@@ -20,7 +20,6 @@ anova(object, ...)
 \item{method}{Character string. The possible options are 
 \code{"satorra.bentler.2001"}, \code{"satorra.bentler.2010"},
 \code{"satorra.2000"}, and \code{"standard"}. See details.}
-\item{H1}{Not used yet}
 \item{A.method}{Character string. The possible options are \code{"exact"}
 and \code{"delta"}. This is only used when method = \code{"satorra.2000"}.
 It determines how the Jacobian of the constraint function (the matrix A)

--- a/man/lavTestLRT.Rd
+++ b/man/lavTestLRT.Rd
@@ -18,8 +18,8 @@ anova(object, ...)
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
 \item{...}{additional objects of class \code{\linkS4class{lavaan}}.}
 \item{method}{Character string. The possible options are 
-\code{"satorra.bentler.2001"}, \code{"satorra.bentler.2010"} and
-\code{"satorra.2000"}. See details.}
+\code{"satorra.bentler.2001"}, \code{"satorra.bentler.2010"},
+\code{"satorra.2000"}, and \code{"standard"}. See details.}
 \item{H1}{Not used yet}
 \item{A.method}{Character string. The possible options are \code{"exact"}
 and \code{"delta"}. This is only used when method = \code{"satorra.2000"}.
@@ -50,26 +50,32 @@ we use a mean and variance adjusted (Satterthwaite style) test statistic.}
     \code{lavTestLRT} function, which has a few additional arguments.
 
     If \code{type = "Chisq"} and the test statistics are scaled, a
-    special scaled difference test statistic is computed. If method is
+    special scaled difference test statistic is computed. If \code{method} is
     \code{"satorra.bentler.2001"}, a simple approximation is used
     described in Satorra & Bentler (2001). In some settings,
     this can lead to a negative test statistic. To ensure a positive
     test statistic, we can use the method proposed by 
-    Satorra & Bentler (2010). Alternatively, when method is
-    \code{"satorra.2000"}, the original formulas of Satorra (2000) are
-    used.
+    Satorra & Bentler (2010). Alternatively, when \code{method="satorra.2000"},
+    the original formulas of Satorra (2000) are used.  The latter is used for
+    model comparison, when \code{...} contain additional (nested) models.
+    Even when test statistics are scaled in \code{object} or \code{...},
+    users may request the  \code{method="standard"} test statistic,
+    without a robust adjustment.
 }
 \references{
 Satorra, A. (2000). Scaled and adjusted restricted tests in multi-sample
 analysis of moment structures. In Heijmans, R.D.H., Pollock, D.S.G. & Satorra,
-A. (eds.), Innovations in multivariate statistical analysis. A Festschrift for
-Heinz Neudecker (pp.233-247). London: Kluwer Academic Publishers.     
+A. (eds.), \emph{Innovations in multivariate statistical analysis}:
+\emph{A Festschrift for Heinz Neudecker} (pp.233-247). 
+London, UK: Kluwer Academic Publishers.     
 
 Satorra, A., & Bentler, P. M. (2001). A scaled difference chi-square test
-statistic for moment structure analysis. Psychometrika, 66(4), 507-514.
+statistic for moment structure analysis. \emph{Psychometrika, 66}(4), 507-514.
+\doi{10.1007/BF02296192}
 
 Satorra, A., & Bentler, P. M. (2010). Ensuring postiveness of the scaled
-difference chi-square test statistic. Psychometrika, 75(2), 243-248.
+difference chi-square test statistic. \emph{Psychometrika, 75}(2), 243-248.
+\doi{10.1007/s11336-009-9135-y}
 }
 \examples{
 HS.model <- '

--- a/man/lavTestLRT.Rd
+++ b/man/lavTestLRT.Rd
@@ -9,8 +9,8 @@
 \description{
 LRT test for comparing (nested) lavaan models.}
 \usage{
-lavTestLRT(object, ..., method = "default", A.method = "delta",
-           scaled.shifted = TRUE,
+lavTestLRT(object, ..., method = "default", test = "default",
+           A.method = "delta", scaled.shifted = TRUE,
            type = "Chisq", model.names = NULL)
 anova(object, ...)
 }
@@ -18,17 +18,20 @@ anova(object, ...)
 \item{object}{An object of class \code{\linkS4class{lavaan}}.}
 \item{...}{additional objects of class \code{\linkS4class{lavaan}}.}
 \item{method}{Character string. The possible options are 
-\code{"satorra.bentler.2001"}, \code{"satorra.bentler.2010"},
-\code{"satorra.2000"}, and \code{"standard"}. See details.}
+  \code{"satorra.bentler.2001"}, \code{"satorra.bentler.2010"},
+  \code{"satorra.2000"}, and \code{"standard"}. See details.}
+\item{test}{Character string specifying which scaled test statistics to use,
+  in case multiple scaled \code{test=} options were requested when fitting the
+  model(s). See details.}
 \item{A.method}{Character string. The possible options are \code{"exact"}
-and \code{"delta"}. This is only used when method = \code{"satorra.2000"}.
-It determines how the Jacobian of the constraint function (the matrix A)
-will be computed. Note that if \code{A.method = "exact"}, the models must
-    be nested in the parameter sense, while if \code{A.method = "delta"}, they
-    only need to be nested in the covariance matrix sense.}
+  and \code{"delta"}. This is only used when method = \code{"satorra.2000"}.
+  It determines how the Jacobian of the constraint function (the matrix A)
+  will be computed. Note that if \code{A.method = "exact"}, the models must
+  be nested in the parameter sense, while if \code{A.method = "delta"}, they
+  only need to be nested in the covariance matrix sense.}
 \item{scaled.shifted}{Logical. Only used when method = \code{"satorra.2000"}.
-If \code{TRUE}, we use a scaled and shifted test statistic; if \code{FALSE},
-we use a mean and variance adjusted (Satterthwaite style) test statistic.}
+  If \code{TRUE}, we use a scaled and shifted test statistic; if \code{FALSE},
+  we use a mean and variance adjusted (Satterthwaite style) test statistic.}
 \item{type}{Character. If \code{"Chisq"}, the test statistic for each
   model is the (scaled or unscaled) model fit test statistic. If \code{"Cf"}, 
   the test statistic for each model is computed by the 
@@ -47,6 +50,16 @@ we use a mean and variance adjusted (Satterthwaite style) test statistic.}
 \details{
     The \code{anova} function for lavaan objects simply calls the
     \code{lavTestLRT} function, which has a few additional arguments.
+    
+    The only \code{test=} options that currently have actual consequences are 
+    \code{"satorra.bentler"}, \code{"yuan.bentler"}, or \code{"yuan.bentler.mplus"}
+    because \code{"mean.var.adjusted"} and \code{"scaled.shifted"} are
+    currently distinguished by the \code{scaled.shifted} argument.
+    See \code{\link{lavOptions}} for details about \code{test=} options
+    implied by robust \code{estimator=} options). The \code{"default"} is to
+    select the first available scaled statistic, if any. To check which test(s)
+    were calculated when fitting your model(s), use 
+    \code{lavInspect(fit, "options")$test}.
 
     If \code{type = "Chisq"} and the test statistics are scaled, a
     special scaled difference test statistic is computed. If \code{method} is
@@ -86,4 +99,53 @@ fit1 <- cfa(HS.model, data = HolzingerSwineford1939)
 fit0 <- cfa(HS.model, data = HolzingerSwineford1939, 
             orthogonal = TRUE)
 lavTestLRT(fit1, fit0)
+
+
+## When multiple test statistics are selected when the model is fitted,
+## use the type= and test= arguments to select a test for comparison.
+
+## refit models, requesting 6 test statistics (in addition to "standard")
+t6.1 <- cfa(HS.model, data = HolzingerSwineford1939,
+            test = c("browne.residual.adf","scaled.shifted","mean.var.adjusted",
+                     "satorra.bentler", "yuan.bentler", "yuan.bentler.mplus"))
+t6.0 <- cfa(HS.model, data = HolzingerSwineford1939, orthogonal = TRUE,
+            test = c("browne.residual.adf","scaled.shifted","mean.var.adjusted",
+                     "satorra.bentler", "yuan.bentler", "yuan.bentler.mplus"))
+
+## By default (test="default", type="Chisq"), the first scaled statistic
+## requested will be used. Here, that is "scaled.shifted"
+lavTestLRT(t6.1, t6.0)
+## But even if "satorra.bentler" were requested first, method="satorra.2000"
+## provides the scaled-shifted chi-squared difference test:
+lavTestLRT(t6.1, t6.0, method = "satorra.2000")
+## == lavTestLRT(update(t6.1, test = "scaled.shifted"), update(t6.0, test = "scaled.shifted"))
+
+## The mean- and variance-adjusted (Satterthwaite) statistic implies
+## scaled.shifted = FALSE
+lavTestLRT(t6.1, t6.0, method = "satorra.2000", scaled.shifted = FALSE)
+
+## Because "satorra.bentler" is not the first scaled test in the list,
+## we MUST request it explicitly:
+lavTestLRT(t6.1, t6.0, test = "satorra.bentler") # method="satorra.bentler.2001"
+## == lavTestLRT(update(t6.1, test = "satorra.bentler"), update(t6.0, test = "satorra.bentler"))
+
+## The "strictly-positive test" is necessary when the above test is < 0:
+lavTestLRT(t6.1, t6.0, test = "satorra.bentler", method = "satorra.bentler.2010")
+
+## Likewise, other scaled statistics can be selected:
+lavTestLRT(t6.1, t6.0, test = "yuan.bentler")
+## == lavTestLRT(update(t6.1, test = "yuan.bentler"), update(t6.0, test = "yuan.bentler"))
+lavTestLRT(t6.1, t6.0, test = "yuan.bentler.mplus")
+## == lavTestLRT(update(t6.1, test = "yuan.bentler.mplus"), update(t6.0, test = "yuan.bentler.mplus"))
+
+## To request the difference between Browne's (1984) residual-based statistics,
+## rather than statistics based on the fitted model's discrepancy function,
+## use the type= argument:
+lavTestLRT(t6.1, t6.0, type = "browne.residual.adf")
+
+## Despite requesting multiple robust tests, it is still possible to obtain
+## the standard chi-squared difference test (i.e., without a robust correction)
+lavTestLRT(t6.1, t6.0, method = "standard")
+## == lavTestLRT(update(t6.1, test = "standard"), update(t6.0, test = "standard"))
+
 }


### PR DESCRIPTION
`lav_fit_measures()` also checks fitted model for `@external$h1.model`, as does `lav_object_summary()`.  Here is an example to demonstrate:

```
## simulate data from 2 x 2 design with orthogonal factors
des <- expand.grid(therapy = c(-1,1), drug = c(-1,1))
des$int <- des$therapy*des$drug
set.seed(123)
dat <- do.call(rbind, lapply(1:5, function(n) {
  ## n=5 per group (4 groups)
  yHat <- 1 + 2*des$therapy + 3*des$drug - 4*des$int
  des$DV <- rnorm(4, mean = yHat, sd = sqrt(4*var(yHat))) # Rsq = 20%
  des
}))

## Fit in lavaan with orthogonality constraints
mod <- ' DV ~ therapy + drug + int
## only estimate variances
  DV ~~ DV
  therapy ~~ therapy
  drug ~~ drug
  int ~~ int
'
fit <- lavaan(mod, data = dat, fixed.x = FALSE,# h1 = FALSE,
              test = c("browne.residual.nt","satorra.bentler","scaled.shifted"))
fit # unscaled ChiSq=0 with df=3

## These 3 df will make any more-restricted model seem to fit better
mod0 <- ' DV ~ b1*therapy + b1*drug # equal effects
          DV ~ 0*int                # no interaction
## only estimate variances
  DV ~~ DV
  therapy ~~ therapy
  drug ~~ drug
  int ~~ int
'
fit0 <- lavaan(mod0, data = dat, fixed.x = FALSE, #h1 = FALSE,
               test = c("browne.residual.nt","satorra.bentler","scaled.shifted"))
fit0 # unscaled ChiSq=6.7 with df=5, NOT significant

## compare to a more appropriate h1 model:
lavTestLRT(fit0, fit) # same ChiSq=6.7, but with df=2, IS significant
## we should prefer this as the default h1 model

## this updated allows us to get fit indices using df=2 rather than 5
fitMeasures(fit0, h1.model = fit, output = "text")


## Optionally override default saturated model in @h1 slot
fit@h1  <- list()
fit0@h1 <- list()
fit@external$h1.model <- fit
fit0@external$h1.model <- fit

## because show() calls lav_fit_summary(), these all display df=2
fit0
lavTestLRT(fit0)
fitMeasures(fit0, output = "text")
```

Tests with unadjusted _df_=5 are still available from `lavTest(fit0, output = "text")`

Contrary to what I speculated when we discussed this in person, I no longer expect a problem with RMRs.  The issue here is that there are structural constraints in the unrestricted model's implied moments, which should be reflected by _df_ > 0.  But the unrestricted moments are the same, so residuals will be the same.  Their _SE_s and CIs in `lavResiduals()` might be improved, if the custom `h1.model` parameters are estimated more efficiently.  But that's for future research.
