### PR TITLE
Sort `def.idx` by dependencies

### DIFF
--- a/R/lav_partable_constraints.R
+++ b/R/lav_partable_constraints.R
@@ -28,6 +28,13 @@ lav_partable_constraints_def <- function(partable, con = NULL, debug = FALSE,
     }
   }
 
+  # sort order of def.idx by dependencies
+  dep <- lapply(partable$rhs[def.idx], FUN = \(x) all.vars(parse(text=x)))
+  lab.raw <- partable$lhs[def.idx]
+  adj.mat <- matrix(0L, nrow = length(def.idx), ncol = length(def.idx))
+  for (i in seq_along(lab.raw)) adj.mat[lab.raw %in% dep[[i]], i] <- 1L
+  def.idx <- def.idx[order_adj_mat(adj.mat)]
+
   # create function
   formals(def.function) <- alist(.x. = , ... = )
   if (txtOnly) {
@@ -540,4 +547,33 @@ lav_partable_constraints_label_id <- function(partable, con = NULL,
   names(con.x.idx) <- con.labels
 
   con.x.idx
+}
+
+order_adj_mat <- function(adj.mat) {
+  A <- adj.mat
+  n <- nrow(A)
+
+  ordered <- c()  # Vector to store sorted nodes
+
+  while (length(ordered) < n) {
+    # Compute in-degree as column sums
+    in_degree <- colSums(A)
+
+    # Find nodes with zero in-degree and not already sorted
+    zero_nodes <- which(in_degree == 0 & !(1:n %in% ordered))
+
+    # If there are no zero in-degree nodes, the graph has a cycle
+    if (!length(zero_nodes)) {
+      lav_msg_warn(gettext("unable to sort `:=` parameters, might be non-recursive!"))
+      return(seq_len(n)) # return input order
+    }
+
+    # Add zero in-degree nodes to the sorted list
+    ordered <- c(ordered, zero_nodes)
+
+    # Remove outgoing edges from these nodes
+    A[zero_nodes, ] <- 0
+  }
+
+  ordered
 }


### PR DESCRIPTION
Suggested solution to fix #444

Now `def.idx` is sorted inside of `lav_partable_constraints_def()`.

This example now runs fine for both models:
```r
library(lavaan)

# Works fine
model <- '
  ind60 =~ x1 + x2 + x3
  dem60 =~ y1 + y2 + y3 + y4
  dem65 =~ y5 + y6 + y7 + y8
  dem60 ~ a * ind60
  dem65 ~ b * ind60 + c * dem60

  # Superflous constraints
  sum_abc := a + b + c
  mean_abc := sum_abc / 3

  a == mean_abc
  b == mean_abc
  c == mean_abc
'

fit <- sem(model, data = PoliticalDemocracy)

# No longer fails due to wrong ordering of `:=` parameters
model <- '
  ind60 =~ x1 + x2 + x3
  dem60 =~ y1 + y2 + y3 + y4
  dem65 =~ y5 + y6 + y7 + y8
  dem60 ~ a * ind60
  dem65 ~ b * ind60 + c * dem60

  # Superflous constraints
  mean_abc := sum_abc / 3
  sum_abc := a + b + c

  a == mean_abc
  b == mean_abc
  c == mean_abc
'

fit <- sem(model, data = PoliticalDemocracy)
```

If the parameters defined using the  `:=` operator are non-recursive, the sorting will fail. In that case the original order is kept as is, and a warning is issued.

Here is an example:
```r
model <- '
  ind60 =~ x1 + x2 + x3
  dem60 =~ y1 + y2 + y3 + y4
  dem65 =~ y5 + y6 + y7 + y8
  dem60 ~ a * ind60
  dem65 ~ b * ind60 + c * dem60

  # non-recursive constraits
  mean_abc := sum_abc / 3
  sum_abc := a + b + c + 0 * mean_abc

  a == mean_abc
  b == mean_abc
  c == mean_abc
'

fit <- sem(model, data = PoliticalDemocracy)
#> Error in func(x, ...) : object 'sum_abc' not found
#> In addition: Warning messages:
#> 1: lavaan->order_adj_mat():  
#>    unable to sort `:=` parameters, might be non-recursive! 
#> 2: lavaan->order_adj_mat():  
#>    unable to sort `:=` parameters, might be non-recursive! 
```
There might be a better way to handle the warnings, as this leads to the same warning being issued twice. *non-recursive* might be the wrong term here as well, as it usually refers to the paths in the model, not the dependencies of the model constraints.