### PR TITLE
Fix fit-time FMG test dispatch

### DIFF
--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -535,9 +535,15 @@ lav_model_test <- function(lavobject = NULL,
         lavobject = lavobject,
         lavsamplestats = lavsamplestats,
         lavmodel = lavmodel,
+        lavdata = lavdata,
         lavoptions = lavoptions,
         lavimplied = lavimplied,
+        TEST.unscaled = TEST[[1]],
         TEST.chisq = unscaled.TEST,
+        E.inv = attr(VCOV, "E.inv"),
+        Delta = attr(VCOV, "Delta"),
+        WLS.V = attr(VCOV, "WLS.V"),
+        Gamma = attr(VCOV, "Gamma"),
         test = this.test
       )
     } else if (lavoptions$estimator == "PML") {


### PR DESCRIPTION
## Summary

This fixes the fit-time FMG path reported in #539.

After the FMG p-value PR was merged, this example failed:

```r
library(lavaan)
example(cfa)
fit <- cfa(HS.model, data = HolzingerSwineford1939, test = "peba4")
```

At fit time, `lav_model_test()` calls `lav_test_fmg()` with `lavobject = NULL`, so the FMG helper cannot recover `TEST.unscaled` and related matrices from the fitted object. This patch passes the same fit-time objects that are already available in `lav_model_test()` through to `lav_test_fmg()`.

## Scope

This is intentionally narrow: one file changed, six arguments added to the existing FMG dispatch.

## Validation

I verified that:

```r
fit <- cfa(HS.model, data = HolzingerSwineford1939, test = "peba4")
```

now runs and populates `fit@test[["peba4"]]`.

I also ran:

```sh
R CMD build .
R CMD check lavaan_0.6-22.2603.tar.gz
```

Result:

```text
Status: OK
```
