### PR TITLE
Mean Centered Simple Main Effects in Interaction Models

### DIFF
--- a/R/lav_sam_step1_local.R
+++ b/R/lav_sam_step1_local.R
@@ -1082,15 +1082,15 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
     eeta2 <- ((jac_eeta2_fi_i %*% jac_this2fi_i) +
                                               jac_eeta2_this) %*% jac_x2this
 
-    jac_veta2_fi_i <- get_jac_veta2_fi(x = fi, MTM = this_mtm,
-                         FS.MEAN = fs_mean,
-                         lambda.star = step1$lambda[[1]],
-                         keep.idx = keep_idx)
+    jac_veta2_fi_i <- get_jac_veta2_fi(x = fi, mtm = this_mtm,
+                                       fs_mean = fs_mean,
+                                       lambda_star = step1$lambda[[1]],
+                                       keep_idx = keep_idx)
     jac_veta2_this_i <- matrix(0, nrow = nrow(jac_veta2_fi_i),
                                                   ncol = ncol(jac_this2fi_i))
     jac_veta2_this_i[, idx] <- get_jac_veta2_this(x = this, fi = fi,
-                                               lambda.star = step1$lambda[[1]],
-                                               keep.idx = keep_idx)
+                                                  lambda_star = step1$lambda[[1]],
+                                                  keep_idx = keep_idx)
     veta2 <- ((jac_veta2_fi_i %*% jac_this2fi_i) +
                                        jac_veta2_this_i) %*% jac_x2this
 

