### PR TITLE
lav_test_print() skips $stat.group when NULL

### DIFF
--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -715,8 +715,8 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
   newTEST <- lav_obj_h0@test
 
   ## assemble a call to lavTestLRT()
-  lrtCallTemplate <- list(quote(lavTestLRT), object = quote(lav_obj_h1),
-                          quote(lav_obj_h0)) # in ...
+  lrtCallTemplate <- list(quote(lavTestLRT), object = quote(lav_obj_h0),
+                          quote(lav_obj_h1)) # in ...
 
   ## can only update tests available in both objects
   testNames0 <- names(lav_obj_h0@test)

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -723,8 +723,6 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
   testNames1 <- names(lav_obj_h1@test)
   testNames <- intersect(testNames0, testNames1)
 
-  # copyScaled <- FALSE # in case scaled test is NA (when standard == 0)
-  
   ## loop over those tests
   for (tn in testNames) {
     lrtCall <- lrtCallTemplate
@@ -742,16 +740,6 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
     } else if (tn %in% c("satorra.bentler",
                          "yuan.bentler","yuan.bentler.mplus")) {
       lrtCall$test <- tn
-      
-      ## is LRT even necessary?
-      # noScaledStat    <- is.na(lav_obj_h0@test[[tn]]$stat)
-      # noScalingFactor <- is.na(lav_obj_h0@test[[tn]]$scaling.factor)
-      # perfectFit      <- isTRUE( all.equal(lav_obj_h0@test$standard$stat, 0) )
-      # 
-      # if (perfectFit && (noScaledStat || noScalingFactor)) {
-      #   copyScaled <- TRUE
-      # }
-      
     } else if (grepl(pattern = "browne", x = tn)) {
       lrtCall$type <- tn
     } else {
@@ -761,17 +749,6 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
     }
 
     ## get new test
