### PR TITLE
effect.coding = TRUE leads to integer coding of ordinal variables

### DIFF
--- a/R/lav_partable.R
+++ b/R/lav_partable.R
@@ -1026,24 +1026,16 @@ lav_model_partable  <- function(
               # 1) fix bottom and top per ov
               trows <- which(tmp.list$lhs[thresholds.idx] == ind)
               plabs <- tmp.list$plabel[thresholds.idx][trows[c(1, length(trows))]]
-
-              tmp.list$free[thresholds.idx][trows[1]] <- 0L
-              tmp.list$ustart[thresholds.idx[trows[1]]] <- round(.5 + Kmax/nlevs[ind], 3)
-              tmp.list$user[thresholds.idx[trows[1]]] <- 2L
-              ## tmp$lhs <- c(tmp$lhs, plabs[1])
-              ## tmp$rhs <- c(tmp$rhs, round(.5 + Kmax/nlevs[ind], 3))
-              ## tmp$op <- c(tmp$op, "==")
-              ## tmp$block <- c(tmp$block, 0L)
-              ## tmp$user <- c(tmp$user, 2L)
-              ## tmp$ustart <- c(tmp$ustart, as.numeric(NA))
+              thisidx <- thresholds.idx[trows[1]]
+              tmp.list$free[thisidx] <- 0L
+              tmp.list$ustart[thisidx] <- round(.5 + Kmax/nlevs[ind], 3)
+              tmp.list$user[thisidx] <- 2L
 
               if (nlevs[ind] > 2L) {
-                tmp$lhs <- c(tmp$lhs, plabs[2])
-                tmp$rhs <- c(tmp$rhs, round(.5 + Kmax * (nlevs[ind] - 1)/nlevs[ind], 3))
-                tmp$op <- c(tmp$op, "==")
-                tmp$block <- c(tmp$block, 0L)
-                tmp$user <- c(tmp$user, 2L)
-                tmp$ustart <- c(tmp$ustart, as.numeric(NA))
+                thisidx <- thresholds.idx[trows[length(trows)]]
+                tmp.list$free[thisidx] <- 0L
+                tmp.list$ustart[thisidx] <- round(.5 + Kmax * (nlevs[ind] - 1)/nlevs[ind], 3)
+                tmp.list$user[thisidx] <- 2L
               }
 
               # 2) free intercepts of variables with > 2 levels, only if automatically fixed


### PR DESCRIPTION
This PR implements "integer coding" when `effect.coding = TRUE` and all observed variables are categorical (binary or ordinal). Some details:

- The previous behavior of `effect.coding = TRUE` with ordinal variables seemed awkward because the intercepts were all fixed to 0 already, so the only restriction was that loadings average 1. The PR improves this situation and also follows from [my recent paper.](https://doi.org/10.1017/psy.2026.10084) The idea is to put some identification constraints on thresholds, which frees some other parameters.
- The PR only impacts models where all observed variables are binary or ordinal.
- If somebody likes the old behavior of `effect.coding = TRUE` in models with all ordinal variables, another option would be a new argument like `integer.coding = TRUE`. But I would prefer to avoid new arguments, and I am not sure anyone likes the old behavior!
- I will paste some tests in the next comment.