### PR TITLE
translator friendly changes

### DIFF
--- a/R/ctr_pml_plrt.R
+++ b/R/ctr_pml_plrt.R
@@ -298,11 +298,10 @@ ctr_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
 
     par.idx <- match(PARLABEL, NAMES)
     if (any(is.na(par.idx))) {
-      lav_msg_warn(
-        gettext("[ctr_pml_plrt] mismatch between DELTA labels and PAR labels!"),
-        gettextf("PARLABEL: %s", lav_msg_view(PARLABEL)),
-        gettextf("DELTA LABELS: %s", lav_msg_view(NAMES))
-      )
+      lav_msg_warn(gettextf(
+        "mismatch between DELTA labels and PAR labels!
+        PARLABEL: %1$s, DELTA LABELS: %2$s", lav_msg_view(PARLABEL)),
+         lav_msg_view(NAMES))
     }
 
     drhodpsi_MAT[[g]] <- delta.g[par.idx, index.par, drop = FALSE]

--- a/R/lav_cfa_fabin.R
+++ b/R/lav_cfa_fabin.R
@@ -101,9 +101,8 @@ lav_cfa_fabin_internal <- function(lavmodel = NULL, lavsamplestats = NULL,
   }
   # no BETA matrix! (i.e., no higher-order factors)
   if (!is.null(lavmodel@GLIST$beta)) {
-    lav_msg_stop(
-      gettext("FABIN estimator not available for models"),
-      gettext("that require a BETA matrix"))
+    lav_msg_stop(gettext(
+    "FABIN estimator not available for models that require a BETA matrix"))
   }
   # no std.lv = TRUE for now
   if (lavoptions$std.lv) {

--- a/R/lav_cfa_guttman1952.R
+++ b/R/lav_cfa_guttman1952.R
@@ -218,9 +218,8 @@ lav_cfa_guttman1952_internal <- function(lavobject = NULL, # convenience
   }
   # no BETA matrix! (i.e., no higher-order factors)
   if (!is.null(lavmodel@GLIST$beta)) {
-    lav_msg_stop(
-      gettext("GUTTMAN1952 estimator not available for models"),
-      gettext("that require a BETA matrix"))
+    lav_msg_stop(gettext(
+   "GUTTMAN1952 estimator not available for models that require a BETA matrix"))
   }
   # no std.lv = TRUE for now
   if (lavoptions$std.lv) {
@@ -246,9 +245,8 @@ lav_cfa_guttman1952_internal <- function(lavobject = NULL, # convenience
   m.theta <- lavmodel@m.free.idx[[theta.idx]]
   nondiag.idx <- m.theta[!m.theta %in% lav_matrix_diag_idx(nvar)]
   if (length(nondiag.idx) > 0L) {
-    lav_msg_warn(
-      gettext("this implementation of FABIN does not handle"),
-      gettext("correlated residuals yet!"))
+    lav_msg_warn(gettext(
+      "this implementation of FABIN does not handle correlated residuals yet!"))
   }
 
   # 1. obtain estimate for (diagonal elements of) THETA

--- a/R/lav_cfa_jamesstein.R
+++ b/R/lav_cfa_jamesstein.R
@@ -179,9 +179,9 @@ lav_cfa_jamesstein_internal <- function(lavobject = NULL, # convenience
   m.theta <- lavmodel@m.free.idx[[theta.idx]]
   nondiag.idx <- m.theta[!m.theta %in% lav_matrix_diag_idx(nvar)]
   if (length(nondiag.idx) > 0L) {
-    lav_msg_warn(
-      gettext("this implementation of JS/JSA does not handle"),
-      gettext("correlated residuals yet!"))
+    lav_msg_warn(gettext(
+      "this implementation of JS/JSA does not handle correlated residuals yet!"
+      ))
   }
 
 

--- a/R/lav_data.R
+++ b/R/lav_data.R
@@ -514,9 +514,9 @@ lav_data_full <- function(data = NULL, # data.frame
   if (!is.null(group) && length(group) > 0L) {
     if (!(group %in% names(data))) {
       lav_msg_stop(gettextf(
-        "grouping variable %s not found;", sQuote(group)),
-        gettextf("variable names found in data frame are: %s",
-        paste(names(data), collapse = " ")))
+        "grouping variable %1$s not found; variable names 
+        found in data frame are: %2$s",
+        sQuote(group),paste(names(data), collapse = " ")))
     }
     # note: by default, we use the order as in the data;
     # not as in levels(data[,group])
@@ -561,11 +561,9 @@ lav_data_full <- function(data = NULL, # data.frame
     if (is.character(sampling.weights)) {
       if (!(sampling.weights %in% names(data))) {
         lav_msg_stop(
-          gettextf("sampling weights variable %s not found;",
-          sQuote(sampling.weights)),
-          gettext("variable names found in data frame are: "),
-          paste(names(data), collapse = " ")
-        )
+          gettextf("sampling weights variable %1$s not found; 
+                   variable names found in data frame are: %2$s",
+          sQuote(sampling.weights)), paste(names(data), collapse = " "))
       }
       # check for missing values in sampling weight variable
       if (any(is.na(data[[sampling.weights]]))) {
@@ -587,10 +585,9 @@ lav_data_full <- function(data = NULL, # data.frame
       # which one did we not find?
       not.ok <- which(!cluster %in% names(data))
       lav_msg_stop(gettextf(
-        "cluster variable(s) %s not found;", sQuote(cluster[not.ok])),
-        gettext("variable names found in data frame are:"),
-        paste(names(data), collapse = " ")
-      )
+        "cluster variable(s) %1$s not found;
+        variable names found in data frame are: %2$s",
+        sQuote(cluster[not.ok]), paste(names(data), collapse = " ")))
     }
 
     # check for missing values in cluster variable(s)
@@ -868,9 +865,9 @@ lav_data_full <- function(data = NULL, # data.frame
         norig[[g]] <- length(which(data[[group]] == group.label[g]))
         if (warn && (nobs[[g]] < norig[[g]])) {
           lav_msg_warn(gettextf(
-              "%1$s cases were deleted in group %2$s  due to missing values",
-              (norig[[g]] - nobs[[g]]), group.label[g]),
-            gettext("in  exogenous variable(s), while fixed.x = TRUE."))
+              "%1$s cases were deleted in group %2$s  due to missing values
+              in  exogenous variable(s), while fixed.x = TRUE.",
+              (norig[[g]] - nobs[[g]]), group.label[g]))
         }
       } else {
         case.idx[[g]] <- which(data[[group]] == group.label[g])
@@ -891,9 +888,9 @@ lav_data_full <- function(data = NULL, # data.frame
         norig[[g]] <- nrow(data)
         if (warn && (nobs[[g]] < norig[[g]])) {
           lav_msg_warn(
-            gettextf("%s cases were deleted due to missing values in ",
-                     (norig[[g]] - nobs[[g]])),
-            gettext("exogenous variable(s), while fixed.x = TRUE."))
+            gettextf("%s cases were deleted due to missing values in 
+                     exogenous variable(s), while fixed.x = TRUE.",
+                     (norig[[g]] - nobs[[g]])))
         }
       } else {
         case.idx[[g]] <- 1:nrow(data)
@@ -972,8 +969,8 @@ lav_data_full <- function(data = NULL, # data.frame
       txt <- ""
       if (ngroups > 1L) txt <- gettextf("in group %s", g)
       lav_msg_warn(
-        gettext("small number of observations (nobs < nvar)"), txt,
-        gettextf(": nobs = %1$s  nvar = %2$s", nobs[[g]], nvar))
+        gettextf("small number of observations (nobs < nvar) %1$s: 
+                 nobs = %2$s  nvar = %3$s", txt, nobs[[g]], nvar))
     }
     # check variances per group (if we have multiple groups)
     # to catch zero-variance variables within a group (new in 0.6-8)
@@ -1057,29 +1054,28 @@ lav_data_full <- function(data = NULL, # data.frame
         } else if (length(zero.var) == length(within.var)) {
           # all zero! possibly a between-level variable
           gtxt <- if (ngroups > 1L) {
-            gettextf("in group %s.", g)
+            gettextf("in group %s", g)
           } else {
-            "."
+            ""
           }
           lav_msg_warn(
-            gettextf("Level-1 variable %s", dQuote(ov.names[[g]][v])),
-            gettext("has no variance at the within level"), gtxt,
-            gettext("The variable appears to be a between-level variable."),
-            gettext("Please remove this variable from"),
-            gettext("the level 1 section in the model syntax.")
-          )
+            gettextf("Level-1 variable %1$s has no variance at the within 
+                     level %2$s. The variable appears to be a between-level 
+                     variable. Please remove this variable from the level 1 
+                     section in the model syntax.", 
+                     dQuote(ov.names[[g]][v])), gtxt)
         } else {
           # some zero variances!
           gtxt <- if (ngroups > 1L) {
-            gettextf("in group %s.", g)
+            gettextf("in group %s", g)
           } else {
-            "."
+            ""
           }
-          lav_msg_warn(
-            gettextf("Level-1 variable %s has no variance within some clusters",
-                     dQuote(ov.names[[g]][v])), gtxt,
-            gettext("The cluster ids with zero within variance are:"),
-            lav_msg_view(Lp[[g]]$cluster.id[[2]][zero.var], "none"))
+          lav_msg_warn(gettextf(
+          "Level-1 variable %1$s has no variance within some clusters %2$s.
+          The cluster ids with zero within variance are: %3$s.",
+          dQuote(ov.names[[g]][v])), gtxt,
+          lav_msg_view(Lp[[g]]$cluster.id[[2]][zero.var], "none"))
         }
       }
 
@@ -1102,24 +1098,23 @@ lav_data_full <- function(data = NULL, # data.frame
             "."
           }
           lav_msg_warn(gettextf(
-            "Level-2 variable %s has non-zero variance at the within level",
+            "Level-2 variable %1$ss has non-zero variance at the within
+            level %2$s in one cluster with id: %3$ss. Please double-check
+            if this is a between only variable.",
             dQuote(ov.names[[g]][v])), gtxt,
-            gettextf("in one cluster with id: %s.",
-                      Lp[[g]]$cluster.id[[2]][non.zero.var]),
-            gettext(
-              "Please double-check if this is a between only variable."))
+            Lp[[g]]$cluster.id[[2]][non.zero.var])
         } else {
           error.flag <- TRUE
           # several
           gtxt <- if (ngroups > 1L) {
-            gettextf("in group %s.", g)
+            gettextf("in group %s", g)
           } else {
-            "."
+            ""
           }
           lav_msg_warn(gettextf(
-            "Level-2 variable %s has non-zero variance at the within level",
+            "Level-2 variable %1$s has non-zero variance at the within level
+            %2$s. The cluster ids with non-zero within variance are: %3$s",
             dQuote(ov.names[[g]][v])), gtxt,
-            gettext("The cluster ids with non-zero within variance are: "),
             lav_msg_view(Lp[[g]]$cluster.id[[2]][non.zero.var], "none"))
         }
       }

