### PR TITLE
check for mixed multilevel modifiers

### DIFF
--- a/R/lav_syntax.R
+++ b/R/lav_syntax.R
@@ -17,7 +17,8 @@ lavParseModelString <- function(model.syntax = "", as.data.frame. = FALSE,
   }
   parser <- tolower(parser)
   if (!parser %in% c("old", "new", "c.r")) {
-    lav_msg_stop(gettext("parser= argument should be \"old\", \"new\" or \"c.r\""))
+    lav_msg_stop(gettext("parser= argument should
+     be \"old\", \"new\" or \"c.r\""))
   }
 
   if (parser == "old") {
@@ -28,13 +29,13 @@ lavParseModelString <- function(model.syntax = "", as.data.frame. = FALSE,
     )
   } else if (parser == "c.r") {
     # new parser
-    out <- ldw_parse_model_string_cr(
+    out <- lav_parse_model_string_cr(
       model.syntax = model.syntax,
       as.data.frame. = as.data.frame.
     )
   } else {
     # new parser
-    out <- ldw_parse_model_string(
+    out <- lav_parse_model_string(
       model.syntax = model.syntax,
       as.data.frame. = as.data.frame.
       )
@@ -123,7 +124,7 @@ lav_parse_model_string_orig <- function(model.syntax = "",
   end.idx <- c(start.idx[-1] - 1, length(model))
   model.orig <- model
   model <- character(length(start.idx))
-  for (i in 1:length(start.idx)) {
+  for (i in seq_along(start.idx)) {
     model[i] <- paste(model.orig[start.idx[i]:end.idx[i]], collapse = "")
   }
 
@@ -174,7 +175,7 @@ lav_parse_model_string_orig <- function(model.syntax = "",
   CON <- vector("list", length = 0L)
   BLOCK <- 1L
   BLOCK_OP <- FALSE
-  for (i in 1:length(model)) {
+  for (i in seq_along(model)) {
     x <- model[i]
     if (lav_debug()) {
       cat("formula to parse:\n")
@@ -397,9 +398,9 @@ other (observed) variable in the model syntax. Problematic term is: "),
     if (lav_debug()) print(out)
 
     # for each lhs element
-    for (l in 1:length(lhs.names)) {
+    for (l in seq_along(lhs.names)) {
       # for each rhs element
-      for (j in 1:length(out)) {
+      for (j in seq_along(out)) {
         # catch intercepts
         if (names(out)[j] == "intercept") {
           if (op == "~") {
@@ -546,7 +547,7 @@ other (observed) variable in the model syntax. Problematic term is: "),
 
   # enumerate modifier indices
   mod.idx <- which(FLAT.rhs.mod.idx > 0L)
-  FLAT.rhs.mod.idx[mod.idx] <- 1:length(mod.idx)
+  FLAT.rhs.mod.idx[mod.idx] <- seq_along(mod.idx)
 
   FLAT <- list(
     lhs = FLAT.lhs, op = FLAT.op, rhs = FLAT.rhs,

--- a/R/lav_syntax_parser_cr.R
+++ b/R/lav_syntax_parser_cr.R
@@ -1,5 +1,5 @@
 # -------------------- main parsing function in C or R ----------------------- #
-ldw_parse_model_string_cr <- function(model.syntax = "",
+lav_parse_model_string_cr <- function(model.syntax = "",
                                       as.data.frame. = FALSE) {
   stopifnot(length(model.syntax) > 0L)
   # replace 'strange' tildes (in some locales) (new in 0.6-6)
@@ -25,7 +25,7 @@ ldw_parse_model_string_cr <- function(model.syntax = "",
       lav_msg_stop(gettextf("Internal program error on line %d of C code.",
                             flat[2L]))
     } else {
-      tl <- ldw_txtloc(modelsrc, flat[2L] + 1L)
+      tl <- lav_parse_txtloc(modelsrc, flat[2L] + 1L)
       if (flat[1L] == 21L) { # SPE_ILLNUMLIT
         lav_msg_stop(gettext("Illegal numeric literal"),
                      tl[1L],
@@ -127,12 +127,19 @@ ldw_parse_model_string_cr <- function(model.syntax = "",
                      footer = tl[2L]
         )
       } else if (flat[1L] == 51L) { # SPE_INVALIDEXPRTYP
-        lav_msg_stop(gettext("Incorrrect type for expression!"),
+        lav_msg_stop(gettext("Incorrect type for expression!"),
                      tl[1L],
                      footer = tl[2L]
         )
       } else if (flat[1L] == 52L) { # SPE_LVLGRP
         lav_msg_stop(gettext("groups can not be nested within levels!"),
+                     tl[1L],
+                     footer = tl[2L]
+        )
+      } else if (flat[1L] == 53L) { # SPE_MIXEDMOD
+        lav_msg_stop(gettext(
+          "Combining labels and fixed values in multigroup modifiers
+           isn't allowed!"),
                      tl[1L],
                      footer = tl[2L]
         )
@@ -192,7 +199,7 @@ ldw_parse_model_string_cr <- function(model.syntax = "",
     warns <- attr(flat, "warns")
     attr(flat, "warns") <- NULL
     for (w in warns) {
-      tl <- ldw_txtloc(modelsrc, w[2L] + 1L)
+      tl <- lav_parse_txtloc(modelsrc, w[2L] + 1L)
       if (w[1L] == 101L) { # SPW_OPERATORBLANKS
         lav_msg_warn(gettext("Blancs in lavaan operators are deprecated."),
                      tl[1L],


### PR DESCRIPTION
check for mixed multilevel modifiers, e.g. 'F =~ c(a, 2) * x1' is not allowed 
standardize function names in parser(s)