### PR TITLE
ensure maxcpu is at least 1, for #374

### DIFF
--- a/R/lav_options_default.R
+++ b/R/lav_options_default.R
@@ -406,7 +406,7 @@ lav_options_default <- function() {
   elm("parallel", "no", chr = c(
     "no", "multicore", "snow"
   ))
-  maxcpu <- parallel::detectCores() - 1L
+  maxcpu <- max(1L, parallel::detectCores() - 1L)
   elm("ncpus", maxcpu, nm = paste0("[1,", maxcpu, "]"))
   elm("cl", NULL, oklen = c(0L, 1L))
   elm("iseed", NULL, oklen = c(0L, 1L))


### PR DESCRIPTION
When `parallel::detectCores() == 1`, the defaults currently set the lower bound of `ncpus` to 1 with an upper bound of 0. It can be difficult to satisfy those conditions.