### PR TITLE
when ensuring that start values of thresholds are ordered, respect fixed thresholds

### DIFF
--- a/R/lav_start.R
+++ b/R/lav_start.R
@@ -1000,7 +1000,7 @@ lav_start <- function(start.method = "default",
                                lavpartable$op == "|" & lavpartable$lhs == oo &
                                lavpartable$free > 0)
         item.th <- start[this.idx]
-        if (length(item.th) > 1L && !all(diff(item.th) > 0)) {
+        if (length(item.th) > 1L && length(this.free.idx) > 0 && !all(diff(item.th) > 0)) {
           start[this.free.idx] <- cumsum(abs(item.th))[match(this.free.idx, this.idx)]
         }
       }


### PR DESCRIPTION
Related to #505: I found that the value of some fixed thresholds (especially upper thresholds) can be modified when the starting values of the remaining free thresholds are not ordered correctly. This PR addresses the issue.

This is not a full fix because there could still be a situation where starting values of some free, middle thresholds become larger than a fixed upper threshold. But it is doubtful to happen for the effect coding modification of #505, and I am not sure there are other situations where people fix an upper threshold. Also, `start = "simple"` seems to avoid this issue altogether.