### PR TITLE
add option allow.empty.cell

### DIFF
--- a/R/lav_data.R
+++ b/R/lav_data.R
@@ -557,6 +557,9 @@ lav_data_full <- function(data = NULL, # data.frame
     group <- character(0L)
   }
 
+  # ensure allow.empty.cell is logical
+  if (is.null(allow.empty.cell)) allow.empty.cell <- FALSE
+  
   # sampling weights
   if (!is.null(sampling.weights)) {
     if (is.character(sampling.weights)) {

--- a/R/lav_dataframe.R
+++ b/R/lav_dataframe.R
@@ -12,7 +12,8 @@ lav_dataframe_vartable <- function(frame = NULL, ov.names = NULL,
                                    ov.names.x = NULL,
                                    ordered = NULL,
                                    factor = NULL,
-                                   as.data.frame. = FALSE) {
+                                   as.data.frame. = FALSE,
+                                   allow.empty.cell = FALSE) {
   if (missing(ov.names)) {
     var.names <- names(frame)
   } else {
@@ -58,9 +59,18 @@ lav_dataframe_vartable <- function(frame = NULL, ov.names = NULL,
     # handle ordered/factor
     if (!is.null(ordered) && var.names[i] %in% ordered) {
       type.x <- "ordered"
-      lev <- sort(unique(x)) # we assume integers!
-      nlev[i] <- length(lev)
-      lnam[i] <- paste(lev, collapse = "|")
+      if (allow.empty.cell) {
+        nlev[i] <- max(as.numeric(x))
+        if (inherits(x, 'factor')) {
+          lnam[i] <- paste(levels(x), collapse = "|")
+        } else {
+          lnam[i] <- paste(1:nlev[i], collapse = "|")
+        }
+      } else {
+        lev <- sort(unique(x)) # we assume integers!
+        nlev[i] <- length(lev)
+        lnam[i] <- paste(lev, collapse = "|")
+      }
       user[i] <- 1L
     } else if (!is.null(factor) && var.names[i] %in% factor) {
       type.x <- "factor"

--- a/R/lav_muthen1984.R
+++ b/R/lav_muthen1984.R
@@ -24,6 +24,7 @@ muthen1984 <- function(Data = NULL,
                        zero.keep.margins = TRUE,
                        zero.cell.warn = FALSE,
                        zero.cell.tables = TRUE,
+                       allow.empty.cell = TRUE,
                        group = 1L) { # group only for error messages
 
   # just in case Data is a vector
@@ -58,7 +59,7 @@ muthen1984 <- function(Data = NULL,
   step1 <- lav_samplestats_step1(
     Y = Data, wt = wt, ov.names = ov.names,
     ov.types = ov.types, ov.levels = ov.levels, ov.names.x = ov.names.x,
-    eXo = eXo, scores.flag = WLS.W, group = group
+    eXo = eXo, scores.flag = WLS.W, allow.empty.cell = allow.empty.cell, group = group
   )
 
   FIT <- step1$FIT

--- a/R/lav_options_default.R
+++ b/R/lav_options_default.R
@@ -416,6 +416,7 @@ lav_options_default <- function() {
       nm = "[0, 1]", oklen = c(1L, -2L))
   elm("zero.keep.margins", "default", chr = "default", bl = TRUE)
   elm("zero.cell.warn", FALSE, bl = TRUE) # since 0.6-1
+  elm("allow.empty.cell", FALSE, bl = TRUE) # since 0.6-19
   elm("cat.wls.w", TRUE, bl = TRUE) # since 0.6-18
 
   # starting values (char values checked in lav_options_set())

--- a/R/lav_samplestats.R
+++ b/R/lav_samplestats.R
@@ -27,6 +27,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,
   zero.add <- lavoptions$zero.add
   zero.keep.margins <- lavoptions$zero.keep.margins
   zero.cell.warn <- lavoptions$zero.cell.warn
+  allow.empty.cell <- lavoptions$allow.empty.cell
   dls.a <- lavoptions$estimator.args$dls.a
   dls.GammaNT <- lavoptions$estimator.args$dls.GammaNT
 
@@ -299,7 +300,8 @@ lav_samplestats_from_data <- function(lavdata = NULL,
           zero.add = zero.add,
           zero.keep.margins = zero.keep.margins,
           zero.cell.warn = FALSE,
-          zero.cell.tables = TRUE
+          zero.cell.tables = TRUE,
+          allow.empty.cell = allow.empty.cell
         )
       } else {
         CAT <- muthen1984(
@@ -315,7 +317,8 @@ lav_samplestats_from_data <- function(lavdata = NULL,
           zero.add = zero.add,
           zero.keep.margins = zero.keep.margins,
           zero.cell.warn = FALSE,
-          zero.cell.tables = TRUE
+          zero.cell.tables = TRUE,
+          allow.empty.cell = allow.empty.cell
         )
       }
       lav_verbose(current.verbose)

--- a/man/lavOptions.Rd
+++ b/man/lavOptions.Rd
@@ -458,6 +458,9 @@ Categorical estimation options:
     \item{\code{zero.cell.warn}:}{Logical. Only used if some observed 
       endogenous variables are categorical. If \code{TRUE}, give a warning if 
       one or more cells of a bivariate frequency table are empty.}
+    \item{\code{allow.empty.cell}:}{Logical. If \code{TRUE}, ignore
+      situations where an ordinal variable has fewer categories than
+      expected, or where a category is empty in a specific group.}
 }
 
 Starting values options:


### PR DESCRIPTION
This adds an extra option `allow.empty.cell`, which allows for ordinal variables that are missing some categories. This could involve an empty category in one group of a multi-group model, or a variable of class factor that (say) has 4 levels but only 3 are observed. My goal here is to have lavaan process these ordinal variables, so I can then model them in blavaan (where priors could compensate for the missing categories).

The default is `allow.empty.cell = FALSE`, where everything should work as usual.

For `allow.empty.cell = TRUE`, I had to set arbitrary starting values for the thresholds around empty categories. Assuming a variable with K categories, here is what I did:

Empty category 1: lower threshold -Inf, upper threshold -4
Empty category K: lower threshold 4, upper threshold Inf
Empty other category: upper threshold = .01 + lower threshold