### PR TITLE
Fix dimension mismatch in sam() with multiple endogenous variables for SE

### DIFF
--- a/R/lav_sam_step1_local.R
+++ b/R/lav_sam_step1_local.R
@@ -1060,7 +1060,7 @@ lav_sam_gamma_add <- function(STEP1 = NULL, FIT = NULL, group = 1L) {
 
     # (MTM %x% (tcrossprod(fi) - MTM)) -- part B
     block.b <- lav_matrix_vec(fi %x% MTM) %x% diag(P)
-    long.b <- do.call("rbind", lapply(seq_len(P), function(i) diag(4) %x% MTM[,i])) %x% fi
+    long.b <- do.call("rbind", lapply(seq_len(P), function(i) diag(P) %x% MTM[,i])) %x% fi
     big.b <- block.b + long.b
     part.b <- big.b[lav_matrix_vech(INDEX[keep.idx, keep.idx]),]
 


### PR DESCRIPTION
The function get.JAC.veta2.fi() had a hardcoded dimension (4) that caused errors ("Error in block.b + long.b : non-conformable arrays") when a model had multiple endogenous latent variables where some had interactions/quadratic terms and others didn't. This fix replaces the hardcoded value with the dimension P.
