### PR TITLE
Fix LSAM + ESEM standard error computation (issue #487)

### DIFF
--- a/R/lav_sam_step2_se.R
+++ b/R/lav_sam_step2_se.R
@@ -81,6 +81,18 @@ lav_sam_step2_se <- function(FIT = NULL, JOINT = NULL,
       FIT.PA@ParTable$free > 0L)
     step2.rm.idx <- PTS.free[id.idx]
   }
+  
+  # Fix for EFA/ESEM: when rotation is used, FIT.PA@Model@con.jac includes
+  # columns for rotation identification constraints that are not part of
+  # step2.free.idx. These extra columns cause dimension mismatch in
+  # lav_model_information_augment_invert(). Remove them via rm.idx.
+  if (nrow(FIT.PA@Model@con.jac) > 0L) {
+    n_jac_cols <- ncol(FIT.PA@Model@con.jac)
+    n_step2 <- length(step2.free.idx)
+    if (n_jac_cols > n_step2) {
+      step2.rm.idx <- union(step2.rm.idx, (n_step2 + 1):n_jac_cols)
+    }
+  }
 
   # invert augmented information, for I.22 block only
   # new in 0.6-16 (otherwise, eq constraints in struc part are ignored)


### PR DESCRIPTION
Hi Yves,

As mentioned in issue #487, when using sam() with EFA/ESEM and sam.method='local', the constraint Jacobian (con.jac) includes columns for rotation identification parameters that are not part of step2.free.idx. This causes a dimension mismatch in lav_model_information_augment_invert() when computing 'information + crossprod(H)'.

This is probably not the best fix, but it adds extra column indices to step2.rm.idx so they are removed before the matrix operation. Let me know!

# Comparison check

```r
library(lavaan); library(MASS)

set.seed(12345);n <- 300

# 3 factors, 3 indicators each
Sigma1 <- matrix(0.3, 9, 9)
diag(Sigma1) <- 1
Sigma1[1:3, 1:3] <- matrix(0.6, 3, 3); diag(Sigma1)[1:3] <- 1
Sigma1[4:6, 4:6] <- matrix(0.6, 3, 3); diag(Sigma1)[4:6] <- 1
Sigma1[7:9, 7:9] <- matrix(0.6, 3, 3); diag(Sigma1)[7:9] <- 1

# 1 factor, 5 indicators
Sigma2 <- matrix(0.5, 5, 5); diag(Sigma2) <- 1

X <- mvrnorm(n, rep(0, 9), Sigma1); Y <- mvrnorm(n, rep(0, 5), Sigma2)

sim_data <- data.frame(
  x1 = X[,1], x2 = X[,2], x3 = X[,3],
  x4 = X[,4], x5 = X[,5], x6 = X[,6],
  x7 = X[,7], x8 = X[,8], x9 = X[,9],
  y1 = Y[,1], y2 = Y[,2], y3 = Y[,3], y4 = Y[,4], y5 = Y[,5]
)

model <- '
efa("block1")*f1 + efa("block1")*f2 + efa("block1")*f3 =~ 
  x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9

outcome =~ y1 + y2 + y3 + y4 + y5

outcome ~ f1 + f2 + f3
'

# test ESEM + local SAM
result_local <- tryCatch({
  sam(model, data = sim_data,
      mm.list = list(mm1 = c("f1", "f2", "f3"), mm2 = "outcome"),
      sam.method = "local", 
      rotation = "geomin")
}, error = function(e) {
  cat("ERROR:", conditionMessage(e), "\n")
  return(NULL)
})

if (!is.null(result_local)) {
  cat("SAM + ESEM with local method works")
} else {
  stop("fix not working")
}

# validate SEs by comparing with:
# local SAM
local_params <- parameterEstimates(result_local)
local_struct <- local_params[local_params$op == "~", c("lhs", "rhs", "est", "se")]
# global SAM
result_global <- sam(model, data = sim_data,
                     mm.list = list(mm1 = c("f1", "f2", "f3"), mm2 = "outcome"),
                     sam.method = "global")
global_params <- parameterEstimates(result_global)
global_struct <- global_params[global_params$op == "~", c("lhs", "rhs", "est", "se")]
# SEM
result_sem <- sem(model, data = sim_data)
sem_params <- parameterEstimates(result_sem)
sem_struct <- sem_params[sem_params$op == "~", c("lhs", "rhs", "est", "se")]

data.frame(
  parameter = paste(local_struct$lhs, "~", local_struct$rhs),
  est = round(local_struct$est, 4),
  se_local = round(local_struct$se, 4),
  se_global = round(global_struct$se, 4),
  se_sem = round(sem_struct$se, 4),
  ratio_local_global = round(local_struct$se / global_struct$se, 3)
)
```