### PR TITLE
center ordinal lvs during lavPredict() optimization

### DIFF
--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -1396,12 +1396,12 @@ lav_predict_eta_ebm_ml <- function(lavobject = NULL, # for convenience
   f.eta.i <- function(x, y.i, x.i, mu.i) {
     # add 'dummy' values (if any) for ov.y
     if (length(lavmodel@ov.y.dummy.lv.idx[[g]]) > 0L) {
-      x2 <- c(x, data.obs[[g]][i,
+      x2 <- c(x - mu.i, data.obs[[g]][i,
         lavmodel@ov.y.dummy.ov.idx[[g]],
         drop = FALSE
       ])
     } else {
-      x2 <- x
+      x2 <- x - mu.i
     }
 
     # conditional density of y, given eta.i(=x)


### PR DESCRIPTION
Hi Yves, here is a small issue I discovered in lavPredict() with ordinal variables.

The optimization step involves predictions from the standard normal cdf [here.](https://github.com/yrosseel/lavaan/blob/5029c2ba09631edf9d2ec31a9befcc1a77557511/R/lav_predict.R#L1857) This works most of the time because the lv mean (alpha) is usually fixed to 0. But it doesn't work when the lv mean is nonzero, which might happen in some multi-group models or in the silly model below that fixes the lv mean to 3. So the pull request explicitly centers the lvs by alpha before they get sent to the `pnorm()` lines.

```r
data(Science, package = 'mirt')

m1 <- ' f1 =~ Comfort + Work + Future + Benefit
             f1 ~ 3*1 '

fit <- cfa(m1, data = Science, ordered = TRUE, std.lv = TRUE)
lvs <- lavPredict(fit)
summary(lvs[,1]) ## mean is near 1 in 0.6-17
```