--- a/R/lav_h1_implied.R
+++ b/R/lav_h1_implied.R
@@ -167,11 +167,10 @@ lav_h1_implied_logl <- function(lavdata = NULL,
         } else {
           " "
         }
-        lav_msg_warn(
-          gettext("H1 estimation resulted in a within covariance matrix"), gtxt,
-          gettextf(
-            "with (near) zero variances for some of the level-1 variables: %s",
-            lav_msg_view(lavdata@ov.names.l[[g]][[1]][zero.var]))
+        lav_msg_warn(gettextf(
+          "H1 estimation resulted in a within covariance matrix %1$s with 
+          (near) zero variances for some of the level-1 variables: %2$s",
+            gtxt, lav_msg_view(lavdata@ov.names.l[[g]][[1]][zero.var]))
         )
       }
 

--- a/R/lav_lavaan_step01_ovnames.R
+++ b/R/lav_lavaan_step01_ovnames.R
@@ -335,12 +335,10 @@ lav_lavaan_step01_ovnames_checklv <- function(                    # nolint
       # ignore
     } else {
       lav_msg_stop(gettextf(
-        "Interaction terms involving latent variables (%s) are not supported.",
-        lv.lv.names[lv.int.idx[1]]),
-        gettext("You may consider creating product indicators to define
-                the latent interaction term. See the indProd() function
-                in the semTools package.")
-      )
+        "Interaction terms involving latent variables (%s) are not supported. 
+        You may consider creating product indicators to define
+        the latent interaction term. See the indProd() function
+        in the semTools package.", lv.lv.names[lv.int.idx[1]]))
     }
   }
 

