### PR TITLE
EFA handling `lavMoments` object

### DIFF
--- a/R/xxx_efa.R
+++ b/R/xxx_efa.R
@@ -41,7 +41,7 @@ efa <- function(data = NULL,
   #}
 
   # if data= argument is used, convert to data.frame (eg matrix, tibble, ...)
-  if (!is.null(data)) {
+  if (!is.null(data) && !inherits(data, "lavMoments")) {
     data <- as.data.frame(data)
   }
 


### PR DESCRIPTION
This should hopefully address #468: When using an object of class `lavMoments` (i.e., the output of `lavaan.mi::poolSat`) as the data input in `lavaan::efa`, no longer try to transform such an object to a data frame.