### PR TITLE
Added faster version of computeSigmaHat

### DIFF
--- a/R/lav_model_compute.R
+++ b/R/lav_model_compute.R
@@ -29,14 +29,14 @@ computeSigmaHat <- function(lavmodel = NULL, GLIST = NULL, extra = FALSE,
     if (lav_debug()) print(Sigma.hat[[g]])
 
     if (extra) {
-      speed <- lavaan_speed_cholesky()
+      speed <- if (exists("lavaan_speed_cholesky")) lavaan_speed_cholesky() else FALSE
       # check if matrix is positive definite
       if (speed) {
         # fast path: try Cholesky directly
         cS <- tryCatch(chol(Sigma.hat[[g]]), error = function(e) NULL)
         is_pd <- !is.null(cS)
       } else {
-        # slow path: eigenvalue-based PD check (values only)
+        # slow path: eigenvalue-based PD check
         ev <- eigen(Sigma.hat[[g]], symmetric = TRUE, only.values = TRUE)$values
         is_pd <- !(any(ev < sqrt(.Machine$double.eps)) || sum(ev) == 0)
       }


### PR DESCRIPTION
As discussed in #438, I started with speeding up `computeSigmaHat`, since I expect this to have the largest impact. The speedup appears to be around 1.5–2× for the entire `lavaan` call (without standard errors and tests).  

This PR is **not meant to be merged into `master` immediately**, more testing is needed. For that reason, I’ve kept the old version and added a switch via a global function (in the spirit of `uselavaanC`). See [this file](https://gist.github.com/karchjd/24a79c4709ced6b35a9b6bec568d95ba) file for details on how to switch between versions, some testing succesful testing of equality, and some benchmarking results. I assume you have a test suite to help further validate the change.  

The main risk is that the Cholesky decomposition failure check may not be fully equivalent to the existing positive-definiteness check based on eigenvalue decomposition. 