### PR TITLE
Document Mean Centering of Simple Main Effects with Multiple Interaction Terms

### DIFF
--- a/R/lav_standardize.R
+++ b/R/lav_standardize.R
@@ -180,7 +180,7 @@ lav_standardize_lv <- function(lavobject = NULL,
     )
 
     if (length(lv.int.names) > 0L) {
-      # Replace ETA for interaction terms with SD(A)*SD(B)
+
       for (int.name in lv.int.names) {
         components <- strsplit(int.name, ":", fixed = TRUE)[[1L]]
         a <- components[1]
@@ -198,6 +198,45 @@ lav_standardize_lv <- function(lavobject = NULL,
 
         # Do we need to shift simple main effects?
         if (exp.a != 0 || exp.b != 0) {
+          # KS, 08/05/26
+          #
+          # This covers the general case of y ~ x + z + w + x:z + x:x
+          # This should naturally extend to other conditions with more
+          # interaction terms. e.g., y ~ x + z + w + x:z + x:x + w:z
+          #
+          # For y = b0 + b1*x + b2*z + b3*xz + b4x^2
+          # b1 and b2 are the slope at the x=0 and z=0. When mean-centering
+          # we have to re-define b1 and b2 to the expected slopes
+          # (i.e., the partial derivatives) at x=mean(x), z=mean(z).
+          #
+          # Computing the partial derivatives we get
+          #
+          #   dy/dx = b1 + b3*z + 2*b4*x
+          #   dy/dz = b2 + b3*x
+          #
+          # With x=mean(x) and z=mean(x), we get
+          #
+          #   dy/dx = b1 + b3 * mean(z) + 2 * b4 * mean(x)
+          #   dy/dz = b2 + b3 * mean(x)
+          #
+          # Since we iteratively update out[<idx>] for b1 and b2, we carry
+          # out all the necessary conditions, by the end of the loop.
+          #
+          # Iteration: 1, interaction term: x:z
+          #   b1 <- b1 + b3 * mean(z)
+          #   b2 <- b2 + b3 * mean(x)
+          #
+          # Iteration: 2, quadratic term: x:x
+          #   b1 <- b1 + b4 * mean(x)
+          #   b1 <- b1 + b4 * mean(x)
+          #
+          #   The above is thus equivalent to b1 + 2 * b4 * mean(x)
+          #
+          # Putting it all together we get
+          #
+          #   b1 <- b1 + b3 * mean(z) + 2 * b4 * mean(x)
+          #   b2 <- b2 + b3 * mean(x)
+          #
 
           # Find dependent variables
           lv.int.dep <- unique(partable$lhs[
@@ -225,14 +264,14 @@ lav_standardize_lv <- function(lavobject = NULL,
           }
         }
 
+        # Replace ETA for interaction terms with SD(A)*SD(B)
         ETA[idx.int] <- ETA[idx.a] * ETA[idx.b]
-        ETA2[idx.int] <- ETA[idx.int]^2
+        ETA2[idx.int] <- ETA[idx.int]^2 # idk what the point of this is (08/05/25;KS)
       }
     }
 
     # End interaction/quadratic term correction for now (08/05/26;KS)
-    # The next step is to correctly scale the variances of the interaction
-    # terms
+    # The next step is to correctly scale the variances of the interaction terms
 
     # 1a. "=~" regular indicators
     idx <- which(partable$op == "=~" & !(partable$rhs %in% lv.names) &

--- a/R/lav_standardize.R
+++ b/R/lav_standardize.R
@@ -266,7 +266,6 @@ lav_standardize_lv <- function(lavobject = NULL,
 
         # Replace ETA for interaction terms with SD(A)*SD(B)
         ETA[idx.int] <- ETA[idx.a] * ETA[idx.b]
-        ETA2[idx.int] <- ETA[idx.int]^2 # idk what the point of this is (08/05/25;KS)
       }
     }
 


### PR DESCRIPTION
Apologies for not doing this in the first place!

When writing the code for #543 I didn't really consider how the mean centering would be applied in more complicated models, where we have multiple interaction terms (including quadratic terms), e.g., `y ~ x + z + x:z + x:x + z:z`.

The code from #543 does work properly for these models, but it's not obvious at first glance. I've now added a comment block explaining how it works with multiple interaction (and quadratic) effects.

It might be a bit too long..., so if you feel like this is an unnecessary change just reject the PR. I just wanted to make sure that this was documented somewhere (e.g., in this PR on GitHub).

Here is an example, showing that we get the same estimates (not considering the standard errors).

```r
library(lavaan)
library(modsem)

m0 <- '
  X =~ x1 + x2 + x3
  Z =~ z1 + z2 + z3
  Y =~ y1 + y2 + y3
  Y ~ X + Z + X:Z + X:X
'

m1 <- '
  X =~ x1 + x2 + x3
  Z =~ z1 + z2 + z3
  Y =~ y1 + y2 + y3
  Y ~ X + Z + X:Z + X:X

  X ~ 1
  Z ~ 1
  x1 ~ 0*1
  z1 ~ 0*1
'

f0 <- sam(m0, oneInt)
standardizedSolution(f0)
#> 10   Y  ~   X   0.423 0.018  23.135  0.000    0.387    0.459
#> 11   Y  ~   Z   0.358 0.017  21.032  0.000    0.325    0.392
#> 12   Y  ~ X:Z   0.454 0.018  25.797  0.000    0.420    0.489
#> 13   Y  ~ X:X  -0.004 0.015  -0.273  0.785   -0.033    0.025

f1 <- sam(m1, oneInt)
standardizedSolution(f2)
#> 10   Y  ~   X   0.423 0.037  11.567  0.000    0.351    0.495
#> 11   Y  ~   Z   0.358 0.028  12.828  0.000    0.303    0.413
#> 12   Y  ~ X:Z   0.454 0.018  25.480  0.000    0.419    0.489
#> 13   Y  ~ X:X  -0.004 0.015  -0.273  0.785   -0.033    0.025
```

Also, I noticed this line, which looks completely unnecessary, as `ETA2` is not used later on. I therefore removed it in the last commit.

```r
ETA2[idx.int] <- ETA[idx.int]^2
```