### PR TITLE
Improvements to allow.empty.cell

### DIFF
--- a/R/lav_bvord.R
+++ b/R/lav_bvord.R
@@ -279,7 +279,7 @@ lav_bvord_init_cache <- function(fit.y1 = NULL,
 
   # starting value (for both exo and not-exo)
   # if(is.null(wt)) {
-  if(sd(Y1) == 0 || sd(Y2) == 0) {
+  if(sd(Y1, na.rm = TRUE) == 0 || sd(Y2, na.rm = TRUE) == 0) {
     rho.init <- 0.0
   } else {
     rho.init <- cor(Y1, Y2, use = "pairwise.complete.obs")

--- a/R/lav_bvord.R
+++ b/R/lav_bvord.R
@@ -279,7 +279,11 @@ lav_bvord_init_cache <- function(fit.y1 = NULL,
 
   # starting value (for both exo and not-exo)
   # if(is.null(wt)) {
-  rho.init <- cor(Y1, Y2, use = "pairwise.complete.obs")
+  if(sd(Y1) == 0 || sd(Y2) == 0) {
+    rho.init <- 0.0
+  } else {
+    rho.init <- cor(Y1, Y2, use = "pairwise.complete.obs")
+  }
   # }
   # cov.wt does not handle missing values...
   # rho.init <- cov.wt(cbind(Y1, Y2), wt = wt, cor = TRUE)$cor[2,1]

--- a/R/lav_data.R
+++ b/R/lav_data.R
@@ -979,7 +979,7 @@ lav_data_full <- function(data = NULL, # data.frame
     }
     # check variances per group (if we have multiple groups)
     # to catch zero-variance variables within a group (new in 0.6-8)
-    if (ngroups > 1L && !allow.single.case) {
+    if (ngroups > 1L && !allow.empty.cell) {
       # X
       group.var <- apply(X[[g]], 2, var, na.rm = TRUE)
       zero.var <- which(group.var < .Machine$double.eps)

--- a/R/lav_data.R
+++ b/R/lav_data.R
@@ -979,7 +979,7 @@ lav_data_full <- function(data = NULL, # data.frame
     }
     # check variances per group (if we have multiple groups)
     # to catch zero-variance variables within a group (new in 0.6-8)
-    if (ngroups > 1L) {
+    if (ngroups > 1L && !allow.single.case) {
       # X
       group.var <- apply(X[[g]], 2, var, na.rm = TRUE)
       zero.var <- which(group.var < .Machine$double.eps)

--- a/R/lav_dataframe.R
+++ b/R/lav_dataframe.R
@@ -60,10 +60,11 @@ lav_dataframe_vartable <- function(frame = NULL, ov.names = NULL,
     if (!is.null(ordered) && var.names[i] %in% ordered) {
       type.x <- "ordered"
       if (allow.empty.cell) {
-        nlev[i] <- max(as.numeric(x), na.rm = TRUE)
         if (inherits(x, 'factor')) {
+          nlev[i] <- nlevels(x)
           lnam[i] <- paste(levels(x), collapse = "|")
         } else {
+          nlev[i] <- max(as.numeric(x), na.rm = TRUE)
           lnam[i] <- paste(1:nlev[i], collapse = "|")
         }
       } else {

--- a/R/lav_dataframe.R
+++ b/R/lav_dataframe.R
@@ -60,7 +60,7 @@ lav_dataframe_vartable <- function(frame = NULL, ov.names = NULL,
     if (!is.null(ordered) && var.names[i] %in% ordered) {
       type.x <- "ordered"
       if (allow.empty.cell) {
-        nlev[i] <- max(as.numeric(x))
+        nlev[i] <- max(as.numeric(x), na.rm = TRUE)
         if (inherits(x, 'factor')) {
           lnam[i] <- paste(levels(x), collapse = "|")
         } else {

--- a/R/lav_samplestats_step1.R
+++ b/R/lav_samplestats_step1.R
@@ -107,7 +107,8 @@ lav_samplestats_step1 <- function(Y,
           misidx <- !exidx
           zidx <- y.freq == 0L
           if (y.freq[ov.levels[i]] == 0L) {
-            nhi <- ov.levels[i] - tail( which(diff(zidx) == 1), 1)
+            wdz <- which(diff(zidx) == 1L)
+            nhi <- ov.levels[i] - wdz[length(wdz)]
             exidx[(ov.levels[i] - nhi) : (ov.levels[i] - 1)] <- FALSE
             misidx[(ov.levels[i] - nhi) : (ov.levels[i] - 1)] <- TRUE
           }

--- a/R/lav_uvord.R
+++ b/R/lav_uvord.R
@@ -45,8 +45,14 @@ lav_uvord_fit <- function(y = NULL,
 
   # optim.method
   minObjective <- lav_uvord_min_objective
-  minGradient <- lav_uvord_min_gradient
-  minHessian <- lav_uvord_min_hessian
+  y.ncat <- length(tabulate(y.freq)) # number of response categories
+  if (y.ncat > 1L) {
+    minGradient <- lav_uvord_min_gradient
+    minHessian <- lav_uvord_min_hessian
+  } else {
+    minGradient <- NULL
+    minHessian <- NULL
+  }
   if (optim.method == "nlminb" || optim.method == "nlminb2") {
     # nothing to do
   } else if (optim.method == "nlminb0") {
@@ -198,13 +204,13 @@ lav_uvord_init_cache <- function(y = NULL,
   Y2 <- matrix(1:nth, nobs, nth, byrow = TRUE) == (y - 1L)
 
   # starting values
-  if (nexo == 0L) {
+  if (nexo == 0L && nth > 0L) {
     if (logistic) {
       th.start <- qlogis(cumsum(y.prop[-length(y.prop)]))
     } else {
       th.start <- qnorm(cumsum(y.prop[-length(y.prop)]))
     }
-  } else if (nth == 1L && nexo > 0L) {
+  } else if ((nth == 1L && nexo > 0L) || nth == 0L) {
     th.start <- 0
   } else {
     if (logistic) {

--- a/R/lav_uvord.R
+++ b/R/lav_uvord.R
@@ -45,7 +45,7 @@ lav_uvord_fit <- function(y = NULL,
 
   # optim.method
   minObjective <- lav_uvord_min_objective
-  y.ncat <- length(tabulate(y.freq)) # number of response categories
+  y.ncat <- length(tabulate(y)) # number of response categories
   if (y.ncat > 1L) {
     minGradient <- lav_uvord_min_gradient
     minHessian <- lav_uvord_min_hessian
@@ -200,8 +200,12 @@ lav_uvord_init_cache <- function(y = NULL,
   o2 <- ifelse(y == 1, -100, 0)
 
   # TH matrices (Matrix logical?)
-  Y1 <- matrix(1:nth, nobs, nth, byrow = TRUE) == y
-  Y2 <- matrix(1:nth, nobs, nth, byrow = TRUE) == (y - 1L)
+  if (nth > 0L) {
+    Y1 <- matrix(1:nth, nobs, nth, byrow = TRUE) == y
+    Y2 <- matrix(1:nth, nobs, nth, byrow = TRUE) == (y - 1L)
+  } else {
+    Y1 <- Y2 <- matrix(nrow = nobs, ncol = 0)
+  }
 
   # starting values
   if (nexo == 0L && nth > 0L) {


### PR DESCRIPTION
This contains various improvements to the `allow.empty.cell` option from #377, including better consideration of multiple groups and missing data, and turning off some initial value computations that sometimes do not work for empty categories. This PR should only impact models where the user requests `allow.empty.cell = TRUE`. Improvements were aided by many examples from @jpritikin.