### PR TITLE
seperate functions for cfa/sem and growth

### DIFF
--- a/R/lav_lavaan_step00_init.R
+++ b/R/lav_lavaan_step00_init.R
@@ -1,5 +1,4 @@
 lav_lavaan_step00_parameters <- function(matchcall = NULL,
-                                         defaults = NULL,
                                          syscall = NULL,
                                          dotdotdot = NULL) {
   # 1. to resolve a problem where parameter 'cl' is matched to 'cluster'
@@ -27,10 +26,26 @@ lav_lavaan_step00_parameters <- function(matchcall = NULL,
   if (!is.null(mc$cluster)) mc$cluster <- eval(mc$cluster, parent.frame(2))
 
   # default options
-  if (!is.null(defaults)) {
+  if (any(ddd$model.type == c("sem", "cfa", "growth"))) {
+    # default options for sem/cfa or growth
+    defaults <- list(
+      int.ov.free     = ddd$model.type != "growth",
+      int.lv.free     = ddd$model.type == "growth",
+      auto.fix.first  = TRUE, # (re)set in lav_options_set
+      auto.fix.single = TRUE,
+      auto.var        = TRUE,
+      auto.cov.lv.x   = TRUE,
+      auto.cov.y      = TRUE,
+      auto.th         = TRUE,
+      auto.delta      = TRUE,
+      auto.efa        = TRUE
+    )
     for (dflt.i in seq_along(defaults)) {
       argname <- names(defaults)[dflt.i]
-      if (is.null(mc[[argname]])) mc[[argname]] <- defaults[[dflt.i]]
+      if (is.null(mc[[argname]])) {
+        mc[[argname]] <- defaults[[dflt.i]]
+        ddd[[argname]] <- defaults[[dflt.i]]
+      }
     }
   }
 

--- a/R/lav_lavaan_step01_ovnames.R
+++ b/R/lav_lavaan_step01_ovnames.R
@@ -150,7 +150,6 @@ lav_lavaan_step01_ovnames_ovorder <- function(flat.model = NULL,       # nolint
 }
 
 lav_lavaan_step01_ovnames_group <- function(flat.model = NULL,        # nolint
-                                            ov.names   = character(0L),
                                             ngroups    = 1L) {
   # if "group :" appears in flat.model
   #   tmp.group.values: set of names in corresponding right hand sides
@@ -173,7 +172,7 @@ lav_lavaan_step01_ovnames_group <- function(flat.model = NULL,        # nolint
   flat.model.2 <- NULL
   tmp.lav <- NULL
   group.values <- NULL
-
+  ov.names  <- character(0L)
   if (any(flat.model$op == ":" & tolower(flat.model$lhs) == "group")) {
     # here, we only need to figure out:
     # - ngroups

--- a/R/lav_options_default.R
+++ b/R/lav_options_default.R
@@ -96,7 +96,9 @@ lav_options_default <- function() {
     }
   }
   # ------------------------- store options --------------------------
-  elm("model.type", "sem")
+  elm("model.type", "sem", chr = c(lavaan = "lavaan", cfa = "sem",
+            growth = "growth", sem = "sem", efa = "efa", 
+            unrestricted = "unrestricted"))
 
   # global
   elm("mimic", "lavaan", chr = c(default = "lavaan", lavaan = "lavaan",

--- a/R/xxx_lavaan.R
+++ b/R/xxx_lavaan.R
@@ -59,7 +59,6 @@ lavaan <- function(
   mc <- match.call(expand.dots = TRUE)
   temp <- lav_lavaan_step00_parameters(
     matchcall = mc,
-    defaults  = NULL,
     syscall   = sys.call(), # to get main arguments without partial matching
     dotdotdot = list(...)
   )
@@ -112,7 +111,6 @@ lavaan <- function(
   ngroups <- 1L # default value
   temp <- lav_lavaan_step01_ovnames_group(
     flat.model = flat.model,
-    ov.names   = ov.names,
     ngroups    = ngroups
   )
   flat.model <- temp$flat.model
@@ -435,69 +433,55 @@ lavaan <- function(
 
   out
 }
-
-
-# # # # # # # # # # # # #
-# # cfa + sem + growth # #
-# # # # # # # # # # # # #
-growth <- cfa <- sem <- function(
-    # user-specified model: can be syntax, parameter Table
+# # # # # # # # #
+# # cfa + sem # #
+# # # # # # # # #
+cfa <- sem <- function(
+  model = NULL,
+  data = NULL,
+  ordered = NULL,
+  sampling.weights = NULL,
+  sample.cov = NULL,
+  sample.mean = NULL,
+  sample.th = NULL,
+  sample.nobs = NULL,
+  group = NULL,
+  cluster = NULL,
+  constraints = "",
+  WLS.V = NULL, # nolint
+  NACOV = NULL, # nolint
+  ov.order = "model",
+  ...) {
+  sc <- sys.call()
+  sc[["model.type"]] <- quote("sem")
+  # call mother function
+  sc[[1L]] <- quote(lavaan::lavaan)
+  eval(sc, parent.frame())
+}
+# # # # # # # #
+# # growth  # #
+# # # # # # # #
+growth <- function(
     model = NULL,
-    # data (second argument, most used)
     data = NULL,
-    # variable information
     ordered = NULL,
-    # sampling weights
     sampling.weights = NULL,
-    # summary data
     sample.cov = NULL,
     sample.mean = NULL,
     sample.th = NULL,
     sample.nobs = NULL,
-    # multiple groups?
     group = NULL,
-    # multiple levels?
     cluster = NULL,
-    # constraints
     constraints = "",
-    # user-specified variance matrices
     WLS.V = NULL, # nolint
     NACOV = NULL, # nolint
-    # internal order of ov.names
     ov.order = "model",
-    # options (dotdotdot)
     ...) {
-  mc <- match.call(expand.dots = TRUE)
-  # model.type? (cfa or sem or growth)
-  model.type <- as.character(mc[[1L]])
-  if (length(model.type) == 3L) {
-    model.type <- model.type[3L]
-  }
-  # default options for sem/cfa or growth
-  defaults <- list(
-    int.ov.free     = model.type != "growth",
-    int.lv.free     = model.type == "growth",
-    auto.fix.first  = TRUE, # (re)set in lav_options_set
-    auto.fix.single = TRUE,
-    auto.var        = TRUE,
-    auto.cov.lv.x   = TRUE,
-    auto.cov.y      = TRUE,
-    auto.th         = TRUE,
-    auto.delta      = TRUE,
-    auto.efa        = TRUE
-  )
-  temp <- lav_lavaan_step00_parameters(
-    matchcall = mc,
-    defaults  = defaults,
-    syscall   = sys.call(), # to get main arguments without partial matching
-    dotdotdot = list(...)
-  )
-  mc <- temp$mc
-  mc$model.type <- model.type
-
+  sc <- sys.call()
+  sc[["model.type"]] <- quote("growth")
   # call mother function
-  mc[[1L]] <- quote(lavaan::lavaan)
-  eval(mc, parent.frame())
+  sc[[1L]] <- quote(lavaan::lavaan)
+  eval(sc, parent.frame())
 }
 
 # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
functions also made much simpler: call lavaan() via  sys.call() and add model.type; defaults are set in lav_lavaan_step00_parameters() called in lavaan() lav_options_default(): add check for valid value of model.type remove unused parameter  lav_lavaan_step01_ovnames_group