--- a/R/lav_lavaan_step09_model.R
+++ b/R/lav_lavaan_step09_model.R
@@ -54,8 +54,9 @@ lav_lavaan_step09_model <- function(slotModel = NULL, # nolint
             lavpartable$user == 1L)
           if (length(user.var.idx)) {
             lav_msg_warn(
-              gettext("variance (theta) values for categorical variables"),
-              gettextf("are ignored if parameterization = %s!", "'delta'")
+              gettextf("variance (theta) values for categorical variables 
+                       are ignored if parameterization = %s!",
+                       "'delta'")
             )
           }
         } else if (lavmodel@parameterization == "theta") {
@@ -66,8 +67,9 @@ lav_lavaan_step09_model <- function(slotModel = NULL, # nolint
             lavpartable$user == 1L)
           if (length(user.delta.idx)) {
             lav_msg_warn(
-              gettext("scaling (~*~) values for categorical variables"),
-              gettextf("are ignored if parameterization = %s!", "'theta'")
+              gettextf("scaling (~*~) values for categorical variables 
+                       are ignored if parameterization = %s!", 
+                       "'theta'")
             )
           }
         }

--- a/R/lav_model.R
+++ b/R/lav_model.R
@@ -83,7 +83,9 @@ lav_model <- function(lavpartable = NULL,                          # nolint
   } else if (lavoptions$representation == "RAM") {
     tmp.rep <- lav_ram(lavpartable, target = NULL, extra = TRUE)
   } else {
-    lav_msg_notallowed("representation", c("LISREL", "RAM"))
+    lav_msg_stop(gettextf(
+      "%1$s argument must be either %2$s or %3$s",
+      "representation", "LISREL", "RAM"))
   }
   if (lavoptions$debug) print(tmp.rep)
 
