### PR TITLE
replace MASS::mvrnorm with lav_mvrnorm for cross-machine reproducibility

### DIFF
--- a/R/lav_bootstrap.R
+++ b/R/lav_bootstrap.R
@@ -352,9 +352,9 @@ lav_bootstrap_internal <- function(object = NULL,
         BOOT.idx = BOOT.idx,
         lavoptions = lavoptions
       )
-    } else { # parametric!
+    } else { # parametric! (using sign-invariant method for reproducibility)
       for (g in 1:lavdata@ngroups) {
-        dataX[[g]] <- MASS::mvrnorm(
+        dataX[[g]] <- lav_mvrnorm(
           n = lavdata@nobs[[g]],
           Sigma = Sigma.hat[[g]],
           mu = Mu.hat[[g]]

--- a/R/lav_simulate.R
+++ b/R/lav_simulate.R
@@ -166,9 +166,9 @@ lav_data_simulate <- function(model = NULL,
       }
     }
 
-    # generate normal data
+    # generate normal data (using sign-invariant method for reproducibility)
     tmp <- try(
-      MASS::mvrnorm(
+      lav_mvrnorm(
         n = sample.nobs[b],
         mu = MU, Sigma = COV, empirical = empirical
       ),

--- a/R/lav_simulate_old.R
+++ b/R/lav_simulate_old.R
@@ -287,9 +287,9 @@ lav_data_simulate_old <- function( # user-specified model
       COV <- COV * sample.nobs[g] / (sample.nobs[g] - 1)
     }
 
-    # FIXME: change to rmvnorm once we include the library?
+    # Using sign-invariant method for cross-machine reproducibility
     if (is.null(skewness) && is.null(kurtosis)) {
-      X[[g]] <- MASS::mvrnorm(
+      X[[g]] <- lav_mvrnorm(
         n = sample.nobs[g],
         mu = Mu.hat[[g]],
         Sigma = COV,
@@ -505,8 +505,8 @@ lav_data_valemaurelli1983 <- function(n = 100L, COR, skewness, kurtosis) {
     print(eigen(ICOR)$values)
   }
 
-  # generate Z ## FIXME: replace by rmvnorm once we use that package
-  X <- Z <- MASS::mvrnorm(n = n, mu = rep(0, nvar), Sigma = ICOR)
+  # generate Z (using sign-invariant method for cross-machine reproducibility)
+  X <- Z <- lav_mvrnorm(n = n, mu = rep(0, nvar), Sigma = ICOR)
 
   # transform Z using Fleishman constants
   for (i in 1:nvar) {


### PR DESCRIPTION
## summary

- adds `lav_mvrnorm()` function in `lav_utils.R` as a replacement for `MASS::mvrnorm()`
- replaces all `MASS::mvrnorm()` calls with `lav_mvrnorm()` in bootstrap and simulation code
- fixes cross-machine reproducibility issues when using the same random seed

## problem

`MASS::mvrnorm()` uses eigendecomposition with transformation matrix `sqrt(Lambda) Q'` which is NOT invariant to eigenvector sign flips. different BLAS/LAPACK implementations may produce different eigenvector signs, leading to different samples even with the same seed.

reference: https://blog.djnavarro.net/posts/2025-05-18_multivariate-normal-sampling-floating-point/

## solution

`lav_mvrnorm()` uses the sign-invariant formula `Q sqrt(Lambda) Q'` (following `mvtnorm::rmvnorm`), which produces identical results regardless of eigenvector sign choices.

## files changed

- `R/lav_utils.R`: new `lav_mvrnorm()` function
- `R/lav_bootstrap.R`: use `lav_mvrnorm()` for parametric bootstrap
- `R/lav_simulate.R`: use `lav_mvrnorm()` for data simulation
- `R/lav_simulate_old.R`: use `lav_mvrnorm()` for data simulation