### PR TITLE
lav_mvrnorm() fills matrix(byrow=TRUE) to reproduce subset n < N

### DIFF
--- a/R/lav_utils.R
+++ b/R/lav_utils.R
@@ -59,7 +59,7 @@ lav_mvrnorm <- function(n = 1, mu, Sigma, tol = 1e-06, empirical = FALSE,
 
   if (empirical) {
     # generate standard normal, then apply empirical transformation
-    X <- matrix(stats::rnorm(p * n), n, p)
+    X <- matrix(stats::rnorm(p * n), n, p, byrow=TRUE)
     X <- scale(X, center = TRUE, scale = FALSE)   # center
     X <- X %*% svd(X, nu = 0)$v                   # orthogonalize
     X <- scale(X, center = FALSE, scale = TRUE)   # unit variance
@@ -71,7 +71,7 @@ lav_mvrnorm <- function(n = 1, mu, Sigma, tol = 1e-06, empirical = FALSE,
     if (n == 1) drop(X) else X
   } else {
     # generate samples (following mvtnorm exactly)
-    X <- matrix(stats::rnorm(n * p), nrow = n) %*% R
+    X <- matrix(stats::rnorm(n * p), nrow = n, byrow=TRUE) %*% R
     X <- sweep(X, 2, mu, "+")
     colnames(X) <- nm
 


### PR DESCRIPTION
Following my comment on #492, it is desirable in Monte Carlo studies to be able to reproduce the same smaller (sub)samples when generating larger samples.  Adapting the current `?lavSimulateData` help-page example:

```
population.model <- ' f1 =~ x1 + 0.8*x2 + 1.2*x3
                      f2 =~ x4 + 0.5*x5 + 1.5*x6

                      f2 ~ 0.5*f1
                    '

## generate N=5, then N=6 using same seed
set.seed(1234)
lavSimulateData(population.model, sample.nobs=5L)
set.seed(1234)
lavSimulateData(population.model, sample.nobs=6L)
```

Similar to `MASS::mvrnorm()``, this results in a completely different top 5 rows in the second, larger sample.

```
> set.seed(1234)
> lavSimulateData(population.model, sample.nobs=5L)
          x1          x2        x3         x4         x5         x6
1 -1.9053181 -0.05254602 -1.315096 -1.0855451 -0.3535416 -2.9110943
2 -0.1507362 -0.91727235 -1.512185 -0.6338042 -0.5520833  0.3905636
3  0.6813426 -0.86911068 -1.259972 -1.9246382 -0.9472693 -2.5438199
4 -3.2875322 -1.31791963 -1.065743 -1.3872816  0.1845345 -0.8403031
5  0.7841853 -0.60598931  1.385567  2.7619643 -0.5206557 -0.4167550

> set.seed(1234)
> lavSimulateData(population.model, sample.nobs=6L)
           x1         x2         x3         x4         x5         x6
1 -1.98134018 -1.1941595 -1.7053832 -0.9689669 -0.7596179  0.9046047
2  0.36567176 -0.4760378  0.1703498  2.7657234 -1.2732608  0.0492392
3  1.57861018 -0.1691168  1.5524969  0.1068578  0.5611405 -0.7502857
4 -3.56925729 -1.8688855 -1.5785570 -1.5090598 -1.5328427 -2.0288189
5 -0.09013206 -0.8925981 -1.1341176 -1.5695740 -0.5796514 -3.3226327
6 -0.14240817 -1.5171577 -1.6893523 -0.3494977 -1.3404922 -2.3812500
```

The solution implemented in `mvtnorm` and `mnormt` packages (see also `rockchalk::mvrnorm()`, which is a copy of `MASS` with `byrow=TRUE`) is simply to fill the matrix `byrow` instead of the default column-wise. 

Following the changes in this PR, this is the desired behavior:

```
> set.seed(1234)
> lavSimulateData(population.model, sample.nobs=5L)
          x1          x2         x3         x4         x5         x6
1 -1.2668401  0.22960977  1.0127120 -2.8129107  0.1955182 -0.1947636
2 -1.4214700 -1.22401587 -1.5805280 -2.0530593 -1.0587034 -2.7429186
3 -0.8429874  0.01107201  0.8794139 -0.6970572 -0.8043954 -1.7913530
4 -0.4387259  2.73459184  0.6122232 -0.3514699 -0.3709399  0.6684135
5 -1.3499451 -1.97318480 -0.2127141 -2.0547598 -0.5306903 -2.4826047

> set.seed(1234)
> lavSimulateData(population.model, sample.nobs=6L)
          x1          x2         x3         x4         x5         x6
1 -1.2668401  0.22960977  1.0127120 -2.8129107  0.1955182 -0.1947636
2 -1.4214700 -1.22401587 -1.5805280 -2.0530593 -1.0587034 -2.7429186
3 -0.8429874  0.01107201  0.8794139 -0.6970572 -0.8043954 -1.7913530
4 -0.4387259  2.73459184  0.6122232 -0.3514699 -0.3709399  0.6684135
5 -1.3499451 -1.97318480 -0.2127141 -2.0547598 -0.5306903 -2.4826047
6  0.7017434 -0.79603639 -1.1901050 -1.6436719 -2.2003004 -2.8812400
```