-    # if (tn %in% c("satorra.bentler", "yuan.bentler", "yuan.bentler.mplus")
-    #     && copyScaled) {
-    #   ## Don't run lavTestLRT(). Keep existing H0 test stat to avoid error.
-    #   ## But adjust df
-    #   newTEST[[tn]]$df <- lav_obj_h0@test[[tn]]$df - lav_obj_h1@test[[tn]]$df
-    #   ## for RMSEA, reverse-engineer $trace.UGamma from $scaling.factor & new df
-    #   newTEST[[tn]]$trace.UGamma <- newTEST[[tn]]$df * newTEST[[tn]]$scaling.factor
-    #   ## skip the rest of this loop
-    #   next 
-    #   
-    # } else 
     if (lav_obj_h0@test[[1]]$df == lav_obj_h1@test[[1]]$df) {
       ## suppress warning about == df
       ANOVA <- suppressWarnings(eval(as.call(lrtCall)))

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -723,7 +723,7 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
   testNames1 <- names(lav_obj_h1@test)
   testNames <- intersect(testNames0, testNames1)
 
-  copyScaled <- FALSE # in case scaled test is NA (when standard == 0)
+  # copyScaled <- FALSE # in case scaled test is NA (when standard == 0)
   
   ## loop over those tests
   for (tn in testNames) {
@@ -736,6 +736,7 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
         lrtCall$method <- "mean.var.adjusted.PLRT"
       } else {
         lrtCall$method <- "satorra.2000"
+        if (tn == "mean.var.adjusted") lrtCall$scaled.shifted <- FALSE
       }
       lrtCall$scaled.shifted <- tn == "scaled.shifted"
     } else if (tn %in% c("satorra.bentler",
@@ -743,13 +744,13 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
       lrtCall$test <- tn
       
       ## is LRT even necessary?
-      noScaledStat    <- is.na(lav_obj_h1@test[[tn]]$stat)
-      noScalingFactor <- is.na(lav_obj_h1@test[[tn]]$scaling.factor)
-      perfectFit      <- isTRUE( all.equal(lav_obj_h1@test$standard$stat, 0) )
-      
-      if (perfectFit && (noScaledStat || noScalingFactor)) {
-        copyScaled <- TRUE
-      }
+      # noScaledStat    <- is.na(lav_obj_h0@test[[tn]]$stat)
+      # noScalingFactor <- is.na(lav_obj_h0@test[[tn]]$scaling.factor)
+      # perfectFit      <- isTRUE( all.equal(lav_obj_h0@test$standard$stat, 0) )
+      # 
+      # if (perfectFit && (noScaledStat || noScalingFactor)) {
+      #   copyScaled <- TRUE
+      # }
       
     } else if (grepl(pattern = "browne", x = tn)) {
       lrtCall$type <- tn
@@ -760,17 +761,18 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
     }
 
     ## get new test
-    if (tn %in% c("satorra.bentler", "yuan.bentler", "yuan.bentler.mplus")
-        && copyScaled) {
-      ## Don't run lavTestLRT(). Keep existing H0 test stat to avoid error.
-      ## But adjust df
-      newTEST[[tn]]$df <- newTEST[[tn]]$df - lav_obj_h1@test[[tn]]$df
-      ## for RMSEA, reverse-engineer $trace.UGamma from $scaling.factor & new df
-      newTEST[[tn]]$trace.UGamma <- newTEST[[tn]]$df * newTEST[[tn]]$scaling.factor
-      ## skip the rest of this loop
-      next 
-      
-    } else if (lav_obj_h0@test[[1]]$df == lav_obj_h1@test[[1]]$df) {
+    # if (tn %in% c("satorra.bentler", "yuan.bentler", "yuan.bentler.mplus")
+    #     && copyScaled) {
+    #   ## Don't run lavTestLRT(). Keep existing H0 test stat to avoid error.
+    #   ## But adjust df
+    #   newTEST[[tn]]$df <- lav_obj_h0@test[[tn]]$df - lav_obj_h1@test[[tn]]$df
+    #   ## for RMSEA, reverse-engineer $trace.UGamma from $scaling.factor & new df
+    #   newTEST[[tn]]$trace.UGamma <- newTEST[[tn]]$df * newTEST[[tn]]$scaling.factor
+    #   ## skip the rest of this loop
+    #   next 
+    #   
+    # } else 
+    if (lav_obj_h0@test[[1]]$df == lav_obj_h1@test[[1]]$df) {
       ## suppress warning about == df
       ANOVA <- suppressWarnings(eval(as.call(lrtCall)))
     } else {

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -734,7 +734,6 @@ lav_update_test_custom_h1 <- function(lav_obj_h0, lav_obj_h1) {
         lrtCall$method <- "mean.var.adjusted.PLRT"
       } else {
         lrtCall$method <- "satorra.2000"
-        if (tn == "mean.var.adjusted") lrtCall$scaled.shifted <- FALSE
       }
       lrtCall$scaled.shifted <- tn == "scaled.shifted"
     } else if (tn %in% c("satorra.bentler",

--- a/R/lav_test_diff.R
+++ b/R/lav_test_diff.R
@@ -205,8 +205,15 @@ lav_test_diff_SatorraBentler2001 <- function(m1, m0, test = 2) {
   T1 <- m1@test[[1]]$stat
   r1 <- m1@test[[1]]$df
   c1 <- m1@test[[test]]$scaling.factor
-  if (r1 == 0) { # saturated model
-    c1 <- 1
+  
+  ## check for situations when scaling.factor would be NA
+  if (r1 == 0) {
+    ## saturated model
+    c1 <- 1 # canceled out by 0 when calculating "cd"
+    
+  } else if (r1 > 0 && isTRUE(all.equal(T1, 0))) {
+    ## perfect fit
+    c1 <- 0 # cancels out r1 when calculating "cd"
   }
 
   T0 <- m0@test[[1]]$stat

--- a/R/lav_test_print.R
+++ b/R/lav_test_print.R
@@ -283,7 +283,7 @@ lav_test_print <- function(object, nd = 3L) {
             justify = "right"
           )
         } else {
-          tmp <- sprintf(num.format, TEST[[scaled.idx]]$stat.group[g])
+          tmp <- sprintf(num.format, TEST[[block]]$stat.group[g])
           c2[g] <- format(tmp,
             width = 8L + max(0, (nd - 3L)) * 4L,
             justify = "right"

--- a/R/lav_test_print.R
+++ b/R/lav_test_print.R
@@ -271,7 +271,7 @@ lav_test_print <- function(object, nd = 3L) {
 
     # multiple groups?
     ngroups <- ngroups
-    if (ngroups > 1L) {
+    if (ngroups > 1L && !is.null(TEST[[block]]$stat.group)) {
       c1 <- c2 <- c3 <- character(ngroups)
       for (g in 1:ngroups) {
         tmp <- sprintf("  %-40s", group.label[[g]])


### PR DESCRIPTION
When I added `lav_update_test_custom_h1()` in PR #328, I set `$stat.group <- NULL` because when there is a more restricted `h1.model=`, the updated test is only available for the whole model.  This causes an error when `lav_test_print`ing multigroup models that have a hidden `@external$h1.model`.

```
HS.model <- '
    visual  =~ x1 + x2 + x3
    textual =~ x4 + x5 + x6
    speed   =~ x7 + x8 + x9
'
fit1 <- cfa(HS.model, data = HolzingerSwineford1939, group = "school")
fit0 <- cfa(HS.model, data = HolzingerSwineford1939, group = "school", 
            orthogonal = TRUE)
fit0@external$h1.model <- fit1
fit1 # prints group stats
fit0 # no group stats found, error
```

So I just added an additional condition in `lav_test_print()` to only print group stats `if (ngroups > 1L && !is.null(TEST[[block]]$stat.group))`.
