### PR TITLE
print different header for lavaan.mi object

### DIFF
--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -1388,7 +1388,11 @@ print.lavaan.summary <- function(x, ..., nd = 3L) {
 
   # extra fit measures (if present)
   if (!is.null(y$fit)) {
-    print.lavaan.fitMeasures(y$fit, nd = nd, add.h0 = FALSE)
+    add.h0 <- FALSE
+    if (!is.null(attr(y$fit, "add.h0"))) {
+      add.h0 <- attr(y$fit, "add.h0")
+    }
+    print.lavaan.fitMeasures(y$fit, nd = nd, add.h0 = add.h0)
   }
 
   # efa output

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -1390,7 +1390,7 @@ print.lavaan.summary <- function(x, ..., nd = 3L) {
   if (!is.null(y$fit)) {
     add.h0 <- FALSE
     if (!is.null(attr(y$fit, "add.h0"))) {
-      add.h0 <- attr(y$fit, "add.h0")
+      add.h0 <- isTRUE(attr(y$fit, "add.h0"))
     }
     print.lavaan.fitMeasures(y$fit, nd = nd, add.h0 = add.h0)
   }

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -1088,7 +1088,7 @@ print.lavaan.summary <- function(x, ..., nd = 3L) {
   }
   
   #TDJ: print header for lavaan.mi object (or nothing when NULL)
-  cat(y$mi_header)
+  cat(y$top_of_lavaanmi)
   
   # optim
   if (!is.null(y$optim)) {

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -1088,7 +1088,7 @@ print.lavaan.summary <- function(x, ..., nd = 3L) {
   }
   
   #TDJ: print header for lavaan.mi object (or nothing when NULL)
-  cat(y$header.mi)
+  cat(y$mi_header)
   
   # optim
   if (!is.null(y$optim)) {

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -1086,7 +1086,10 @@ print.lavaan.summary <- function(x, ..., nd = 3L) {
       }
     }
   }
-
+  
+  #TDJ: print header for lavaan.mi object (or nothing when NULL)
+  cat(y$header.mi)
+  
   # optim
   if (!is.null(y$optim)) {
     estimator <- y$optim$estimator


### PR DESCRIPTION
The `$header` portion of `print.lavaan.summary()` is not all appropriate for a lavaan.mi object, and it uses some internal functions I cannot access.  To simplify this for the `lavaan.summary` object returned by `lavaan_mi_object_summary()`, I simply add a `$header.mi` element that is a character string to `cat()`.  When it is NULL, then nothing will be printed, so this doesn't interfere with the usual `print.lavaan.summary()` business.