--- a/R/lav_standardize.R
+++ b/R/lav_standardize.R
@@ -205,16 +205,18 @@ lav_standardize_lv <- function(lavobject = NULL,
 
           for (dep in lv.int.dep) {
             idx.beta.a <- which(
-              partable$lhs == dep & partable$op == "~" & partable$rhs == a
+              partable$lhs == dep & partable$op == "~" &
+              partable$rhs == a & partable$group == g
             )
 
             idx.beta.b <- which(
-              partable$lhs == dep & partable$op == "~" & partable$rhs == b
+              partable$lhs == dep & partable$op == "~" &
+              partable$rhs == b & partable$group == g
             )
 
             beta.ab <- partable$est[
               partable$lhs == dep & partable$op == "~" &
-              partable$rhs == int.name
+              partable$rhs == int.name & partable$group == g
             ]
 
             out[idx.beta.a] <- out[idx.beta.a] + beta.ab * exp.b

--- a/R/lav_standardize.R
+++ b/R/lav_standardize.R
@@ -139,6 +139,11 @@ lav_standardize_lv <- function(lavobject = NULL,
       lavmodel = lavmodel,
       GLIST = GLIST
     )
+
+    LV.EETA <- lav_model_eeta(
+      lavmodel = lavmodel,
+      GLIST = GLIST
+    )
   }
 
   for (g in 1:lavmodel@nblocks) {
@@ -163,6 +168,7 @@ lav_standardize_lv <- function(lavobject = NULL,
     # change negative values to NA
     ETA2[ETA2 < 0] <- as.numeric(NA)
     ETA <- sqrt(ETA2)
+    EETA <- LV.EETA[[g]]
 
     # Interaction/quadratic term correction (FV)
     # (based on Kelava & Brandt, 2022; Brandt et al., 2015)
@@ -176,22 +182,54 @@ lav_standardize_lv <- function(lavobject = NULL,
       # Replace ETA for interaction terms with SD(A)*SD(B)
       for (int.name in lv.int.names) {
         components <- strsplit(int.name, ":", fixed = TRUE)[[1L]]
+        a <- components[1]
+        b <- components[2]
+
         idx.int <- match(int.name, lv.names)
-        idx.a <- match(components[1], lv.names)
-        idx.b <- match(components[2], lv.names)
+        idx.a   <- match(a, lv.names)
+        idx.b   <- match(b, lv.names)
+
+        # Need a, b and interaction term before moving on
         if (is.na(idx.a) || is.na(idx.b) || is.na(idx.int)) next
+
+        exp.a <- EETA[idx.a]
+        exp.b <- EETA[idx.b]
+
+        # Do we need to shift simple main effects?
+        if (exp.a != 0 || exp.b != 0) {
+
+          # Find dependent variables
+          lv.int.dep <- unique(partable$lhs[
+            partable$op == "~" & partable$rhs == int.name
+          ])
+
+          for (dep in lv.int.dep) {
+            idx.beta.a <- which(
+              partable$lhs == dep & partable$op == "~" & partable$rhs == a
+            )
+
+            idx.beta.b <- which(
+              partable$lhs == dep & partable$op == "~" & partable$rhs == b
+            )
+
+            beta.ab <- partable$est[
+              partable$lhs == dep & partable$op == "~" &
+              partable$rhs == int.name
+            ]
+
+            out[idx.beta.a] <- out[idx.beta.a] + beta.ab * exp.b
+            out[idx.beta.b] <- out[idx.beta.b] + beta.ab * exp.a
+          }
+        }
+
         ETA[idx.int] <- ETA[idx.a] * ETA[idx.b]
         ETA2[idx.int] <- ETA[idx.int]^2
       }
-
-      # Note: centering adjustments for non-zero latent means
-      # are not yet implemented. LSAM has all the information needed;
-      # Brandt et al., 2015, Eqs. 11-12 not needed.
-      lav_msg_warn(gettext("centering adjustments for non-zero
-        latent means are not yet implemented for interaction terms."
-      ))
     }
-    # End interaction/quadratic term correction for now (23/02/26;FV)
+
+    # End interaction/quadratic term correction for now (08/05/26;KS)
+    # The next step is to correctly scale the variances of the interaction
+    # terms
 
     # 1a. "=~" regular indicators
     idx <- which(partable$op == "=~" & !(partable$rhs %in% lv.names) &


### PR DESCRIPTION
Building on #480 and #501.

1. Added mean centering of simple main effects in interaction models.
2. Also fixed an apparent bug introduced when renaming parameters/variables to snake_case in commit 88bfb99b15a38c33198c00bc5cf43173ae4ef383.

There is still an issue of how to compute the correct variance of the interaction terms, when the model has been mean centered.

I also have a concern. It seems like the standard errors using the delta method are quite different, which seems wrong. I think a reason for this is the could be the call to `lav_model_eeta()`. When calculating the jacobian the output from `lav_model_eeta()` is unaffected, which leads to improper standard errors. The more principled way of doing this would likely be to update `GLIST` from `partable` before calling `lav_model_eeta()`. This is also a potential problem with the call to `lav_model_veta()`, but I suspect it is less problematic.

Here you can see an example

```r
library(lavaan)
library(modsem)

m.ncentered <- '
  X =~ x1 + x2 + x3
  Z =~ z1 + z2 + z3
  Y =~ y1 + y2 + y3
  Y ~ X + Z + X:Z

  # intercepts
  X ~ 1
  Z ~ 1
  x1 ~ 0 * 1
  z1 ~ 0 * 1
'

m.centered <- '
  X =~ x1 + x2 + x3
  Z =~ z1 + z2 + z3
  Y =~ y1 + y2 + y3
  Y ~ X + Z + X:Z
'

fit.ncentered <- sam(m.ncentered, oneInt)
standardizedSolution(fit.ncentered)
#> 10   Y  ~   X   0.423 0.027  15.771  0.000    0.371    0.476
#> 11   Y  ~   Z   0.358 0.028  12.981  0.000    0.304    0.412
#> 12   Y  ~ X:Z   0.453 0.017  26.360  0.000    0.419    0.486

fit.centered <- sam(m.centered, oneInt)
standardizedSolution(fit.centered)
#> 10   Y  ~   X   0.423 0.018  23.117  0.000    0.387    0.459
#> 11   Y  ~   Z   0.358 0.017  21.036  0.000    0.325    0.392
#> 12   Y  ~ X:Z   0.453 0.017  26.630  0.000    0.419    0.486
```