### PR TITLE
line continuation after any lavaan operator in lav_syntax_parser

### DIFF
--- a/R/lav_syntax_parser.R
+++ b/R/lav_syntax_parser.R
@@ -303,7 +303,8 @@ lav_parse_text_tokens <- function(modelsrc, types) {
     if (elem.type[i] == types$identifier && elem.text[i] == "efa") {
       frm.hasefa <- TRUE
     }
-    if (any(elem.text[i] == c("+", "*", "=~", "-"))) {
+    if (any(elem.text[i] == 
+      c("+", "*", "=~", "-", "<~", "~*~", "~~", "~", "|~", "|", "%"))) {
       if (frm.incremented) {
         frm.number <- frm.number - 1L
         elem.formula.number[i] <- frm.number


### PR DESCRIPTION
The line continuation was only programmed for mathematical operators '+', '-', '*' and lavaan operator '=~'. Now we will assume line continuation after any lavaan operator.