@@ -98,11 +100,10 @@ lav_model <- function(lavpartable = NULL,                          # nolint
       sep = " "
     )
     if (lavoptions$representation == "LISREL") {
-      lav_msg_stop(
-      gettext("a model parameter is not defined in the LISREL representation"),
-      this.formula,
-      gettext("Upgrade to latent variables or consider using representation = 'RAM'.")
-      )
+      lav_msg_stop(gettextf(
+        "a model parameter is not defined in the LISREL representation %s.
+        Upgrade to latent variables or consider using representation = 'RAM'.",
+        this.formula)      )
     } else {
       lav_msg_stop(
         gettextf("parameter is not defined: %s", this.formula)

--- a/R/lav_modification.R
+++ b/R/lav_modification.R
@@ -31,9 +31,9 @@ modindices <- function(object,
   # new in 0.6-17: check if the model contains equality constraints
   if (object@Model@eq.constraints) {
     lav_msg_warn(
-      gettext("the modindices() function ignores equality constraints;"),
-      gettext("use lavTestScore() to assess the impact of releasing one "),
-      gettext("or multiple constraints.")
+      gettext("the modindices() function ignores equality constraints;
+              use lavTestScore() to assess the impact of releasing one or 
+              multiple constraints.")
     )
   }
 
@@ -109,9 +109,8 @@ modindices <- function(object,
   )
   # just in case...
   if (inherits(I22.inv, "try-error")) {
-    lav_msg_stop(
-      gettext("could not compute modification indices;"),
-      gettext("information matrix is singular"))
+    lav_msg_stop(gettext(
+      "could not compute modification indices; information matrix is singular"))
   }
 
   V <- I11 - I12 %*% I22.inv %*% I21

--- a/R/lav_msg.R
+++ b/R/lav_msg.R
@@ -4,6 +4,7 @@
 # via R function 'message()'.
 lav_msg_note <- function(..., showheader = FALSE) {
   wat <- unlist(list(...), use.names = FALSE)
+  if (!showheader) wat <- c("lavaan NOTE: ___", wat)
   message(lav_msg(wat, showheader = showheader), domain = NA)
 }
 
@@ -74,8 +75,13 @@ lav_msg <- function(wat, txt.width = getOption("width", 80L),
   while (nstart <= length(chunks)) {
     while (nstop < length(chunks) &&
            sum(chunk.size[seq.int(nstart, nstop + 1L)]) +
-           nstop - nstart + indent < txt.width) {
+           nstop - nstart + indent < txt.width && chunks[nstop + 1L] != "___") {
       nstop <- nstop + 1
+    }
+    if (nstop < length(chunks) && chunks[nstop + 1L] == "___") { 
+      # forced line break
+      chunks[nstop + 1L] <-  ""
+      nstop <- nstop + 1L
     }
     if (nstop < length(chunks)) {
       chunks[nstop + 1L] <- paste0(
@@ -130,55 +136,42 @@ lav_msg_view <- function(x,
   }
   rv
 }
-# error if argument x is missing
-lav_msg_missing_stop <- function(x) {
-  lav_msg_stop(gettextf("argument %s is missing", x))
-}
-# warning if argument x is missing
-lav_msg_missing_warn <- function(x, usedvalue) {
-  lav_msg_warn(gettextf(
-    "argument %1$s is missing, using %2$s.",
-    x, lav_msg_view(usedvalue)
-  ))
-}
-# error if length of an argument x is greater then 1 and cannot be
-lav_msg_only1_stop <- function(x) {
-  lav_msg_stop(gettextf("argument %s cannot have more than one element", x))
-}
-# warning if length of an argument x is greater then 1 and cannot be
-lav_msg_only1_warn <- function(x, xvalue) {
-  lav_msg_warn(gettextf("%1$s argument should be a single character string.
-  Only the first one (%2$s) is used.", x, xvalue[[1]]))
-}
-# error if argument is unknown (show value)
-lav_msg_unknown <- function(x, xvalue) {
-  lav_msg_stop(gettextf(
-    "%1$s argument unknown: %2$s",
-    x, lav_msg_view(xvalue)
-  ))
-}
-# error if argument isn't one of the allowed values, show values allowed
-lav_msg_notallowed <- function(x, allowed) {
-  if (length(allowed) == 2L) {
-    lav_msg_stop(gettextf(
-      "%1$s argument must be either %2$s",
-      x, lav_msg_view(allowed, "or")
-    ))
-  } else {
-    lav_msg_stop(gettextf(
-      "%1$s argument must be one of %2$s",
-      x, lav_msg_view(allowed, "or")
-    ))
-  }
-}
-# error if argument isn't one of the allowed values (show invalid ones)
-lav_msg_notallowed_multi <- function(x, invalids) {
-  lav_msg_stop(sprintf(
-    ngettext(
-      length(invalids),
-      "invalid value in %1$s argument: %2$s.",
-      "invalid values in %1$s argument: %2$s."
-    ),
-    x, lav_msg_view(invalids, log.sep = "none")
-  ))
-}
+#  ---------------  examples of use ----------------------
+# # warning if argument x is missing
+#   lav_msg_warn(gettextf(
+#     "argument %1$s is missing, using %2$s.",
+#     x, lav_msg_view(usedvalue)
+#   ))
+# 
+# # warning if length of an argument x is greater then 1 and cannot be
+#   lav_msg_warn(gettextf("%1$s argument should be a single character string.
+#   Only the first one (%2$s) is used.", xname, x[[1]]))
+# 
+# # error if argument is unknown (show value)
+#   lav_msg_stop(gettextf(
+#     "%1$s argument unknown: %2$s",
+#     xname, lav_msg_view(xvalue)
+#   ))
+# 
+# # error if argument isn't one of the allowed values, show values allowed
+#   if (length(allowed) == 2L) {
+#     lav_msg_stop(gettextf(
+#       "%1$s argument must be either %2$s",
+#       x, lav_msg_view(allowed, "or")
+#     ))
+#   } else {
+#     lav_msg_stop(gettextf(
+#       "%1$s argument must be one of %2$s",
+#       x, lav_msg_view(allowed, "or")
+#     ))
+#   }
+# 
+# # error if argument isn't one of the allowed values (show invalid ones)
+#   lav_msg_stop(sprintf(
+#     ngettext(
+#       length(invalids),
+#       "invalid value in %1$s argument: %2$s.",
+#       "invalid values in %1$s argument: %2$s."
+#     ),
+#     x, lav_msg_view(invalids, log.sep = "none")
+#   ))

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -43,7 +43,8 @@ lavInspect.lavaan <- function(object,                                # nolint
 
   # only a single argument
   if (length(what) > 1) {
-    lav_msg_only1_stop("what")
+    lav_msg_stop(gettextf("argument %s cannot have more than one element", 
+                          "what"))
   }
 
   # be case insensitive
@@ -623,7 +624,10 @@ lavInspect.lavaan <- function(object,                                # nolint
 
     #### not found ####
   } else {
-    lav_msg_unknown("what", what)
+    lav_msg_stop(gettextf(
+      "%1$s argument unknown: %2$s",
+      "what", lav_msg_view(what)
+    ))
   }
 
 }
@@ -804,7 +808,10 @@ lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
         m.el.idx <- object@Model@m.user.idx[[mm]]
         x.el.idx <- object@Model@x.user.idx[[mm]]
       } else {
-        lav_msg_unknown("type", type)
+        lav_msg_stop(gettextf(
+          "%1$s argument unknown: %2$s",
+          "type", lav_msg_view(type)
+        ))
       }
       # erase everything
       glist[[mm]][, ] <- 0.0
@@ -2614,9 +2621,8 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
       return.value <- return.value[!dup.flag, !dup.flag, drop = FALSE]
     } else {
       lav_msg_warn(
-        gettext("alias is TRUE,"),
-        gettext("but equality constraints do not appear to be simple;"),
-        gettext("returning full vcov"))
+        gettext("alias is TRUE, but equality constraints do not appear
+                to be simple; returning full vcov"))
     }
   }
 
@@ -2994,7 +3000,9 @@ lav_object_inspect_coef <- function(object, type = "free",
     #idx <- which(object@ParTable$free > 0L & !duplicated(object@ParTable$free))
     idx <- which(object@ParTable$free > 0L)
   } else {
-    lav_msg_notallowed("type", c("free", "user"))
+    lav_msg_stop(gettextf(
+      "%1$s argument must be either %2$s or %3$s",
+      "type", "free", "user"))
   }
   tmp.est <- lav_object_inspect_est(object)
   cof <- tmp.est[idx]

--- a/R/lav_object_methods.R
+++ b/R/lav_object_methods.R
@@ -1280,8 +1280,8 @@ setMethod(
     ## is a parameter table, so update the parameter table in the call
     if (!(mode(add) %in% c("list", "character"))) {
       lav_msg_stop(
-        gettext("'add' argument must be model syntax or parameter table."),
-        gettext("See ?lavaanify help page.")
+        gettext("'add' argument must be model syntax or parameter table.
+                See ?lavaanify help page.")
       )
     }
     tmp.pt <- lav_object_extended(newfit, add = add)@ParTable

--- a/R/lav_optim_noniter.R
+++ b/R/lav_optim_noniter.R
@@ -11,15 +11,13 @@ lav_optim_noniter <- function(lavmodel = NULL, lavsamplestats = NULL,
 
   # no support for many things:
   if (lavmodel@ngroups > 1L) {
-    lav_msg_stop(
-      gettext("multiple groups not supported (yet)"),
-      gettext("with optim.method = 'NONITER'."))
+    lav_msg_stop(gettext(
+      "multiple groups not supported (yet) with optim.method = 'NONITER'."))
   }
 
   if (lavdata@nlevels > 1L) {
-    lav_msg_stop(
-      gettext("multilevel not supported (yet)"),
-      gettext("with optim.method = 'NONITER'."))
+    lav_msg_stop(gettext(
+      "multilevel not supported (yet) with optim.method = 'NONITER'."))
   }
 
   # no support (yet) for nonlinear constraints
@@ -28,23 +26,23 @@ lav_optim_noniter <- function(lavmodel = NULL, lavsamplestats = NULL,
     lavmodel@cin.nonlinear.idx
   )
   if (length(nonlinear.idx) > 0L) {
-    lav_msg_stop(
-      gettext("nonlinear constraints not supported (yet)"),
-      gettext("with optim.method = 'NONITER'."))
+    lav_msg_stop(gettext(
+      "nonlinear constraints not supported (yet) with optim.method = 'NONITER'."
+      ))
   }
 
   # no support (yet) for inequality constraints
   if (!is.null(body(lavmodel@cin.function))) {
-    lav_msg_stop(
-      gettext("inequality constraints not supported (yet)"),
-      gettext("with optim.method = 'NONITER'."))
+    lav_msg_stop(gettext(
+    "inequality constraints not supported (yet) with optim.method = 'NONITER'."
+    ))
   }
 
   # no support (yet) for equality constraints
   if (length(lavmodel@ceq.linear.idx) > 0L) {
-    lav_msg_stop(
-      gettext("equality constraints not supported (yet)"),
-      gettext("with optim.method = 'NONITER'."))
+    lav_msg_stop(gettext(
+      "equality constraints not supported (yet) with optim.method = 'NONITER'."
+      ))
   }
 
   # extract current set of free parameters
@@ -93,8 +91,8 @@ lav_optim_noniter <- function(lavmodel = NULL, lavsamplestats = NULL,
     ), silent = TRUE)
   } else {
     lav_msg_warn(
-      gettextf("unknown (noniterative) estimator: %s", lavoptions$estimator),
-      gettext("(returning starting values)")
+      gettextf("unknown (noniterative) estimator: %s 
+               (returning starting values)", lavoptions$estimator)
     )
   }
   if (inherits(x, "try-error")) {

--- a/R/lav_options.R
+++ b/R/lav_options.R
@@ -44,7 +44,15 @@ lav_options_checkvalues <- function(optname, optvalue, chr) {
   optvals <- gsub("[_-]", ".", tolower(optvalue))
   optvalsok <- match(optvals, optvalid)
   if (any(is.na(optvalsok))) {
-    lav_msg_notallowed_multi(optname, optvalue[is.na(optvalsok)])
+    lav_msg_stop(sprintf(
+      ngettext(
+        length(optvalue[is.na(optvalsok)]),
+        "invalid value in %1$s option: %2$s.",
+        "invalid values in %1$s option: %2$s."
+      ),
+      optname, 
+      lav_msg_view(optvalue[is.na(optvalsok)], log.sep = "none")
+    ))
   }
   as.vector(chr[optvalsok])
 }
@@ -85,9 +93,10 @@ lav_options_check <- function(opts, opt.check, subname) {    # nolint
           paste0(subname, opt.name), opt.check1$oklen[2]))
       } else {
         lav_msg_warn(gettextf(
-          "Length of option '%1$s' value should be maximum %2$s;",
+          "Length of option '%1$s' value should be maximum %2$s.
+          Only first %3$s elements used.",
           paste0(subname, opt.name), -opt.check1$oklen[2]),
-          gettextf("Only first %s elements used.", -opt.check1$oklen[2]))
+          -opt.check1$oklen[2])
       }
     }
     if (is.null(opt.check1$bl)) opt.check1$bl <- FALSE
@@ -470,8 +479,8 @@ lav_options_set <- function(opt = NULL) {                     # nolint
     # test
     if (length(opt$test) > 1L) {
       lav_msg_warn(gettextf(
-        "test= argument can only contain a single element if missing = %s ",
-        dQuote(opt$missing)), gettext("(taking the first)"))
+        "test= argument can only contain a single element if missing = %s 
+        (taking the first)"), dQuote(opt$missing))
       opt$test <- opt$test[1]
     }
 
@@ -867,17 +876,15 @@ lav_options_set <- function(opt = NULL) {                     # nolint
     "bollen.stine"
   ))
   if (length(wrong.idx) > 0L) {
-    lav_msg_stop(
-      gettextf("invalid option(s) for test argument: %s.",
-               paste(dQuote(opt$test[wrong.idx]), collapse = " ")),
-      gettextf(" Possible options are: %s.",
-               lav_msg_view(c("none", "standard", "browne.residual.adf",
-                              "browne.residual.nt", "browne.residual.adf.model",
-                              "browne.residual.nt.model", "satorra.bentler",
-                              "yuan.bentler", "yuan.bentler.mplus",
-                              "mean.var.adjusted", "scaled.shifted",
-                              "bollen.stine"), log.sep = "or"))
-    )
+    lav_msg_stop(gettextf(
+    "invalid option(s) for test argument: %1$s. Possible options are: %2$s.",
+    lav_msg_view(opt$test[wrong.idx]),
+    lav_msg_view(c("none", "standard", "browne.residual.adf",
+                    "browne.residual.nt", "browne.residual.adf.model",
+                    "browne.residual.nt.model", "satorra.bentler",
+                    "yuan.bentler", "yuan.bentler.mplus",
+                    "mean.var.adjusted", "scaled.shifted",
+                    "bollen.stine"), log.sep = "or")))
   }
 
   # bounds
@@ -902,8 +909,8 @@ lav_options_set <- function(opt = NULL) {                     # nolint
       opt$bounds <- "user"
     } else {
       lav_msg_stop(
-        gettext("bounds and optim.bounds arguments can not be used together;"),
-        gettext("remove the bounds= argument or set it to \"user\".")
+        gettext("bounds and optim.bounds arguments can not be used together;
+                remove the bounds= argument or set it to \"user\".")
       )
     }
   }

--- a/R/lav_options_estimator.R
+++ b/R/lav_options_estimator.R
@@ -274,10 +274,9 @@ lav_options_est_dwls <- function(opt) {
   # new in 0.6-17: if !categorical, give a warning
   if (!opt$.categorical) {
     lav_msg_warn(gettextf(
-      "estimator %s is not recommended for continuous data. ",
-      dQuote(lav_options_estimatorgroup(opt$estimator))),
-      gettext("Did you forget to set the ordered= argument?"
-      ))
+      "estimator %s is not recommended for continuous data.
+      Did you forget to set the ordered= argument?",
+      dQuote(lav_options_estimatorgroup(opt$estimator))))
   }
   # se
   if (opt$se == "bootstrap" &&

--- a/R/lav_partable_bounds.R
+++ b/R/lav_partable_bounds.R
@@ -83,8 +83,8 @@ lav_partable_add_bounds <- function(partable = NULL,
       } else if (length(optim.bounds$lower.factor) !=
         length(optim.bounds$lower)) {
         lav_msg_stop(
-          gettext("length(optim.bounds$lower.factor) is not equal to"),
-          gettext("length(optim.bounds$lower)")
+          gettext("length(optim.bounds$lower.factor) is not equal to
+                  length(optim.bounds$lower)")
         )
       }
     }
@@ -102,8 +102,8 @@ lav_partable_add_bounds <- function(partable = NULL,
       } else if (length(optim.bounds$upper.factor) !=
         length(optim.bounds$upper)) {
         lav_msg_stop(
-          gettext("length(optim.bounds$lower.factor) is not equal to"),
-          gettext("length(optim.bounds$upper)")
+          gettext("length(optim.bounds$lower.factor) is not equal to
+                  length(optim.bounds$upper)")
         )
       }
     }

--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -194,8 +194,8 @@ lav_predict_internal <- function(lavmodel = NULL,
       new.ordered.lev <- newData@ov$nlev[match.new.idx]
       if (any(orig.ordered.lev - new.ordered.lev != 0)) {
         lav_msg_stop(
-          gettext("mismatch number of categories for some ordered variables"),
-          gettext("in newdata compared to original data.")
+          gettext("mismatch number of categories for some ordered variables
+                  in newdata compared to original data.")
         )
       }
     }
@@ -206,7 +206,8 @@ lav_predict_internal <- function(lavmodel = NULL,
 
   if (type == "lv") {
     if (!is.null(ETA)) {
-      lav_msg_warn(gettext("lvs will be predicted here; supplying ETA has no effect"))
+      lav_msg_warn(gettext("lvs will be predicted here; 
+                           supplying ETA has no effect"))
     }
 
     # post fit check (lv pd?)
@@ -310,8 +311,8 @@ lav_predict_internal <- function(lavmodel = NULL,
         FS.cov.inv <- try(solve(FS.cov), silent = TRUE)
         if (inherits(FS.cov.inv, "try-error")) {
           lav_msg_warn(
-            gettext("could not invert (co)variance matrix of factor scores;"),
-            gettext("returning original factor scores."))
+            gettext("could not invert (co)variance matrix of factor scores;
+                    returning original factor scores."))
           return(out[[g]])
         }
         fs.inv.sqrt <- lav_matrix_symmetric_sqrt(FS.cov.inv)
@@ -1386,7 +1387,8 @@ lav_predict_eta_ebm_ml <- function(lavobject = NULL, # for convenience
   for (g in seq_len(lavdata@ngroups)) {
     if (any(diag(THETA[[g]]) == 0)) {
       lav_msg_stop(gettext(
-        "(residual) variance matrix THETA contains zero elements on the diagonal."))
+        "(residual) variance matrix THETA contains zero elements
+        on the diagonal."))
     }
   }
 
@@ -1462,8 +1464,8 @@ lav_predict_eta_ebm_ml <- function(lavobject = NULL, # for convenience
     neg.var.idx <- which(diag(THETA[[g]]) < 0)
     if (length(neg.var.idx) > 0) {
       lav_msg_warn(
-        gettext("factor scores could not be computed due to"),
-        gettext("at least one negative (residual) variance"))
+        gettext("factor scores could not be computed due to at least
+                one negative (residual) variance"))
       next
     }
 

--- a/R/lav_samplestats_gamma.R
+++ b/R/lav_samplestats_gamma.R
@@ -437,8 +437,8 @@ lav_samplestats_Gamma <- function(Y, # Y+X if cond!
     if (conditional.x || fixed.x || !is.null(Sigma) ||
       !is.null(cluster.idx)) {
       lav_msg_stop(
-        gettext("unbiased Gamma only available for the simple"), gettext(
-        "(not conditional.x or fixed.x or model-based or clustered) setting."))
+        gettext("unbiased Gamma only available for the simple
+        (not conditional.x or fixed.x or model-based or clustered) setting."))
     } else {
       COV <- COV.unbiased <- cov(Y)
       COV <- COV * (N - 1) / N

--- a/R/lav_syntax_parser.R
+++ b/R/lav_syntax_parser.R
@@ -408,8 +408,8 @@ ldw_parse_step2 <- function(modellist, modelsrc, types, debug, warn) {
 ldw_parse_check_valid_name <- function(formul1, ind, modelsrc) {
   if (make.names(formul1$elem.text[ind]) != formul1$elem.text[ind]) {
     lav_msg_stop(
-      gettext("identifier is either a reserved word (in R) or"),
-      gettext("contains an illegal character"),
+      gettext("identifier is either a reserved word (in R) or 
+              contains an illegal character"),
       ldw_txtloc(modelsrc, formul1$elem.pos[ind])
     )
   }
@@ -768,29 +768,26 @@ ldw_parse_model_string <- function(model.syntax = "", as.data.frame. = FALSE,
     if (op == ":") { # ------------------------- block start ------------------
       if (opi == 1L) {
         lav_msg_stop(
-        gettext("Missing block identifier."),
-        gettext("The correct syntax is: \"LHS: RHS\", where LHS is a block"),
-        gettext("identifier (eg group or level), and RHS is the"),
-        gettext("group/level/block number or label."),
+        gettext("Missing block identifier. The correct syntax is: \"LHS: RHS\",
+                where LHS is a block identifier (eg group or level), and RHS is
+                the group/level/block number or label."),
         ldw_txtloc(modelsrc, formul1$elem.pos[1]))
       }
       if (opi > 2L || all(tolower(formul1$elem.text[1]) !=
                           c("group", "level", "block", "class"))) {
         lav_msg_stop(
-        gettext("Invalid block identifier."),
-        gettext("The correct syntax is: \"LHS: RHS\", where LHS is a block"),
-        gettext("identifier (eg group or level), and RHS is the"),
-        gettext("group/level/block number or label."),
+        gettext("Invalid block identifier. The correct syntax is: \"LHS: RHS\",
+                where LHS is a block identifier (eg group or level), and RHS is
+                the group/level/block number or label."),
         ldw_txtloc(modelsrc, formul1$elem.pos[1]))
       }
       if (nelem != 3 || all(formul1$elem.type[3] !=
                 c(types$stringliteral, types$identifier, types$numliteral))) {
         lav_msg_stop(
-        gettext("syntax contains block identifier \"group\" with missing"),
-        gettext("or invalid number/label."),
-        gettext("The correct syntax is: \"LHS: RHS\", where LHS is a block"),
-        gettext("identifier (eg group or level), and RHS is the"),
-        gettext("group/level/block number or label."),
+        gettext("syntax contains block identifier \"group\" with missing or
+                invalid number/label.The correct syntax is: \"LHS: RHS\", where
+                LHS is a block identifier (eg group or level), and RHS is the 
+                group/level/block number or label."),
         ldw_txtloc(modelsrc, formul1$elem.pos[1]))
       }
       flat.idx <- flat.idx + 1L
@@ -824,8 +821,8 @@ ldw_parse_model_string <- function(model.syntax = "", as.data.frame. = FALSE,
       (formul1$elem.type[nelem] != types$numliteral || all(op != c("~", "=~"))))
     {
       lav_msg_stop(
-        gettext("Last element of rhs part expected to be an identifier or,"),
-        gettext("for operator ~ or =~, a numeric literal!"),
+        gettext("Last element of rhs part expected to be an identifier or,
+                for operator ~ or =~, a numeric literal!"),
         ldw_txtloc(modelsrc, formul1$elem.pos[nelem]))
     }
     # intercept fixed on 0
@@ -859,13 +856,12 @@ ldw_parse_model_string <- function(model.syntax = "", as.data.frame. = FALSE,
     # check at most 1 colon
     if (length(colons) > 1) {
       lav_msg_stop(
-        gettext("Three-way or higher-order interaction terms (using multiple"),
-        gettext("colons) are not supported in the lavaan syntax;"),
-        gettext("please manually construct the product terms yourself in the"),
-        gettext("data.frame, give them an appropriate name, and then you can"),
-        gettext("use these interaction variables as any other (observed)"),
-        gettext("variable in the model syntax."),
-        ldw_txtloc(modelsrc, formul1$elem.pos[colons[2]]))
+        gettext("Three-way or higher-order interaction terms (using multiple 
+                colons) are not supported in the lavaan syntax; please manually
+                construct the product terms yourself in the data.frame, give
+                them an appropriate name, and then you can use these interaction
+                variables as any other (observed) variable in the model syntax."
+                ), ldw_txtloc(modelsrc, formul1$elem.pos[colons[2]]))
     }
     if (length(colons) == 1) { # collapse items around colon "a" ":" "b" => "a:b"
       formul1$elem.text[colons - 1L] <-

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -9,8 +9,12 @@ lavTest <- function(lavobject, test = "standard",
                     output = "list", drop.list.single = TRUE) {
   # check output
   output.valid <- c("list", "text")
-  if (!any(output == output.valid)) lav_msg_notallowed("output", output.valid)
-
+  if (!any(output == output.valid)) {
+      lav_msg_stop(gettextf(
+        "%1$s argument must be either %2$s",
+        "output", lav_msg_view(output.valid, "or")
+      ))
+  }
   # extract 'test' slot
   TEST <- lavobject@test
 
@@ -183,21 +187,28 @@ lav_test_rename <- function(test, check = FALSE) {
       "browne.residual.adf.model"
     ))
     if (length(bad.idx) > 0L) {
-      lav_msg_notallowed_multi("test", test[bad.idx])
+      lav_msg_stop(sprintf(
+        ngettext(
+          length(test[bad.idx]),
+          "invalid value in %1$s argument: %2$s.",
+          "invalid values in %1$s argument: %2$s."
+        ),
+        "test", lav_msg_view(test[bad.idx], log.sep = "none")
+      ))
     }
 
     # if 'default' is included, length(test) must be 1
     if (length(test) > 1L && any("default" == test)) {
       lav_msg_stop(
-        gettextf("if test= argument contains \"%s\"", "default"),
-        gettext("it cannot contain additional elements"))
+        gettextf("if test= argument contains \"%s\", it cannot contain
+                 additional elements", "default"))
     }
 
     # if 'none' is included, length(test) must be 1
     if (length(test) > 1L && any("none" == test)) {
       lav_msg_stop(
-        gettextf("if test= argument contains \"%s\"", "none"),
-        gettext("it cannot contain additional elements"))
+        gettextf("if test= argument contains \"%s\" it cannot contain
+                 additional elements", "none"))
     }
   }
 
@@ -549,9 +560,9 @@ lav_model_test <- function(lavobject = NULL,
           unscaled.TEST <- TEST[[idx[1]]]
         } else {
           lav_msg_warn(gettextf(
-            "scaled.test [%s] not found among available (non scaled) tests:",
-            lavoptions$scaled.test), lav_msg_view(test),
-            gettext("Using standard test instead."))
+            "scaled.test [%1$s] not found among available (non scaled) tests:
+            %2$s. Using standard test instead.",
+            lavoptions$scaled.test), lav_msg_view(test))
         }
       }
 
@@ -585,12 +596,11 @@ lav_model_test <- function(lavobject = NULL,
           unscaled.TEST <- TEST[[idx[1]]]
         } else {
           lav_msg_warn(gettextf(
-            "scaled.test [%s] not found among available (non scaled) tests:",
-            lavoptions$scaled.test), lav_msg_view(test),
-            gettext("Using standard test instead."))
-        }
+            "scaled.test [%1$s] not found among available (non scaled) tests:
+            %2$s. Using standard test instead.",
+            lavoptions$scaled.test), lav_msg_view(test))
+          }
       }
-
 
       out <- lav_test_yuan_bentler(
         lavobject = NULL,


### PR DESCRIPTION
put error and warning msgs in one string to translate remove unused lav_msg_ functions, but give examples of use for the developper(s)