### PR TITLE
Fix for missing scores in case of fiml.

### DIFF
--- a/R/ctr_estfun.R
+++ b/R/ctr_estfun.R
@@ -210,7 +210,7 @@ lav_scores_ml <- function(ntab = 0L,
       score.sigma <- matrix(0, nsub, nvar * (nvar + 1) / 2)
       score.mu <- matrix(0, nsub, nvar)
 
-      for (p in seq_along(length(M))) {
+      for (p in seq_len(length(M))) {
         ## Data
         # X <- M[[p]][["X"]]
         case.idx <- Mp$case.idx[[p]]


### PR DESCRIPTION
When estimating a model with fiml, only the scores of the first missingness-group are reported by lavScores. This is due to the seq_along function always evaluating to 1. I replaced seq_along with seq_len, which fixes the issue.

Example:

```
library(lavaan)

model <- ' 
  # latent variable definitions
     ind60 =~ x1 + x2 + x3
     dem60 =~ y1 + a*y2 + b*y3 + c*y4
     dem65 =~ y5 + a*y6 + b*y7 + c*y8

  # regressions
    dem60 ~ ind60
    dem65 ~ ind60 + dem60
'

PoliticalDemocracy_NA <- PoliticalDemocracy
PoliticalDemocracy_NA[1:5, "x3"] <- NA

# if there are missing data points,.

fit <- sem(model, 
           data = PoliticalDemocracy_NA,
           missing = "ml")
lavScores(fit) |>
  head()
```
Note that the **first five lines are all zeros** because they are skipped in the for-loop.