### PR TITLE
if allow.empty.cell, turn off some samplestats computations

### DIFF
--- a/R/lav_samplestats.R
+++ b/R/lav_samplestats.R
@@ -228,7 +228,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,
           } else {
             lav_msg_stop(gettext("data contains no observations"))
           }
-        } else {
+        } else if (!allow.empty.cell) {
           if (ngroups > 1L) {
             lav_msg_stop(gettextf("data contains only a single observation
                                    in group %s", g))
@@ -641,7 +641,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,
             #missing.h1.[[g]]$sigma <- out$Sigma
             #missing.h1.[[g]]$mu <- out$Mu
             #missing.h1.[[g]]$h1 <- out$fx
-          } else {
+          } else if (!allow.empty.cell) {
             out <- lav_mvnorm_missing_h1_estimate_moments(
               y = X[[g]],
               wt = WT[[g]],


### PR DESCRIPTION
Here are two small changes that turn off some code when `allow.empty.cell = TRUE`:
- turn off the check for one observation per group.
- avoid an h1 computation that can become long or result in an error, when there is one observation per group.

These are both intended to help blavaan, which can handle some models with one observation per group. (It potentially allows for estimation of some models with definition variables.)

Relying on `allow.empty.cell` is maybe not the best thing to do because these changes are not related to empty cells. But considering that `allow.empty.cell` was already primarily for blavaan, I thought this might be better than adding a new argument/option. I could be convinced to add a new argument instead if you think it is better!