### PR TITLE
add vcov(standardized=, free.only=) arguments

### DIFF
--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -2610,7 +2610,9 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
     # } else {
     colnames(return.value) <- rownames(return.value) <-
       lav_partable_labels(object@ParTable,
-                          type = ifelse(free.only, "free", "user"))
+                          ## add "user" labels?
+                          type = ifelse(standardized && !free.only,
+                                        "user", "free"))
     # }
   }
 

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -2609,7 +2609,8 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
     #    # todo
     # } else {
     colnames(return.value) <- rownames(return.value) <-
-      lav_partable_labels(object@ParTable, type = "free")
+      lav_partable_labels(object@ParTable,
+                          type = ifelse(free.only, "free", "user"))
     # }
   }
 

--- a/R/lav_object_methods.R
+++ b/R/lav_object_methods.R
@@ -1140,6 +1140,12 @@ setMethod(
       lav_msg_stop(gettext("vcov not available if se=\"none\""))
     }
 
+    ## verify there are any user-defined parameters
+    #FIXME? smarter to check @ParTable for $op == ":="?
+    if (is.null(formals(object@Model@def.function))) {
+      type <- "free" # avoids error in lav_object_inspect_vcov_def()
+    }
+    
     if (type == "user" || type == "joint" || type == "all" || type == "full" ||
       type == "complete") {
       if (remove.duplicated) {

--- a/R/lav_object_methods.R
+++ b/R/lav_object_methods.R
@@ -1130,7 +1130,8 @@ setMethod(
 
 setMethod(
   "vcov", "lavaan",
-  function(object, type = "free", labels = TRUE, remove.duplicated = FALSE) {
+  function(object, type = "free", labels = TRUE, remove.duplicated = FALSE, 
+           standardized = NULL, free.only = TRUE) {
     # check for convergence first!
     if (object@optim$npar > 0L && !object@optim$converged) {
       lav_msg_stop(gettext("model did not converge"))
@@ -1146,6 +1147,11 @@ setMethod(
       type <- "free" # avoids error in lav_object_inspect_vcov_def()
     }
     
+    if (!is.null(standardized)) {
+      standardized <- tolower(standardized[1])
+      stopifnot(standardized %in% c("std.lv","std.all","std.nox"))
+    }
+    
     if (type == "user" || type == "joint" || type == "all" || type == "full" ||
       type == "complete") {
       if (remove.duplicated) {
@@ -1155,11 +1161,16 @@ setMethod(
       }
       tmp.varcov <- lav_object_inspect_vcov_def(object,
         joint = TRUE,
+        standardized = !is.null(standardized),
+        type = ifelse(is.null(standardized), "std.all", standardized),
         add.labels = labels,
         add.class = TRUE
       )
     } else if (type == "free") {
       tmp.varcov <- lav_object_inspect_vcov(object,
+        standardized = !is.null(standardized),
+        type = ifelse(is.null(standardized), "std.all", standardized),
+        free.only = free.only,
         add.labels = labels,
         add.class = TRUE,
         remove.duplicated = remove.duplicated


### PR DESCRIPTION
I’m working on some lavaan.mi functionality in `semTools::monteCarloCI()`, which requires the full `vcov()` for a standardized solution.  When I last visited, I worked out a hack for `standardizedSolution.mi()` by creating a fake lavaan object with pooled results inside it.  That object can also be passed to the workhorse:

```
lav_object_inspect_vcov(fit, standardized = TRUE, free.only = FALSE)
```

But that is not a public function.  I explored 2 possibilities to call it indirectly via public functions, both of which have a limitation I need to circumvent:

- Running `lavInspect(fit, "vcov.std.all")` only sets `free.only=TRUE`, without any way to pass more arguments via `...` because `lavInspect()` only has a `what=` argument.  It does not seem optimal to create even more `what=` options with long names to allow for the combination with defined/joint output.
- The `vcov()` method does not have a `free.only=` argument (`type="free"` only indicates whether user-defined parameters are included), nor a `standardized=` argument.  This seems like a better candidate, because there are already some other undocumented arguments (which CRAN doesn't seem to care about, since you define the method within the `setMethod()` call).

This PR adds these 2 arguments to your `vcov()` method to pass them to `lav_object_inspect_vcov()`.  I left these new arguments undocumented (like the existing ones) to avoid advertising them.
