### PR TITLE
Add FMG goodness-of-fit p-value tests

### DIFF
--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -225,6 +225,7 @@ lav_fit_measures <- function(object, fit.measures = "all",
 
   # check standard.test
   standard.test <- lav_test_rename(standard.test, check = TRUE)[1] # only 1
+  fmg.standard.test <- lav_test_fmg_is_fmg(standard.test)
 
   # check scaled.test
   if (!scaled.test %in% c("none", "default", "standard")) {
@@ -243,7 +244,8 @@ lav_fit_measures <- function(object, fit.measures = "all",
 
   # do we have a scaled test statistic? if so, which one?
   scaled.flag <- FALSE
-  if (scaled.test != "none" &&
+  if (!fmg.standard.test &&
+      scaled.test != "none" &&
       any(test.names %in% c(
         "satorra.bentler",
         "yuan.bentler", "yuan.bentler.mplus",
@@ -266,8 +268,12 @@ lav_fit_measures <- function(object, fit.measures = "all",
     if (scaled.flag) {
       this.test <- unique(this.test, scaled.test)
     }
+    lavtest.scaled.test <- standard.test
+    if (fmg.standard.test) {
+      lavtest.scaled.test <- scaled.test
+    }
     TEST <- lavTest(object,
-                    test = this.test, scaled.test = standard.test,
+                    test = this.test, scaled.test = lavtest.scaled.test,
                     drop.list.single = FALSE
     )
     # replace in object, if we pass it to lav_fit_* functions

--- a/R/lav_options.R
+++ b/R/lav_options.R
@@ -988,6 +988,8 @@ lav_options_set <- function(opt = NULL) {
     "browne.residual.adf.model",
     "bollen.stine"
   ))
+  fmg_idx <- which(vapply(opt$test, lav_test_fmg_is_fmg, logical(1L)))
+  wrong_idx <- setdiff(wrong_idx, fmg_idx)
   if (length(wrong_idx) > 0L) {
     lav_msg_stop(gettextf(
       "invalid option(s) for test argument: %1$s. Possible options are: %2$s.",

--- a/R/lav_samplestats.R
+++ b/R/lav_samplestats.R
@@ -175,6 +175,10 @@ lav_samplestats_from_data <- function(lavdata = NULL,
     ))) {
       NACOV.compute <- TRUE
     }
+    if (missing == "listwise" &&
+        any(vapply(test, lav_test_fmg_is_fmg, logical(1L)))) {
+      NACOV.compute <- TRUE
+    }
     if (estimator == "IV" &&
         lavoptions$estimator.args$iv.vcov.stage1 == "gamma") {
       NACOV.compute <- TRUE

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -180,6 +180,8 @@ lav_test_rename <- function(test, check = FALSE) {
 
   # check?
   if (check) {
+    fmg.idx <- which(vapply(test, lav_test_fmg_is_fmg, logical(1L)))
+
     # report unknown values
     bad.idx <- which(!test %in% c(
       "standard", "none", "default",
@@ -195,6 +197,7 @@ lav_test_rename <- function(test, check = FALSE) {
       "browne.residual.adf",
       "browne.residual.adf.model"
     ))
+    bad.idx <- setdiff(bad.idx, fmg.idx)
     if (length(bad.idx) > 0L) {
       lav_msg_stop(sprintf(
         ngettext(
@@ -238,7 +241,8 @@ lav_test_rename <- function(test, check = FALSE) {
     "mean.var.adjusted",
     "scaled.shifted"
   ))
-  test <- c(test[nonscaled.idx], test[scaled.idx])
+  fmg.idx <- which(vapply(test, lav_test_fmg_is_fmg, logical(1L)))
+  test <- c(test[nonscaled.idx], test[scaled.idx], test[fmg.idx])
 
   test
 }
@@ -509,7 +513,34 @@ lav_model_test <- function(lavobject = NULL,
   ######################
 
   for (this.test in test) {
-    if (lavoptions$estimator == "PML") {
+    if (lav_test_fmg_is_fmg(this.test)) {
+      parsed <- lav_test_fmg_parse(this.test)
+      chisq <- lav_test_fmg_resolve_chisq(parsed, lavoptions = lavoptions)
+      unscaled.TEST <- TEST[[1]]
+      if (chisq == "rls") {
+        unscaled.TEST <- lav_test_fmg_browne_nt_model(
+          lavobject = lavobject,
+          lavdata = lavdata,
+          lavsamplestats = lavsamplestats,
+          lavmodel = lavmodel,
+          lavpartable = lavpartable,
+          lavoptions = lavoptions,
+          lavh1 = lavh1,
+          lavimplied = lavimplied
+        )
+        TEST[[unscaled.TEST$test]] <- unscaled.TEST
+      }
+
+      TEST[[this.test]] <- lav_test_fmg(
+        lavobject = lavobject,
+        lavsamplestats = lavsamplestats,
+        lavmodel = lavmodel,
+        lavoptions = lavoptions,
+        lavimplied = lavimplied,
+        TEST.chisq = unscaled.TEST,
+        test = this.test
+      )
+    } else if (lavoptions$estimator == "PML") {
       if (this.test == "mean.var.adjusted") {
         LABEL <- "mean+var adjusted correction (PML)"
         TEST[[this.test]] <-

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -27,6 +27,7 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
                        type = "Chisq", model.names = NULL) {                # nolint end
   type <- tolower(type[1])
   test <- tolower(test[1])
+  method.orig <- method[1]
   method <- tolower(gsub("[-_\\.]", "", method[1]))
   if (type %in% c("browne", "browne.residual.adf", "browne.residual.nt")) {
     if (type == "browne") {
@@ -127,6 +128,19 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
     if (!all(sapply(mods, lavInspect, "converged"))) {
       lav_msg_warn(gettext("not all models converged"))
     }
+  }
+
+  if (type == "chisq" && lav_test_fmg_is_fmg(test)) {
+    return(lav_test_lrt_fmg(
+      mods = mods,
+      test = test,
+      method = method,
+      method.orig = method.orig,
+      estimator = estimator,
+      ntotal = ntotal,
+      ngroups = ngroups,
+      missing = object@Options$missing
+    ))
   }
 
   mods_scaled <- unlist(lapply(mods, function(x) {
@@ -586,6 +600,129 @@ lav_test_lrt_single_model <- function(object, method = "default",
                                    "\n")
   }
 
+  class(val) <- c("anova", class(val))
+
+  val
+}
+
+lav_test_lrt_fmg <- function(mods, test = "pall_ug_ml", method = "default",
+                             method.orig = method,
+                             estimator = "ML", ntotal = NULL,
+                             ngroups = NULL, missing = "listwise") {
+  if (!method %in% c("default", "standard", "satorra2000")) {
+    lav_msg_stop(gettextf(
+      "FMG nested tests require method= %1$s, %2$s, or %3$s; found %4$s.",
+      dQuote("default"), dQuote("standard"), dQuote("satorra.2000"),
+      dQuote(method.orig)
+    ))
+  }
+  invisible(lapply(
+    mods,
+    function(x) {
+      lav_test_fmg_check_estimator(x@Options, context = "FMG nested tests")
+      lav_test_fmg_check_missing(x@Options, context = "FMG nested tests")
+    }
+  ))
+  estimators <- vapply(mods, function(x) x@Options$estimator.orig,
+                       character(1L))
+  if (length(unique(estimators)) > 1L) {
+    lav_msg_stop(gettextf(
+      "FMG nested tests require all models to use the same estimator; found %1$s.",
+      lav_msg_view(unique(estimators), "and")
+    ))
+  }
+
+  parsed <- lav_test_fmg_parse(test)
+  chisq <- lav_test_fmg_resolve_chisq(parsed, lavoptions = mods[[1]]@Options)
+
+  if (chisq == "rls") {
+    TESTlist <- lapply(
+      mods,
+      function(x) lav_test_fmg_browne_nt_model(lavobject = x)
+    )
+    Df <- sapply(TESTlist, function(x) x$df)
+    STAT <- sapply(TESTlist, function(x) x$stat)
+  } else {
+    Df <- sapply(mods, function(x) slot(x, "test")[[1]]$df)
+    STAT <- sapply(mods, function(x) slot(x, "test")[[1]]$stat)
+  }
+
+  STAT.delta <- STAT.delta.orig <- c(NA, diff(STAT))
+  Df.delta <- Df.delta.orig <- c(NA, diff(Df))
+  Pvalue.delta <- rep(as.numeric(NA), length(mods))
+
+  if (length(mods) > 1L) {
+    for (m in seq_len(length(mods) - 1L)) {
+      out <- lav_test_fmg_nested(
+        m0 = mods[[m + 1L]],
+        m1 = mods[[m]],
+        test = test
+      )
+      STAT.delta[m + 1L] <- out$stat
+      Df.delta[m + 1L] <- out$df
+      Pvalue.delta[m + 1L] <- out$pvalue
+    }
+  }
+
+  STAT.delta <- round(unname(STAT.delta), 10)
+  Df.delta <- unname(Df.delta)
+  STAT.delta.orig <- unname(STAT.delta.orig)
+  Df.delta.orig <- unname(Df.delta.orig)
+
+  aic <- bic <- rep(NA, length(mods))
+  if (estimator == "ML") {
+    aic <- sapply(mods, FUN = AIC)
+    bic <- sapply(mods, FUN = BIC)
+  } else if (estimator == "PML") {
+    OUT <- lapply(mods, lav_pml_object_aic_bic)
+    aic <- sapply(OUT, "[[", "PL_AIC")
+    bic <- sapply(OUT, "[[", "PL_BIC")
+  }
+
+  if (missing == "listwise") {
+    RMSEA.delta <- c(NA, lav_fit_rmsea(
+      X2 = STAT.delta.orig[-1],
+      df = Df.delta.orig[-1],
+      N = ntotal,
+      G = ngroups,
+      c.hat = rep(1, length(STAT.delta.orig) - 1L)
+    ))
+
+    val <- data.frame(
+      Df = Df,
+      AIC = aic,
+      BIC = bic,
+      Chisq = STAT,
+      "Chisq diff" = STAT.delta,
+      "RMSEA" = RMSEA.delta,
+      "Df diff" = Df.delta,
+      "Pr(>Chisq)" = Pvalue.delta,
+      row.names = names(mods),
+      check.names = FALSE
+    )
+  } else {
+    val <- data.frame(
+      Df = Df,
+      AIC = aic,
+      BIC = bic,
+      Chisq = STAT,
+      "Chisq diff" = STAT.delta,
+      "Df diff" = Df.delta,
+      "Pr(>Chisq)" = Pvalue.delta,
+      row.names = names(mods),
+      check.names = FALSE
+    )
+  }
+
+  idx <- which(val[, "Df diff"] == 0)
+  if (length(idx) > 0L) {
+    val[idx, "Pr(>Chisq)"] <- as.numeric(NA)
+    lav_msg_warn(gettext("some models have the same degrees of freedom"))
+  }
+
+  attr(val, "heading") <- paste0(
+    "\nFMG Chi-Squared Difference Test (test = ", dQuote(test), ")\n"
+  )
   class(val) <- c("anova", class(val))
 
   val

--- a/R/lav_test_browne.R
+++ b/R/lav_test_browne.R
@@ -344,8 +344,15 @@ lav_test_browne_nt_fast <- function(res = NULL, Delta = NULL,
   }
   A <- crossprod(Delta, gamma_inv_delta)
   b <- crossprod(Delta, u)
-  R_chol <- chol(A)
-  Ab_inv_b <- backsolve(R_chol, forwardsolve(t(R_chol), b))
+  Ab_inv_b <- tryCatch(
+    {
+      R_chol <- chol(A)
+      backsolve(R_chol, forwardsolve(t(R_chol), b))
+    },
+    error = function(e) {
+      MASS::ginv(A) %*% b
+    }
+  )
 
   term1 <- as.numeric(crossprod(res, u)) # t(res) Ginv res
   term2 <- as.numeric(crossprod(b, Ab_inv_b)) # t(b) A^{-1} b

--- a/R/lav_test_fmg.R
+++ b/R/lav_test_fmg.R
@@ -1,0 +1,1066 @@
+# FMG (Foldnes, Moss, Gronneberg 2024) test statistics
+# Improved goodness-of-fit tests using eigenvalue methods
+#
+# References:
+# - Foldnes, N., Moss, J., & Gronneberg, S. (2024). Improved goodness of fit
+#   procedures for structural equation models. Structural Equation Modeling.
+# - Du, H., & Bentler, P. M. (2022). 40-Year Old Unbiased Distribution Free
+#   Estimator Reliably Improves SEM Statistics for Nonnormal Data.
+# - Wu, H., & Lin, J. (2016). A Scaled F Distribution as an Approximation to
+#   the Distribution of Test Statistics in Covariance Structure Analysis.
+
+# =====================================================
+# Parser (ported from semTests split_input)
+# =====================================================
+
+#' Check if test string is an FMG test
+#' @param test Character string specifying the test
+#' @return Logical indicating if this is an FMG test
+#' @keywords internal
+lav_test_fmg_is_fmg <- function(test) {
+  test <- tolower(test)
+  patterns <- c(
+    "^peba", "^pols", "^pall", "^all$",
+    "^all_", "^sb_", "^ss_", "^sf_", "^std_"
+  )
+  any(vapply(patterns, function(p) grepl(p, test), logical(1)))
+}
+
+#' Parse FMG test string into components
+#'
+#' Format: {method}{param}_{ug?}_{chisq?}
+#' Examples: peba4_ug_rls, eba2, pols2_ml, sb_ug
+#'
+#' @param string Character string specifying the test
+#' @return List with method, param, unbiased, chisq
+#' @keywords internal
+lav_test_fmg_parse <- function(string) {
+  string <- tolower(string)
+  splitted <- strsplit(string, "_")[[1]]
+
+  # Defaults
+  method <- NULL
+  param <- 2L # default for j (eba/peba) or gamma (pols)
+  unbiased <- FALSE
+  unbiased.explicit <- FALSE
+  chisq <- "default"
+  chisq.explicit <- FALSE
+
+  type <- splitted[1]
+
+  # Parse unbiased and chisq from suffix parts
+  if (length(splitted) == 3L) {
+    unbiased <- (splitted[2] == "ug")
+    unbiased.explicit <- TRUE
+    chisq <- splitted[3]
+    chisq.explicit <- TRUE
+  } else if (length(splitted) == 2L) {
+    if (splitted[2] %in% c("rls", "ml")) {
+      chisq <- splitted[2]
+      chisq.explicit <- TRUE
+    } else if (splitted[2] == "ug") {
+      unbiased <- TRUE
+      unbiased.explicit <- TRUE
+    }
+  }
+
+  # Parse method and parameter
+  if (startsWith(type, "peba")) {
+    method <- "peba"
+    param_str <- substring(type, 5)
+    if (nchar(param_str) > 0L) param <- as.integer(param_str)
+  } else if (startsWith(type, "pols")) {
+    method <- "pols"
+    param_str <- substring(type, 5)
+    if (nchar(param_str) > 0L) param <- as.numeric(param_str)
+  } else if (type == "pall") {
+    method <- "pall"
+  } else if (type == "all") {
+    method <- "all"
+  } else if (type %in% c("sb", "ss", "sf", "std")) {
+    method <- type
+  } else {
+    lav_msg_stop(gettextf(
+      "FMG tests do not support test= %1$s.",
+      dQuote(type)
+    ))
+  }
+
+  list(
+    method = method,
+    param = param,
+    unbiased = unbiased,
+    chisq = chisq,
+    unbiased.explicit = unbiased.explicit,
+    chisq.explicit = chisq.explicit
+  )
+}
+
+lav_test_fmg_resolve_unbiased <- function(parsed, lavoptions = NULL) {
+  if (isTRUE(parsed$unbiased.explicit)) {
+    return(parsed$unbiased)
+  }
+  if (!is.null(lavoptions$gamma.unbiased)) {
+    return(isTRUE(lavoptions$gamma.unbiased))
+  }
+  FALSE
+}
+
+lav_test_fmg_resolve_chisq <- function(parsed, lavoptions = NULL) {
+  if (isTRUE(parsed$chisq.explicit)) {
+    return(parsed$chisq)
+  }
+
+  scaled.test <- "standard"
+  if (!is.null(lavoptions$scaled.test)) {
+    scaled.test <- lavoptions$scaled.test[1L]
+  }
+
+  if (scaled.test %in% c("default", "standard", "none")) {
+    return("ml")
+  } else if (scaled.test == "browne.residual.nt.model") {
+    return("rls")
+  }
+
+  lav_msg_stop(gettextf(
+    "FMG tests require scaled.test= %1$s or %2$s; found %3$s.",
+    dQuote("standard"), dQuote("browne.residual.nt.model"),
+    dQuote(scaled.test)
+  ))
+}
+
+lav_test_fmg_check_missing <- function(lavoptions = NULL,
+                                       context = "FMG tests") {
+  if (is.null(lavoptions) || is.null(lavoptions$missing)) {
+    return(invisible(TRUE))
+  }
+
+  missing <- lavoptions$missing[1L]
+  if (isTRUE(missing == "listwise")) {
+    return(invisible(TRUE))
+  }
+
+  lav_msg_stop(gettextf(
+    "%1$s require missing= %2$s; found %3$s.",
+    context, dQuote("listwise"), dQuote(missing)
+  ))
+}
+
+lav_test_fmg_check_estimator <- function(lavoptions = NULL,
+                                         context = "FMG tests") {
+  if (is.null(lavoptions)) {
+    return(invisible(TRUE))
+  }
+
+  estimator <- lavoptions$estimator
+  estimator.orig <- lavoptions$estimator.orig
+  if (isTRUE(estimator == "ML") &&
+      isTRUE(estimator.orig %in% c("ML", "MLM"))) {
+    return(invisible(TRUE))
+  }
+
+  reported <- if (!is.null(estimator.orig)) estimator.orig else estimator
+  lav_msg_stop(gettextf(
+    "%1$s require estimator= %2$s or %3$s; found %4$s.",
+    context, dQuote("ML"), dQuote("MLM"), dQuote(reported)
+  ))
+}
+
+lav_test_fmg_ugamma_eigenvalues <- function(UGamma, df,
+                                            truncate_negative = TRUE) {
+  eigs <- Re(eigen(UGamma, only.values = TRUE)$values)
+  lambdas_raw <- sort(eigs, decreasing = TRUE)[seq_len(df)]
+  lambdas <- lambdas_raw
+  truncated <- rep(FALSE, length(lambdas))
+
+  if (isTRUE(truncate_negative)) {
+    truncated <- lambdas < 0
+    lambdas[truncated] <- 0
+  }
+
+  list(
+    values = lambdas,
+    raw = lambdas_raw,
+    truncated = truncated,
+    n_truncated = sum(truncated),
+    min_raw = min(lambdas_raw)
+  )
+}
+
+lav_test_fmg_label <- function(parsed, unbiased = FALSE, chisq = "ml") {
+  param <- format(parsed$param, trim = TRUE, scientific = FALSE)
+  method_label <- switch(parsed$method,
+    "peba" = paste0("pEBA-", param),
+    "pols" = paste0("pOLS-", param),
+    "pall" = "PALL",
+    "all" = "ALL",
+    "sb" = "SB",
+    "ss" = "scaled-shifted",
+    "sf" = "scaled-F",
+    "std" = "standard chi-square",
+    parsed$method
+  )
+  chisq_label <- if (chisq == "rls") "RLS" else toupper(chisq)
+  gamma_label <- if (isTRUE(unbiased)) "unbiased Gamma, " else ""
+
+  paste0(method_label, " p-value test (", gamma_label, chisq_label, ")")
+}
+
+lav_test_fmg_chisq_equivalent <- function(pvalue, df) {
+  if (is.na(pvalue) || is.na(df) || df <= 0L) {
+    return(as.numeric(NA))
+  }
+  pvalue <- max(0, min(1, pvalue))
+  stats::qchisq(pvalue, df = df, lower.tail = FALSE)
+}
+
+lav_test_fmg_stat_group_equivalent <- function(stat_group = NULL,
+                                               source_stat = NULL,
+                                               stat = NULL) {
+  if (is.null(stat_group)) {
+    return(NULL)
+  }
+  if (length(stat_group) == 1L) {
+    return(stat)
+  }
+  if (is.na(source_stat) || source_stat == 0 || is.infinite(stat)) {
+    return(rep(stat / length(stat_group), length(stat_group)))
+  }
+
+  stat_group * stat / source_stat
+}
+
+lav_test_fmg_browne_nt_model <- function(lavobject = NULL,
+                                         lavdata = NULL,
+                                         lavsamplestats = NULL,
+                                         lavmodel = NULL,
+                                         lavpartable = NULL,
+                                         lavoptions = NULL,
+                                         lavh1 = NULL,
+                                         lavimplied = NULL) {
+  out <- try(
+    lav_test_browne(
+      lavobject = lavobject,
+      lavdata = lavdata,
+      lavsamplestats = lavsamplestats,
+      lavmodel = lavmodel,
+      lavpartable = lavpartable,
+      lavoptions = lavoptions,
+      lavh1 = lavh1,
+      lavimplied = lavimplied,
+      ADF = FALSE,
+      model.based = TRUE
+    ),
+    silent = TRUE
+  )
+  if (!inherits(out, "try-error")) {
+    return(out)
+  }
+
+  if (!is.null(lavobject)) {
+    lavdata <- lavobject@Data
+    lavsamplestats <- lavobject@SampleStats
+    lavmodel <- lavobject@Model
+    lavpartable <- lavobject@ParTable
+    lavoptions <- lavobject@Options
+    lavh1 <- lavobject@h1
+    lavimplied <- lavobject@implied
+  }
+
+  if (!is.logical(lavoptions$gamma.n.minus.one)) {
+    n.minus.one <- !(lavoptions$estimator == "ML" &&
+      lavoptions$likelihood == "normal")
+  } else {
+    n.minus.one <- lavoptions$gamma.n.minus.one
+  }
+
+  Delta <- lav_model_delta(lavmodel)
+  Gamma <- lav_object_gamma(
+    lavobject = NULL,
+    lavdata = lavdata,
+    lavoptions = lavoptions,
+    lavsamplestats = lavsamplestats,
+    lavh1 = lavh1,
+    lavimplied = lavimplied,
+    ADF = FALSE,
+    model.based = TRUE
+  )
+  WLS.obs <- lavsamplestats@WLS.obs
+  WLS.est <- lav_model_wls_est(lavmodel)
+  nobs <- lavsamplestats@nobs
+  ntotal <- lavsamplestats@ntotal
+  ngroups <- length(WLS.obs)
+  stat.group <- numeric(ngroups)
+
+  lineq.flag <- lavmodel@eq.constraints || lavmodel@ceq.simple.only
+
+  if (!lineq.flag) {
+    for (g in seq_len(ngroups)) {
+      RES <- WLS.obs[[g]] - WLS.est[[g]]
+      Delta.c <- lav_matrix_orthogonal_complement(Delta[[g]])
+      t_dgd <- crossprod(Delta.c, Gamma[[g]]) %*% Delta.c
+      t_dgd_inv <- lav_matrix_symmetric_inverse(t_dgd)
+      Ng <- if (n.minus.one) nobs[[g]] - 1L else nobs[[g]]
+      t_res_delta_c <- crossprod(RES, Delta.c)
+      stat.group[g] <-
+        Ng * drop(t_res_delta_c %*% t_dgd_inv %*% t(t_res_delta_c))
+    }
+    STAT <- sum(stat.group)
+  } else {
+    RES.all <- do.call("c", WLS.obs) - do.call("c", WLS.est)
+    Delta.all <- do.call("rbind", Delta)
+    if (lavmodel@eq.constraints) {
+      Delta.g <- Delta.all %*% lavmodel@eq.constraints.K
+    } else {
+      Delta.g <- Delta.all %*% lavmodel@ceq.simple.K
+    }
+    Gamma.inv.weighted <- vector("list", ngroups)
+    for (g in seq_len(ngroups)) {
+      Ng <- if (n.minus.one) nobs[[g]] - 1L else nobs[[g]]
+      Gamma.inv.temp <- try(solve(Gamma[[g]]), silent = TRUE)
+      if (inherits(Gamma.inv.temp, "try-error")) {
+        Gamma.inv.temp <- MASS::ginv(Gamma[[g]])
+      }
+      Gamma.inv.weighted[[g]] <- Gamma.inv.temp * Ng / ntotal
+    }
+    GI <- lav_matrix_bdiag(Gamma.inv.weighted)
+    t_dgid <- t(Delta.g) %*% GI %*% Delta.g
+    t_dgid_inv <- MASS::ginv(t_dgid)
+    q1 <- drop(t(RES.all) %*% GI %*% RES.all)
+    q2 <- drop(t(RES.all) %*%
+      GI %*% Delta.g %*% t_dgid_inv %*% t(Delta.g) %*% GI %*%
+      RES.all)
+    STAT <- ntotal * (q1 - q2)
+    stat.group <- STAT * unlist(nobs) / ntotal
+  }
+
+  if (!is.null(lavobject)) {
+    DF <- lavobject@test[[1]]$df
+  } else {
+    DF <- lav_partable_df(lavpartable)
+    if (!lavmodel@cin.simple.only && nrow(lavmodel@con.jac) > 0L) {
+      ceq.idx <- attr(lavmodel@con.jac, "ceq.idx")
+      if (length(ceq.idx) > 0L) {
+        DF <- DF + qr(lavmodel@con.jac[ceq.idx, , drop = FALSE])$rank
+      }
+    } else if (lavmodel@ceq.simple.only) {
+      DF <- lav_partable_ndat(lavpartable) - max(lavpartable$free)
+    }
+  }
+
+  list(
+    test = "browne.residual.nt.model",
+    stat = STAT,
+    stat.group = stat.group,
+    df = DF,
+    refdistr = "chisq",
+    pvalue = 1 - stats::pchisq(STAT, DF),
+    label = "Browne's residual (NT model-based) test"
+  )
+}
+
+# =====================================================
+# Main entry point
+# =====================================================
+
+#' Compute FMG test statistics
+#'
+#' @param lavobject A lavaan object
+#' @param lavsamplestats Sample statistics (extracted from lavobject if NULL)
+#' @param lavmodel Model object (extracted from lavobject if NULL)
+#' @param lavdata Data object (extracted from lavobject if NULL)
+#' @param lavoptions Options (extracted from lavobject if NULL)
+#' @param TEST.unscaled Unscaled test from lavobject@test[[1]]
+#' @param test Character string specifying the test (e.g., "peba4_ug_rls")
+#' @return List with test results including stat, df, pvalue
+#' @keywords internal
+lav_test_fmg <- function(lavobject = NULL,
+                         lavsamplestats = NULL,
+                         lavmodel = NULL,
+                         lavimplied = NULL,
+                         lavdata = NULL,
+                         lavoptions = NULL,
+                         TEST.unscaled = NULL,
+                         TEST.chisq = NULL,
+                         E.inv = NULL,
+                         Delta = NULL,
+                         WLS.V = NULL,
+                         Gamma = NULL,
+                         test = "peba4") {
+  # Extract from lavobject if provided
+  if (!is.null(lavobject)) {
+    lavsamplestats <- lavobject@SampleStats
+    lavmodel <- lavobject@Model
+    lavoptions <- lavobject@Options
+    lavdata <- lavobject@Data
+    if (is.null(TEST.unscaled)) {
+      TEST.unscaled <- lavobject@test[[1]]
+    }
+  }
+
+  lav_test_fmg_check_estimator(lavoptions, context = "FMG tests")
+  lav_test_fmg_check_missing(lavoptions, context = "FMG tests")
+
+  # Parse test string
+  parsed <- lav_test_fmg_parse(test)
+  chisq <- lav_test_fmg_resolve_chisq(parsed, lavoptions = lavoptions)
+  unbiased <- lav_test_fmg_resolve_unbiased(parsed, lavoptions = lavoptions)
+  label <- lav_test_fmg_label(parsed, unbiased = unbiased, chisq = chisq)
+
+  if (is.null(TEST.chisq)) {
+    TEST.chisq <- TEST.unscaled
+    if (chisq == "rls") {
+      if (is.null(lavobject)) {
+        return(NULL)
+      }
+      TEST.chisq <- lav_test_fmg_browne_nt_model(lavobject = lavobject)
+    }
+  }
+  chisq_stat <- TEST.chisq$stat
+
+  # Get df
+  df <- TEST.unscaled$df
+
+  # Handle df == 0 case
+  if (df == 0L || df < 0L) {
+    return(list(
+      test = test,
+      stat = as.numeric(NA),
+      source.stat = chisq_stat,
+      source.stat.group = TEST.chisq$stat.group,
+      df = df,
+      pvalue = as.numeric(NA),
+      refdistr = "chisq",
+      method = parsed$method,
+      param = parsed$param,
+      unbiased = unbiased,
+      chisq.type = chisq,
+      label = label
+    ))
+  }
+
+  # Get UGamma matrix (with unbiased option)
+  UGamma <- lav_test_fmg_ugamma(
+    lavobject = lavobject,
+    lavsamplestats = lavsamplestats,
+    lavmodel = lavmodel,
+    lavimplied = lavimplied,
+    lavdata = lavdata,
+    lavoptions = lavoptions,
+    TEST.unscaled = TEST.unscaled,
+    E.inv = E.inv,
+    Delta = Delta,
+    WLS.V = WLS.V,
+    Gamma = Gamma,
+    unbiased = unbiased
+  )
+
+  if (is.null(UGamma)) {
+    return(list(
+      test = test,
+      stat = as.numeric(NA),
+      source.stat = chisq_stat,
+      source.stat.group = TEST.chisq$stat.group,
+      df = df,
+      pvalue = as.numeric(NA),
+      refdistr = "chisq",
+      method = parsed$method,
+      param = parsed$param,
+      unbiased = unbiased,
+      chisq.type = chisq,
+      label = label
+    ))
+  }
+
+  # Compute eigenvalues (first df eigenvalues)
+  eig <- lav_test_fmg_ugamma_eigenvalues(UGamma, df)
+  lambdas <- eig$values
+
+  # Compute p-value based on method
+  pvalue <- switch(parsed$method,
+    "peba" = lav_test_fmg_peba(chisq_stat, lambdas, j = parsed$param),
+    "pols" = lav_test_fmg_pols(chisq_stat, lambdas, gamma = parsed$param),
+    "pall" = lav_test_fmg_pall(chisq_stat, lambdas),
+    "all" = lav_test_fmg_all(chisq_stat, lambdas),
+    "sb" = lav_test_fmg_sb(chisq_stat, lambdas),
+    "ss" = lav_test_fmg_ss(chisq_stat, lambdas, df),
+    "sf" = lav_test_fmg_scaled_f(chisq_stat, lambdas),
+    "std" = 1 - stats::pchisq(chisq_stat, df),
+    lav_test_fmg_peba(chisq_stat, lambdas, j = 4L) # default
+  )
+
+  # Ensure p-value is in valid range
+  pvalue <- max(0, min(1, pvalue))
+  stat <- lav_test_fmg_chisq_equivalent(pvalue, df)
+  stat.group <- lav_test_fmg_stat_group_equivalent(
+    stat_group = TEST.chisq$stat.group,
+    source_stat = chisq_stat,
+    stat = stat
+  )
+
+  # Return TEST structure
+  list(
+    test = test,
+    stat = stat,
+    stat.group = stat.group,
+    source.stat = chisq_stat,
+    source.stat.group = TEST.chisq$stat.group,
+    df = df,
+    pvalue = pvalue,
+    refdistr = "chisq",
+    method = parsed$method,
+    param = parsed$param,
+    unbiased = unbiased,
+    chisq.type = chisq,
+    UGamma.eigenvalues = lambdas,
+    UGamma.eigenvalues.raw = eig$raw,
+    UGamma.eigenvalues.truncated = eig$n_truncated,
+    label = label
+  )
+}
+
+# =====================================================
+# UGamma computation
+# =====================================================
+
+#' Get UGamma matrix with optional unbiased gamma
+#'
+#' @param lavobject A lavaan object
+#' @param unbiased Logical: use Du & Bentler (2022) unbiased gamma?
+#' @return UGamma matrix
+#' @keywords internal
+lav_test_fmg_ugamma <- function(lavobject = NULL,
+                                lavsamplestats = NULL,
+                                lavmodel = NULL,
+                                lavimplied = NULL,
+                                lavdata = NULL,
+                                lavoptions = NULL,
+                                TEST.unscaled = NULL,
+                                E.inv = NULL,
+                                Delta = NULL,
+                                WLS.V = NULL,
+                                Gamma = NULL,
+                                unbiased = FALSE) {
+  if (!is.null(lavobject)) {
+    lavsamplestats <- lavobject@SampleStats
+    lavmodel <- lavobject@Model
+    lavimplied <- lavobject@implied
+    lavoptions <- lavobject@Options
+    lavdata <- lavobject@Data
+    if (is.null(TEST.unscaled)) {
+      TEST.unscaled <- lavobject@test[[1]]
+    }
+  }
+
+  ngroups <- lavdata@ngroups
+
+  if (unbiased) {
+    # Recompute Gamma with unbiased = TRUE
+    Gamma <- vector("list", ngroups)
+    for (g in seq_len(ngroups)) {
+      Gamma[[g]] <- lav_samplestats_gamma(
+        m_y = lavdata@X[[g]],
+        meanstructure = lavoptions$meanstructure,
+        unbiased = TRUE
+      )
+    }
+  } else {
+    if (is.null(Gamma)) {
+      if (!is.null(lavobject)) {
+        Gamma <- lavTech(lavobject, "Gamma")
+      } else {
+        Gamma <- lavsamplestats@NACOV
+      }
+    }
+    if (!is.list(Gamma)) {
+      Gamma <- list(Gamma)
+    }
+    if (is.null(Gamma[[1L]])) {
+      Gamma <- lav_object_gamma(
+        lavobject = NULL,
+        lavdata = lavdata,
+        lavoptions = lavoptions,
+        lavsamplestats = lavsamplestats,
+        lavh1 = NULL,
+        lavimplied = lavimplied,
+        ADF = TRUE,
+        model.based = FALSE
+      )
+    }
+  }
+
+  # Get U matrix and UGamma using existing infrastructure
+  out <- lav_test_satorra_bentler(
+    lavobject = lavobject,
+    lavsamplestats = lavsamplestats,
+    lavmodel = lavmodel,
+    lavimplied = lavimplied,
+    lavdata = lavdata,
+    lavoptions = lavoptions,
+    TEST.unscaled = TEST.unscaled,
+    E.inv = E.inv,
+    Delta = Delta,
+    WLS.V = WLS.V,
+    Gamma = Gamma,
+    method = "original",
+    return.ugamma = TRUE,
+    return.u = TRUE
+  )
+
+  if (is.null(out)) {
+    return(NULL)
+  }
+
+  # If unbiased, recompute UGamma with new Gamma
+  if (unbiased) {
+    U <- out$UfromUGamma
+    if (is.null(U)) {
+      return(NULL)
+    }
+
+    # Rescale gamma by group weights
+    fg <- unlist(lavsamplestats@nobs) / lavsamplestats@ntotal
+    Gamma_scaled <- vector("list", length(Gamma))
+    for (g in seq_along(Gamma)) {
+      Gamma_scaled[[g]] <- Gamma[[g]] / fg[g]
+    }
+    Gamma_all <- lav_matrix_bdiag(Gamma_scaled)
+    UGamma <- U %*% Gamma_all
+  } else {
+    UGamma <- out$UGamma
+  }
+
+  UGamma
+}
+
+# =====================================================
+# P-value methods
+# =====================================================
+
+#' Pure R Imhof p-value for quadratic forms
+#'
+#' Computes P[Q > q] where Q = sum(lambda_j * chi^2(h_j, delta_j)).
+#' This is a small R port of the Imhof integration used by CompQuadForm,
+#' using stats::integrate().
+#'
+#' @param q Observed quadratic-form value
+#' @param lambda Eigenvalues/weights
+#' @param h Degrees of freedom per component
+#' @param delta Noncentrality parameters per component
+#' @param epsabs Absolute integration tolerance
+#' @param epsrel Relative integration tolerance
+#' @param limit Maximum number of subdivisions
+#' @return List with Qq and abserr
+#' @keywords internal
+lav_test_fmg_imhof <- function(q, lambda, h = rep(1, length(lambda)),
+                               delta = rep(0, length(lambda)),
+                               epsabs = 1e-6, epsrel = 1e-6,
+                               limit = 10000L) {
+  lambda <- as.numeric(lambda)
+  h <- as.numeric(h)
+  delta <- as.numeric(delta)
+
+  keep <- abs(lambda) > .Machine$double.eps
+  lambda <- lambda[keep]
+  h <- h[keep]
+  delta <- delta[keep]
+
+  if (length(lambda) == 0L) {
+    return(list(Qq = ifelse(q < 0, 1, 0), abserr = 0))
+  }
+
+  if (length(lambda) == 1L) {
+    if (lambda > 0) {
+      Qq <- stats::pchisq(q / lambda,
+        df = h, ncp = delta,
+        lower.tail = FALSE
+      )
+    } else if (q < 0) {
+      Qq <- stats::pchisq(q / lambda, df = h, ncp = delta)
+    } else {
+      Qq <- 0
+    }
+    return(list(Qq = Qq, abserr = 0))
+  }
+
+  integrand <- function(u) {
+    vapply(u, function(ui) {
+      if (ui == 0) {
+        return(0.5 * (sum((h + delta) * lambda) - q))
+      }
+
+      lu <- lambda * ui
+      lu2 <- lu * lu
+
+      theta <- 0.5 * sum(h * atan(lu) + delta * lu / (1 + lu2)) -
+        0.5 * q * ui
+      log.rho <- sum(0.25 * h * log1p(lu2) +
+        0.5 * delta * lu2 / (1 + lu2))
+
+      sin(theta) / (ui * exp(log.rho))
+    }, numeric(1L))
+  }
+
+  out <- stats::integrate(
+    integrand,
+    lower = 0,
+    upper = Inf,
+    rel.tol = epsrel,
+    abs.tol = epsabs,
+    subdivisions = limit
+  )
+
+  list(Qq = 0.5 + out$value / pi, abserr = out$abs.error)
+}
+
+#' Penalized EBA p-value (Foldnes et al. 2024)
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @param j Number of blocks
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_peba <- function(chisq, lambdas, j = 4L) {
+  m <- length(lambdas)
+  if (m == 0L) {
+    return(as.numeric(NA))
+  }
+
+  k <- ceiling(m / j)
+  eig <- c(lambdas, rep(NA_real_, k * j - m))
+  dim(eig) <- c(k, j)
+  eig_means <- colMeans(eig, na.rm = TRUE)
+  eig_mean <- mean(lambdas)
+  repeated <- rep(eig_means, each = k)[seq_len(m)]
+  penalized <- (repeated + eig_mean) / 2
+
+  lav_test_fmg_imhof(chisq, penalized)$Qq
+}
+
+#' Penalized OLS p-value (Foldnes et al. 2024)
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @param gamma Penalization parameter
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_pols <- function(chisq, lambdas, gamma = 2) {
+  m <- length(lambdas)
+  if (m == 0L) {
+    return(as.numeric(NA))
+  }
+
+  if (m == 1L) {
+    lambda_hat <- lambdas
+  } else {
+    x <- seq_along(lambdas)
+    beta1_hat <- 1 / gamma * stats::cov(x, lambdas) / stats::var(x)
+    beta0_hat <- mean(lambdas) - beta1_hat * mean(x)
+    lambda_hat <- pmax(beta0_hat + beta1_hat * x, 0)
+  }
+
+  lav_test_fmg_imhof(chisq, lambda_hat)$Qq
+}
+
+#' Penalized all eigenvalues (for nested models)
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_pall <- function(chisq, lambdas) {
+  if (length(lambdas) == 0L) {
+    return(as.numeric(NA))
+  }
+
+  penalized <- lambdas / 2 + mean(lambdas) / 2
+  lav_test_fmg_imhof(chisq, penalized)$Qq
+}
+
+#' All eigenvalues exact p-value
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_all <- function(chisq, lambdas) {
+  if (length(lambdas) == 0L) {
+    return(as.numeric(NA))
+  }
+
+  lav_test_fmg_imhof(chisq, lambdas)$Qq
+}
+
+#' Satorra-Bentler via eigenvalues
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_sb <- function(chisq, lambdas) {
+  m <- length(lambdas)
+  if (m == 0L) {
+    return(as.numeric(NA))
+  }
+
+  1 - stats::pchisq(chisq * m / sum(lambdas), df = m)
+}
+
+#' Scaled and shifted p-value
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @param df Degrees of freedom
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_ss <- function(chisq, lambdas, df) {
+  if (length(lambdas) == 0L || df == 0L) {
+    return(as.numeric(NA))
+  }
+
+  tr_ug <- sum(lambdas)
+  tr_ug2 <- sum(lambdas^2)
+
+  if (tr_ug2 < .Machine$double.eps) {
+    return(as.numeric(NA))
+  }
+
+  a <- sqrt(df / tr_ug2)
+  b <- df - sqrt(df * tr_ug^2 / tr_ug2)
+  t3 <- chisq * a + b
+
+  1 - stats::pchisq(t3, df)
+}
+
+#' Scaled F p-value (Wu & Lin 2016)
+#'
+#' @param chisq Chi-square statistic
+#' @param lambdas Eigenvalues of UGamma
+#' @return p-value
+#' @keywords internal
+lav_test_fmg_scaled_f <- function(chisq, lambdas) {
+  if (length(lambdas) == 0L) {
+    return(as.numeric(NA))
+  }
+
+  s1 <- sum(lambdas)
+  s2 <- sum(lambdas^2)
+  s3 <- sum(lambdas^3)
+  denom <- 2 * s1 * s2^2 - s1^2 * s3 + 2 * s2 * s3
+
+  if (denom > 0) {
+    d1f3 <- s1 * (s1^2 * s2 - 2 * s2^2 + 4 * s1 * s3) / denom
+    d2f3 <- (s1^2 * s2 + 2 * s2^2) / (s3 * s1 - s2^2) + 6
+    if (d2f3 < 6) d2f3 <- Inf
+    cf3 <- s1 * (s1^2 * s2 - 2 * s2^2 + 4 * s1 * s3) /
+      (s1^2 * s2 - 4 * s2^2 + 6 * s1 * s3)
+  } else {
+    d1f3 <- Inf
+    d2f3 <- s1^2 / s2 + 4
+    cf3 <- s1 * (s1^2 + 2 * s2) / (s1^2 + 4 * s2)
+  }
+
+  1 - stats::pf(chisq / cf3, d1f3, d2f3)
+}
+
+# =====================================================
+# Nested model implementation
+# =====================================================
+
+#' FMG test for nested model comparison
+#'
+#' @param m0 Restricted (null) model
+#' @param m1 Unrestricted (alternative) model
+#' @param test Test specification string (e.g., "pall_ug_ml")
+#' @return List with test results
+#' @keywords internal
+lav_test_fmg_nested <- function(m0, m1, test = "pall") {
+  # Ensure m0 has more df than m1
+  if (m0@test[[1]]$df < m1@test[[1]]$df) {
+    tmp <- m0
+    m0 <- m1
+    m1 <- tmp
+  }
+
+  lav_test_fmg_check_estimator(m0@Options, context = "FMG nested tests")
+  lav_test_fmg_check_estimator(m1@Options, context = "FMG nested tests")
+  if (!isTRUE(m0@Options$estimator.orig == m1@Options$estimator.orig)) {
+    lav_msg_stop(gettextf(
+      "FMG nested tests require both models to use the same estimator; found %1$s and %2$s.",
+      dQuote(m0@Options$estimator.orig),
+      dQuote(m1@Options$estimator.orig)
+    ))
+  }
+  lav_test_fmg_check_missing(m0@Options, context = "FMG nested tests")
+  lav_test_fmg_check_missing(m1@Options, context = "FMG nested tests")
+
+  # Parse test string
+  parsed <- lav_test_fmg_parse(test)
+  chisq <- lav_test_fmg_resolve_chisq(parsed, lavoptions = m1@Options)
+  unbiased <- lav_test_fmg_resolve_unbiased(parsed, lavoptions = m1@Options)
+  label <- lav_test_fmg_label(parsed, unbiased = unbiased, chisq = chisq)
+  if (!parsed$method %in% c("pall", "all", "peba", "pols")) {
+    lav_msg_stop(gettextf(
+      "FMG nested tests only support test= %1$s; found %2$s.",
+      lav_msg_view(c("pall", "all", "peba", "pols"), "or"),
+      dQuote(parsed$method)
+    ))
+  }
+
+  # Get df difference
+  df0 <- m0@test[[1]]$df
+  df1 <- m1@test[[1]]$df
+  df <- df0 - df1
+
+  if (df == 0L) {
+    lav_msg_stop(gettext(
+      "Cannot test models with the same degrees of freedom."
+    ))
+  }
+
+  # Get chi-square difference
+  if (chisq == "rls") {
+    chisq0 <- lav_test_fmg_browne_nt_model(lavobject = m0)$stat
+    chisq1 <- lav_test_fmg_browne_nt_model(lavobject = m1)$stat
+  } else {
+    chisq0 <- m0@test[[1]]$stat
+    chisq1 <- m1@test[[1]]$stat
+  }
+  chisq_diff <- chisq0 - chisq1
+
+  # Get UGamma for nested comparison (Satorra 2000 projection)
+  UGamma <- lav_test_fmg_ugamma_nested(m0, m1, unbiased = unbiased)
+
+  if (is.null(UGamma)) {
+    return(list(
+      test = test,
+      stat = as.numeric(NA),
+      source.stat = chisq_diff,
+      df = df,
+      pvalue = as.numeric(NA),
+      label = label
+    ))
+  }
+
+  # Compute first df eigenvalues
+  eig <- lav_test_fmg_ugamma_eigenvalues(UGamma, df)
+  lambdas <- eig$values
+
+  # Compute p-value (pall is recommended for nested)
+  pvalue <- switch(parsed$method,
+    "pall" = lav_test_fmg_pall(chisq_diff, lambdas),
+    "all"  = lav_test_fmg_all(chisq_diff, lambdas),
+    "peba" = lav_test_fmg_peba(chisq_diff, lambdas, j = parsed$param),
+    "pols" = lav_test_fmg_pols(chisq_diff, lambdas, gamma = parsed$param)
+  )
+  pvalue <- max(0, min(1, pvalue))
+  stat <- lav_test_fmg_chisq_equivalent(pvalue, df)
+
+  list(
+    test = test,
+    stat = stat,
+    source.stat = chisq_diff,
+    df = df,
+    pvalue = pvalue,
+    chisq.type = chisq,
+    unbiased = unbiased,
+    UGamma.eigenvalues = lambdas,
+    UGamma.eigenvalues.raw = eig$raw,
+    UGamma.eigenvalues.truncated = eig$n_truncated,
+    label = label
+  )
+}
+
+#' Compute UGamma for nested models (Satorra 2000 projection)
+#'
+#' @param m0 Restricted model
+#' @param m1 Unrestricted model
+#' @param unbiased Use unbiased gamma?
+#' @return UGamma matrix
+#' @keywords internal
+lav_test_fmg_ugamma_nested <- function(m0, m1, unbiased = FALSE) {
+  lavdata <- m1@Data
+  ngroups <- lavdata@ngroups
+
+  # Get Gamma from m1 (with optional unbiased)
+  if (unbiased) {
+    Gamma <- vector("list", ngroups)
+    for (g in seq_len(ngroups)) {
+      Gamma[[g]] <- lav_samplestats_gamma(
+        m_y = lavdata@X[[g]],
+        meanstructure = m1@Options$meanstructure,
+        unbiased = TRUE
+      )
+    }
+  } else {
+    Gamma <- lavTech(m1, "Gamma")
+    if (is.null(Gamma)) {
+      Gamma <- lavTech(m0, "Gamma")
+    }
+    if (is.null(Gamma)) {
+      lav_msg_stop(gettextf(
+        paste(
+          "Could not calculate the gamma matrix.",
+          "Use estimator= %1$s or test= %2$s when fitting your lavaan model."
+        ),
+        dQuote("MLM"), dQuote("satorra.bentler")
+      ))
+    }
+    if (!is.list(Gamma)) Gamma <- list(Gamma)
+  }
+
+  WLS.V <- lavTech(m1, "WLS.V")
+  PI <- lav_model_delta(m1@Model)
+  P.inv <- lavTech(m1, "inverted.information")
+
+  if (is.null(P.inv)) {
+    return(NULL)
+  }
+
+  A <- lav_test_diff_a(m1, m0, method = "delta", reference = "H1")
+
+  # Handle equality constraints
+  if (m1@Model@eq.constraints) {
+    A <- A %*% t(m1@Model@eq.constraints.K)
+  } else if (m1@Model@ceq.simple.only) {
+    A <- A %*% t(m1@Model@ceq.simple.K)
+  }
+
+  # Safety check: remove zero rows/columns
+  APA <- A %*% P.inv %*% t(A)
+  col_sums <- colSums(APA)
+  row_sums <- rowSums(APA)
+  empty.idx <- which(abs(col_sums) < .Machine$double.eps^0.5 &
+    abs(row_sums) < .Machine$double.eps^0.5)
+  if (length(empty.idx) > 0L) {
+    A <- A[-empty.idx, , drop = FALSE]
+  }
+
+  if (nrow(A) == 0L) {
+    return(NULL)
+  }
+
+  # PAAPAAP projection
+  PAAPAAP <- P.inv %*% t(A) %*% MASS::ginv(A %*% P.inv %*% t(A)) %*%
+    A %*% P.inv
+
+  # Build global matrices
+  fg <- unlist(m1@SampleStats@nobs) / m1@SampleStats@ntotal
+  Gamma_f <- vector("list", length(Gamma))
+  for (g in seq_along(Gamma)) {
+    Gamma_f[[g]] <- Gamma[[g]] / fg[g]
+  }
+  Gamma_all <- lav_matrix_bdiag(Gamma_f)
+
+  V_f <- WLS.V
+  for (g in seq_along(WLS.V)) {
+    V_f[[g]] <- fg[g] * WLS.V[[g]]
+  }
+  V_all <- lav_matrix_bdiag(V_f)
+
+  PI_all <- do.call(rbind, PI)
+
+  # U_global (eq. 22 in Satorra 2000)
+  U_all <- V_all %*% PI_all %*% PAAPAAP %*% t(PI_all) %*% V_all
+  U_all %*% Gamma_all
+}

--- a/man/fitMeasures.Rd
+++ b/man/fitMeasures.Rd
@@ -40,7 +40,9 @@ fitmeasures(object, fit.measures = "all",
   and the options are provided as other named elements in this list. The
   \code{standard.test} option determines the main test statistic (chi-square
   value) that will be used to compute all the fit measures that depend on this
-  test statistic. Usually this is \code{"standard"}. The \code{scaled.test}
+  test statistic. Usually this is \code{"standard"}. FMG p-value tests can be
+  selected here using names such as \code{"peba4"}, \code{"pols3"},
+  \code{"pall"}, or \code{"all"}. The \code{scaled.test}
   option determines which scaling method is to be used for the scaled fit
   measures (in case multiple scaling methods were requested). The
   \code{rmsea.ci.level} option, default 0.9, determines the level of the confidence
@@ -113,6 +115,11 @@ Finally, in some situations (especially when the data contains missing values),
 computing these robust fit indices may be computationally intensive. To avoid
 long runtimes, the calculation of robust fit measures can be disabled by
 setting the \code{robust} argument to \code{FALSE} in the \code{fit.measures} list.
+
+FMG p-values can be selected through the existing \code{standard.test}
+mechanism, for example
+\code{fitMeasures(fit, "pvalue", fm.args = list(standard.test = "peba4"))}.
+No separate FMG-specific fit-measure names are needed.
 }
 \references{
 Brosseau-Liard, P. E., Savalei, V., & Li, L. (2012). An investigation of the
@@ -141,6 +148,14 @@ Psychological Methods.
 Zhang, X., & Savalei, V. (2023). New computations for RMSEA and CFI following
 FIML and TS estimation with missing data. Psychological Methods, 28(2),
 263-283. \doi{https://doi.org/10.1037/met0000445}
+
+Foldnes, N., Moss, J., & Gronneberg, S. (2024). Improved goodness of fit
+procedures for structural equation models. \emph{Structural Equation Modeling:
+A Multidisciplinary Journal}, 1-13. \doi{https://doi.org/10.1080/10705511.2024.2372028}
+
+Foldnes, N., Gronneberg, S., & Moss, J. (2026). Penalized eigenvalue block
+averaging: Extension to nested model comparison and Monte Carlo evaluations.
+\emph{Behavior Research Methods, 58}(4). \doi{https://doi.org/10.3758/s13428-026-02968-4}
 }
 
 \examples{
@@ -156,6 +171,7 @@ fitMeasures(fit, c("chisq", "df", "pvalue", "cfi", "rmsea"),
             output = "matrix")
 fitMeasures(fit, c("chisq", "df", "pvalue", "cfi", "rmsea"),
             output = "text")
+fitMeasures(fit, "pvalue", fm.args = list(standard.test = "peba4"))
 ## specify another threshold for RMSEA confidence interval
 fitMeasures(fit, list(
   fit.measures = c("cfi", "rmsea"),

--- a/man/lavOptions.Rd
+++ b/man/lavOptions.Rd
@@ -327,11 +327,14 @@ Estimation options:
       of test statistics can be provided. If \code{"default"}, the value 
       depends on the values of other arguments. See also the 
       \code{\link{lavTest}} function to extract (alternative) 
-      test statistics from a fitted lavaan object.}
+      test statistics from a fitted lavaan object. FMG test names such as
+      \code{"peba4"}, \code{"pols3"}, \code{"pall"}, and \code{"all"} can be
+      requested here for supported ML-family models.}
    \item{\code{standard.test}:}{Character. Choose the test statistic
     that will be used to compute fit measures (like CFI or RSMEA).
     The default is \code{"standard"}, but it could also be (for example)
-    \code{"Browne.residual.nt"}.}
+    \code{"Browne.residual.nt"}, or an FMG test name such as
+    \code{"peba4"}.}
    \item{\code{scaled.test}:}{Character. Choose the test statistic
     that will be scaled (if a scaled test statistic is requested).
     The default is \code{"standard"}, but it could also be (for example)
@@ -341,7 +344,8 @@ Estimation options:
    \item{\code{gamma.unbiased}}{Logical. If \code{TRUE}, we compute an
      unbiased version for the Gamma matrix. Only available for single-level
      complete data and when \code{conditional.x = FALSE} and 
-     \code{fixed.x = FALSE} (for now).}
+     \code{fixed.x = FALSE} (for now). Suffixless FMG test names use this
+     option to choose between biased and unbiased Gamma.}
    \item{\code{bootstrap}:}{Number of bootstrap draws, if bootstrapping is 
      used.}
    \item{\code{do.fit}:}{If \code{FALSE}, the model is not fit, and the 

--- a/man/lavTest.Rd
+++ b/man/lavTest.Rd
@@ -30,7 +30,14 @@ the model.}
     If \code{"boot"} or \code{"bootstrap"} or \code{"Bollen.Stine"} is 
     included, the
     Bollen-Stine bootstrap is used to compute the bootstrap probability value
-    of the (regular) test statistic.}
+    of the (regular) test statistic. FMG p-value tests can be requested using
+    names such as \code{"peba4"}, \code{"pols3"}, \code{"pall"}, or
+    \code{"all"}. Suffixless FMG names use the standard ML chi-square statistic
+    by default; set \code{scaled.test = "Browne.residual.nt.model"} or
+    \code{scaled.test = "RLS"} to use the Browne residual normal-theory
+    model-based statistic. Suffixes such as \code{"_ml"}, \code{"_rls"},
+    and \code{"_ug"} can be used for explicit control, for example
+    \code{"peba4_ug_rls"} or \code{"pols3_ml"}.}
 \item{scaled.test}{Character. Choose the test statistic 
     that will be scaled (if a scaled test statistic is requested). 
     The default is \code{"standard"}, but it could also be (for example)
@@ -61,4 +68,6 @@ HS.model <- '
 '
 fit <- cfa(HS.model, data = HolzingerSwineford1939)
 lavTest(fit, test = "browne.residual.adf")
+lavTest(fit, test = "peba4", output = "text")
+lavTest(fit, test = "pols3", scaled.test = "RLS", output = "text")
 }

--- a/man/lavTestLRT.Rd
+++ b/man/lavTestLRT.Rd
@@ -22,7 +22,8 @@ anova(object, ...)
   \code{"satorra.2000"}, and \code{"standard"}. See details.}
 \item{test}{Character string specifying which scaled test statistics to use,
   in case multiple scaled \code{test=} options were requested when fitting the
-  model(s). See details.}
+  model(s). See details. FMG nested tests can be requested using names such as
+  \code{"pall"}, \code{"all"}, \code{"peba4"}, or \code{"pols3"}.}
 \item{A.method}{Character string. The possible options are \code{"exact"}
   and \code{"delta"}. This is only used when method = \code{"satorra.2000"}.
   It determines how the Jacobian of the constraint function (the matrix A)
@@ -73,6 +74,14 @@ anova(object, ...)
     Even when test statistics are scaled in \code{object} or \code{...},
     users may request the  \code{method="standard"} test statistic,
     without a robust adjustment.
+
+    FMG nested tests are available when \code{type = "Chisq"} and
+    \code{test} is an FMG test name. The supported nested FMG methods are
+    \code{"pall"}, \code{"all"}, \code{"peba"} and \code{"pols"} variants.
+    They use the Satorra (2000) UGamma projection; \code{method} may be left
+    at \code{"default"} or set to \code{"standard"} or
+    \code{"satorra.2000"}. Other nested LRT methods are not used for FMG
+    tests.
 }
 \note{
   If there is a \code{\linkS4class{lavaan}} model stored in 
@@ -92,6 +101,14 @@ statistic for moment structure analysis. \emph{Psychometrika, 66}(4), 507-514.
 Satorra, A., & Bentler, P. M. (2010). Ensuring postiveness of the scaled
 difference chi-square test statistic. \emph{Psychometrika, 75}(2), 243-248.
 \doi{10.1007/s11336-009-9135-y}
+
+Foldnes, N., Moss, J., & Gronneberg, S. (2024). Improved goodness of fit
+procedures for structural equation models. \emph{Structural Equation Modeling:
+A Multidisciplinary Journal}, 1-13. \doi{10.1080/10705511.2024.2372028}
+
+Foldnes, N., Gronneberg, S., & Moss, J. (2026). Penalized eigenvalue block
+averaging: Extension to nested model comparison and Monte Carlo evaluations.
+\emph{Behavior Research Methods, 58}(4). \doi{10.3758/s13428-026-02968-4}
 }
 \examples{
 HS.model <- '
@@ -153,5 +170,8 @@ lavTestLRT(t6.1, t6.0, type = "browne.residual.adf")
 ## the standard chi-squared difference test (i.e., without a robust correction)
 lavTestLRT(t6.1, t6.0, method = "standard")
 ## == lavTestLRT(update(t6.1, test = "standard"), update(t6.0, test = "standard"))
+
+## FMG nested p-values use the Satorra (2000) UGamma projection
+lavTestLRT(fit1, fit0, method = "satorra.2000", test = "pall")
 
 }


### PR DESCRIPTION
# Add FMG goodness-of-fit p-values

## Summary

This PR integrates selected FMG goodness-of-fit p-value methods from
`semTests` into lavaan's existing model-test infrastructure.

The supported user-facing surface is:

- one-model FMG p-values at fit time via `lavaan(..., test = ...)`
- post-hoc one-model FMG p-values via `lavTest()`
- selected FMG p-values via `fitMeasures(..., fm.args = ...)`
- nested FMG difference tests via `lavTestLRT()`

The implementation is intentionally conservative. Unsupported estimator,
missing-data, scaled-test, and nested-method combinations error before a
p-value is computed.

## API

Suffixless FMG names are the preferred lavaan-style interface:

```r
fit <- cfa(
  model,
  data = dat,
  estimator = "MLM"
)

lavTest(fit, test = "peba4")
lavTest(fit, test = "pols3")
fitMeasures(
  fit,
  fit.measures = c("chisq", "df", "pvalue"),
  fm.args = list(standard.test = "pols3")
)
```

FMG tests can also be computed at fit time:

```r
fit <- cfa(
  model,
  data = dat,
  estimator = "MLM",
  test = "peba4",
  scaled.test = "browne.residual.nt.model",
  gamma.unbiased = TRUE
)
```

Nested FMG tests use the Satorra (2000) UGamma projection:

```r
lavTestLRT(
  fit_restricted,
  fit_unrestricted,
  method = "satorra.2000",
  test = "pall"
)
```

The old semTests-style suffix grammar remains available for explicit control
and parity checks:

```text
<method><parameter>[_ug]_<ml|rls>
```

Examples:

- `peba4_rls`: pEBA with biased Gamma and RLS statistic
- `peba4_ug_rls`: pEBA with unbiased Gamma and RLS statistic
- `pols3_ml`: pOLS with gamma penalty 3 and ML statistic
- `pall_ug_ml`: PALL with unbiased Gamma and ML statistic

## Supported Surface

Supported:

- estimators: `ML`, `MLM`
- missing data: `missing = "listwise"`
- chi-square sources: standard ML and Browne residual NT model-based (`RLS`)
- one-model FMG methods: `peba`, `pols`, `pall`, `all`, and suffixed `sb`,
  `ss`, `sf`, `std`
- nested FMG methods: `peba`, `pols`, `pall`, `all`
- nested LRT methods: `default`, `standard`, `satorra.2000`

Not supported:

- estimators such as `MLR`, `MLF`, `GLS`, `WLS`, `DWLS`, `ULS`, and `PML`
- FIML/direct missing-data options
- Yuan-Bentler, scaled-shifted, mean/variance adjusted, Bollen-Stine, and ADF
  Browne tests as FMG chi-square sources
- mixed original estimators across nested models
- nested `sb`, `ss`, `sf`, and `std` FMG variants

Bare `sb` remains lavaan's native Satorra-Bentler test name. The FMG variants
of `sb`, `ss`, `sf`, and `std` are available only through suffixed names such
as `sb_ml` or `sf_rls`.

## Implementation Notes

The implementation is local to lavaan's existing test infrastructure:

- `R/lav_test_fmg.R` adds FMG parsing, UGamma helpers, p-value methods,
  one-model tests, and nested tests.
- `R/lav_test.R` lets FMG names pass through `lav_test_rename()` and dispatches
  them from `lav_model_test()`.
- `R/lav_options.R` allows FMG names through final `test` option validation.
- `R/lav_samplestats.R` computes `NACOV` for listwise fit-time FMG requests.
- `R/lav_test_LRT.R` adds a narrow FMG branch for nested comparisons.
- `R/lav_test_browne.R` adds a generalized-inverse fallback for grouped RLS
  Browne NT calculations when the fast-path projection matrix is singular.
- `R/lav_fit_measures.R` lets FMG names work through the existing
  `fitMeasures(..., fm.args = list(standard.test = ...))` selected-test path.

No runtime dependency or NAMESPACE entry is added.

FMG test entries keep the standard lavaan test shape: `test`, `stat`,
`stat.group`, `df`, `refdistr`, and `pvalue`. The reported `stat` is a
chi-square-equivalent statistic derived from the FMG p-value so existing
printing and `fitMeasures()` paths work unchanged. The original ML/RLS input
statistic is retained as `source.stat`.

## Documentation

This PR adds minimal package-facing documentation for the new surface:

- `lavTest.Rd` documents FMG test names and suffixes, with `peba4` and `pols3`
  examples.
- `lavTestLRT.Rd` documents nested FMG tests and the Satorra (2000) UGamma
  projection.
- `fitMeasures.Rd` documents selecting FMG p-values through
  `fm.args = list(standard.test = "peba4")`.
- `lavOptions.Rd` notes the FMG behavior for `test`, `standard.test`, and
  `gamma.unbiased`.

Citations were added only to pages that already had references sections.

## Validation

Local parity checks were run against the local `semTests/` for:

- ungrouped, grouped, and meanstructure Holzinger-Swineford one-model tests
- one-model `peba`, `pols`, `pall`, `all`, `sb`, `ss`, `sf`, and `std`
  variants
- arbitrary `pols<gamma>` values, including values other than 2
- fit-time FMG tests, `lavTest()`, `fitMeasures()`, and nested `lavTestLRT()`
- ungrouped and grouped nested comparisons for `pall`, `all`, `peba`, and
  `pols`
- parser and error paths for unsupported estimators, missing-data options,
  scaled-test options, nested methods, same-df comparisons, and mixed
  estimators

```text
test-fmg-pvalues.R: 128 passes
test-fmg-lrt.R:      40 passes
```

The test files are local and are not intended to be part of this PR.
