### PR TITLE
Performance Improvements

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,9 +2,11 @@
 .travis.yml
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.vscode$
 ^code_of_conduct.md
 ^coding_style_guide.md
 ^contributing.md
 ^LICENSE
 .claude
 ^CLAUDE.md
+^tmp$

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ lavaan.Rproj
 .DS_Store
 .claude
 CLAUDE.md
+settings.json
+tmp/
+tools/

--- a/R/lav_model_compute.R
+++ b/R/lav_model_compute.R
@@ -1,3 +1,44 @@
+lav_model_group_mm_indices <- function(nmat) {
+  nmat.cumsum <- cumsum(c(0L, nmat))
+  lapply(seq_along(nmat), function(g) {
+    seq_len(nmat[g]) + nmat.cumsum[g]
+  })
+}
+
+lav_model_sigma_extra <- function(Sigma.hat.g = NULL,
+                                  check.sigma.pd = "chol") {
+  # check if matrix is positive definite
+  if (check.sigma.pd == "chol") {
+    # fast path: try Cholesky directly
+    cS <- tryCatch(chol(Sigma.hat.g), error = function(e) NULL)
+    is_pd <- !is.null(cS)
+  } else {
+    # slow path: eigenvalue-based PD check
+    ev <- eigen(Sigma.hat.g, symmetric = TRUE, only.values = TRUE)$values
+    is_pd <- !(any(ev < sqrt(.Machine$double.eps)) || sum(ev) == 0)
+  }
+
+  if (!is_pd) {
+    Sigma.hat.inv <- MASS::ginv(Sigma.hat.g)
+    Sigma.hat.log.det <- log(.Machine$double.eps)
+    attr(Sigma.hat.g, "po") <- FALSE
+    attr(Sigma.hat.g, "inv") <- Sigma.hat.inv
+    attr(Sigma.hat.g, "log.det") <- Sigma.hat.log.det
+  } else {
+    if (check.sigma.pd != "chol") {
+      cS <- chol(Sigma.hat.g)
+    }
+    Sigma.hat.inv <- chol2inv(cS)
+    d <- diag(cS)
+    Sigma.hat.log.det <- 2 * sum(log(d))
+    attr(Sigma.hat.g, "po") <- TRUE
+    attr(Sigma.hat.g, "inv") <- Sigma.hat.inv
+    attr(Sigma.hat.g, "log.det") <- Sigma.hat.log.det
+  }
+
+  Sigma.hat.g
+}
+
 lav_model_sigma <- function(lavmodel = NULL, GLIST = NULL, extra = FALSE,
                             delta = TRUE) {
   # state or final?
@@ -10,13 +51,14 @@ lav_model_sigma <- function(lavmodel = NULL, GLIST = NULL, extra = FALSE,
   nmat <- lavmodel@nmat
   nblocks <- lavmodel@nblocks
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   Sigma.hat <- vector("list", length = nblocks)
 
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -33,33 +75,10 @@ lav_model_sigma <- function(lavmodel = NULL, GLIST = NULL, extra = FALSE,
     if (lav_debug()) print(Sigma.hat[[g]])
 
     if (extra) {
-      # check if matrix is positive definite
-      if (check.sigma.pd == "chol") {
-        # fast path: try Cholesky directly
-        cS <- tryCatch(chol(Sigma.hat[[g]]), error = function(e) NULL)
-        is_pd <- !is.null(cS)
-      } else {
-        # slow path: eigenvalue-based PD check
-        ev <- eigen(Sigma.hat[[g]], symmetric = TRUE, only.values = TRUE)$values
-        is_pd <- !(any(ev < sqrt(.Machine$double.eps)) || sum(ev) == 0)
-      }
-      if (!is_pd) {
-        Sigma.hat.inv <- MASS::ginv(Sigma.hat[[g]])
-        Sigma.hat.log.det <- log(.Machine$double.eps)
-        attr(Sigma.hat[[g]], "po") <- FALSE
-        attr(Sigma.hat[[g]], "inv") <- Sigma.hat.inv
-        attr(Sigma.hat[[g]], "log.det") <- Sigma.hat.log.det
-      } else {
-        if (check.sigma.pd != "chol") {
-          cS <- chol(Sigma.hat[[g]])
-        }
-        Sigma.hat.inv <- chol2inv(cS)
-        d <- diag(cS)
-        Sigma.hat.log.det <- 2 * sum(log(d))
-        attr(Sigma.hat[[g]], "po") <- TRUE
-        attr(Sigma.hat[[g]], "inv") <- Sigma.hat.inv
-        attr(Sigma.hat[[g]], "log.det") <- Sigma.hat.log.det
-      }
+      Sigma.hat[[g]] <- lav_model_sigma_extra(
+        Sigma.hat.g = Sigma.hat[[g]],
+        check.sigma.pd = check.sigma.pd
+      )
     }
   } # nblocks
   Sigma.hat
@@ -88,13 +107,14 @@ lav_model_cond2joint_sigma <- function(lavmodel = NULL, GLIST = NULL,
   nmat <- lavmodel@nmat
   nblocks <- lavmodel@nblocks
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   Sigma.hat <- vector("list", length = nblocks)
 
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -115,33 +135,10 @@ lav_model_cond2joint_sigma <- function(lavmodel = NULL, GLIST = NULL,
     if (lav_debug()) print(Sigma.hat[[g]])
 
     if (extra) {
-      # check if matrix is positive definite
-      if (check.sigma.pd == "chol") {
-        # fast path: try Cholesky directly
-        cS <- tryCatch(chol(Sigma.hat[[g]]), error = function(e) NULL)
-        is_pd <- !is.null(cS)
-      } else {
-        # slow path: eigenvalue-based PD check
-        ev <- eigen(Sigma.hat[[g]], symmetric = TRUE, only.values = TRUE)$values
-        is_pd <- !(any(ev < sqrt(.Machine$double.eps)) || sum(ev) == 0)
-      }
-      if (!is_pd) {
-        Sigma.hat.inv <- MASS::ginv(Sigma.hat[[g]])
-        Sigma.hat.log.det <- log(.Machine$double.eps)
-        attr(Sigma.hat[[g]], "po") <- FALSE
-        attr(Sigma.hat[[g]], "inv") <- Sigma.hat.inv
-        attr(Sigma.hat[[g]], "log.det") <- Sigma.hat.log.det
-      } else {
-        if (check.sigma.pd != "chol") {
-          cS <- chol(Sigma.hat[[g]])
-        }
-        Sigma.hat.inv <- chol2inv(cS)
-        d <- diag(cS)
-        Sigma.hat.log.det <- 2 * sum(log(d))
-        attr(Sigma.hat[[g]], "po") <- TRUE
-        attr(Sigma.hat[[g]], "inv") <- Sigma.hat.inv
-        attr(Sigma.hat[[g]], "log.det") <- Sigma.hat.log.det
-      }
+      Sigma.hat[[g]] <- lav_model_sigma_extra(
+        Sigma.hat.g = Sigma.hat[[g]],
+        check.sigma.pd = check.sigma.pd
+      )
     }
   } # nblocks
 
@@ -156,13 +153,14 @@ lav_model_mu <- function(lavmodel = NULL, GLIST = NULL) {
   nblocks <- lavmodel@nblocks
   representation <- lavmodel@representation
   meanstructure <- lavmodel@meanstructure
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   Mu.hat <- vector("list", length = nblocks)
 
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (!meanstructure) {
@@ -203,21 +201,18 @@ lav_model_cond2joint_mu <- function(lavmodel = NULL, GLIST = NULL) {
   # state or final?
   if (is.null(GLIST)) GLIST <- lavmodel@GLIST
 
-  # check.sigma.pd -- new in 0.6-21
-  check.sigma.pd <- get0("opt_check_sigma_pd", lavaan_cache_env,
-                         ifnotfound = "chol")
-
   nmat <- lavmodel@nmat
   nblocks <- lavmodel@nblocks
   representation <- lavmodel@representation
   meanstructure <- lavmodel@meanstructure
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   Mu.hat <- vector("list", length = nblocks)
 
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
 
     if (!meanstructure) {
       Mu.hat[[g]] <- numeric(lavmodel@nvar[g])
@@ -249,19 +244,20 @@ lav_model_th <- function(lavmodel = NULL, GLIST = NULL, delta = TRUE) {
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
   th.idx <- lavmodel@th.idx
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   TH <- vector("list", length = nblocks)
 
   # compute TH for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     if (length(th.idx[[g]]) == 0) {
       TH[[g]] <- numeric(0L)
       next
     }
 
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
 
     if (representation == "LISREL") {
       TH[[g]] <- lav_lisrel_th(
@@ -287,14 +283,15 @@ lav_model_pi <- function(lavmodel = NULL, GLIST = NULL, delta = TRUE) {
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
   conditional.x <- lavmodel@conditional.x
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   PI <- vector("list", length = nblocks)
 
   # compute TH for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (!conditional.x) {
@@ -322,14 +319,15 @@ lav_model_gw <- function(lavmodel = NULL, GLIST = NULL) {
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
   group.w.free <- lavmodel@group.w.free
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   GW <- vector("list", length = nblocks)
 
   # compute GW for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (!group.w.free) {
@@ -364,14 +362,15 @@ lav_model_vy <- function(lavmodel = NULL, GLIST = NULL, diagonal.only = FALSE) {
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   VY <- vector("list", length = nblocks)
 
   # compute TH for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -406,14 +405,15 @@ lav_model_veta <- function(lavmodel = NULL, GLIST = NULL,
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   VETA <- vector("list", length = nblocks)
 
   # compute VETA for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -451,14 +451,15 @@ lav_model_vetax <- function(lavmodel = NULL, GLIST = NULL) {
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   ETA <- vector("list", length = nblocks)
 
   # compute ETA for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -490,14 +491,15 @@ lav_model_cov_both <- function(lavmodel = NULL, GLIST = NULL,
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   COV <- vector("list", length = nblocks)
 
   # compute COV for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -538,14 +540,15 @@ lav_model_eeta <- function(lavmodel = NULL, GLIST = NULL, lavsamplestats = NULL,
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   EETA <- vector("list", length = nblocks)
 
   # compute E(ETA) for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -589,14 +592,15 @@ lav_model_eetax <- function(lavmodel = NULL, GLIST = NULL,
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   EETAx <- vector("list", length = nblocks)
 
   # compute E(ETA) for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     EXO <- eXo[[g]]
@@ -646,14 +650,15 @@ lav_model_lambda <- function(lavmodel = NULL, GLIST = NULL,
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   LAMBDA <- vector("list", length = nblocks)
 
   # compute LAMBDA for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -695,14 +700,15 @@ lav_model_theta <- function(lavmodel = NULL, GLIST = NULL, fix = TRUE) {
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   THETA <- vector("list", length = nblocks)
 
   # compute THETA for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -741,14 +747,15 @@ lav_model_ey <- function(lavmodel = NULL, GLIST = NULL, lavsamplestats = NULL,
   nblocks <- lavmodel@nblocks
   nmat <- lavmodel@nmat
   representation <- lavmodel@representation
+  mm.idx <- lav_model_group_mm_indices(nmat)
 
   # return a list
   EY <- vector("list", length = nblocks)
 
   # compute E(Y) for each group
-  for (g in 1:nblocks) {
+  for (g in seq_len(nblocks)) {
     # which mm belong to group g?
-    mm.in.group <- 1:nmat[g] + cumsum(c(0, nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (representation == "LISREL") {
@@ -784,6 +791,7 @@ lav_model_yhat <- function(lavmodel = NULL, GLIST = NULL, lavsamplestats = NULL,
 
   # ngroups, not nblocks!
   ngroups <- lavsamplestats@ngroups
+  mm.idx <- lav_model_group_mm_indices(lavmodel@nmat)
 
   # return a list
   YHAT <- vector("list", length = ngroups)
@@ -792,7 +800,7 @@ lav_model_yhat <- function(lavmodel = NULL, GLIST = NULL, lavsamplestats = NULL,
   for (g in seq_len(ngroups)) {
     # which mm belong to group g?
     # FIXME: what if more than g blocks???
-    mm.in.group <- 1:lavmodel@nmat[g] + cumsum(c(0L, lavmodel@nmat))[g]
+    mm.in.group <- mm.idx[[g]]
     MLIST <- GLIST[mm.in.group]
 
     if (is.null(eXo[[g]]) && duplicate) {


### PR DESCRIPTION
# lavaan Performance Changes

My first pass is focused on the `lavaan/R/lav_model_compute.R` file

My main goal was to see if it could be done and, if so, to do it well.

I wasn't sure where to put the utility functions I created, so I placed them at the top of the R file.

## Why This Area

`lav_model_compute.R` is used by hot fitting paths including objective
evaluation, analytical gradients, model-implied statistics, bootstrap helpers,
prediction, and standardization. Repetitive requests to thes functions have a cascading effect down the line.

The plan was:

- Preserve existing behavior and ensure that an equivalence exists.
- Use the `bench` and `profvis` R libraries for measurement.

## Summary Of Changes

### `lavaan/R/lav_model_compute.R`

Added two internal helper functions:

- `lav_model_group_mm_indices(nmat)`
- `lav_model_sigma_extra(Sigma.hat.g, check.sigma.pd)`

These are helper functions that are used throughout the proposal.

#### Technique: Precompute Group Matrix Indices

Before this change, many functions recomputed this pattern inside every group
loop:

```r
1:nmat[g] + cumsum(c(0, nmat))[g]
```

That means each iteration rebuilt the group offsets. My proposal computes group matrix indices once per function call and reuses them, like this:

```r
mm.idx <- lav_model_group_mm_indices(nmat)
mm.in.group <- mm.idx[[g]]
```

This also replaces `1:nmat[g]` with `seq_len(nmat[g])`, avoiding the usual
R footgun around `1:0`.

#### Technique: Extract Sigma Extra Metadata Handling

Both `lav_model_sigma()` and `lav_model_cond2joint_sigma()` duplicated the same
positive-definiteness, inverse, and log-determinant logic. That logic is now in
`lav_model_sigma_extra()`.

The helper preserves the existing attributes:

- `po`
- `inv`
- `log.det`

It also preserves the existing fast Cholesky path, eigen fallback behavior, and
`MASS::ginv()` fallback for non-positive-definite matrices.

#### Technique: Remove Unused Work

`lav_model_cond2joint_mu()` previously looked up `check.sigma.pd`, but that
value was not used by the function.

## Benchmarking

Benchmarking was performed with `bench` using a baseline copy of the package
where only `R/lav_model_compute.R` was restored from `HEAD`. I executed these benchmarks in separate R sessions.

### Speedup Summary

Values below are current `itr/sec` divided by baseline `itr/sec`.

| Scenario | Expression | Speedup |
| --- | ---: | ---: |
| common CFA with means | gradient | 1.53x |
| common CFA with means | objective | 1.29x |
| common CFA with means | sigma extra true | 1.45x |
| common CFA with means | sigma extra false | 1.36x |
| common CFA without means | gradient | 1.51x |
| common CFA without means | objective | 1.56x |
| conditional.x SEM | gradient | 2.01x |
| conditional.x SEM | objective | 2.32x |
| conditional.x SEM | sigma extra true | 3.97x |
| _larger synthetic CFA_ | gradient | 1.82x |
| _larger synthetic CFA_ | objective | 1.43x |
| multigroup CFA with means | gradient | 1.79x |
| multigroup CFA with means | objective | 1.58x |
| RAM guardrail | gradient | 2.24x |
| RAM guardrail | objective | 2.34x |

Some tiny functions showed mixed results in isolated microbenchmarks, for
example `mu` in a couple of scenarios and `sigma_extra_false` in _larger
synthetic CFA_.

## Profiling Findings

The profvis hotspot extraction still identifies the main active stack as:

- `lav_model_gradient`
- `lav_model_sigma`
- `lav_model_objective`
- `lav_model_sigma_extra`
- `lav_model_mu`

I'd prolly focus on the above in future iterations.

## Verification

The following checks were run after the implementation:

```r
Rscript tools/check-lav-model-compute-equivalence.R
```

Result:

```text
lav_model_compute equivalence checks passed
```

Package check was also run with:

```r
rcmdcheck::rcmdcheck(
  "lavaan",
  args = c("--no-manual"),
  error_on = "never",
  check_dir = tempfile("lavaan-rcmdcheck-")
)
```

## Benchmark Results:

| scenario              | expression        | label_baseline | min_baseline | median_baseline | itr_sec_baseline | mem_alloc_baseline | n_gc_baseline | total_time_baseline | label_current | min_current | median_current | itr_sec_current | mem_alloc_current | n_gc_current | total_time_current | _Speedups_    |
| --------------------- | ----------------- | -------------- | ------------ | --------------- | ---------------- | ------------------ | ------------- | ------------------- | ------------- | ----------- | -------------- | --------------- | ----------------- | ------------ | ------------------ | ----------- |
| common_cfa_ml_mean    | gradient          | baseline       | 165.2µs      | 185.5µs         | 4422.743516      | 8.62KB             | 0             |  11.3ms             | current       | 110.3µs     | 125.1µs        | 6765.808311     | 8.62KB            | 0            |   7.39ms           | 1.529776322 |
| common_cfa_ml_mean    | mu                | baseline       |  10.9µs      |  11.3µs         | 80269.70621      | 0B                 | 0             | 622.9µs             | current       |   9.1µs     |   9.4µs        | 98347.75767     | 0B                | 0            | 508.4µs            | 1.225216365 |
| common_cfa_ml_mean    | objective         | baseline       |  85.5µs      |  89.7µs         | 8906.147023      | 4.34KB             | 0             |   5.61ms            | current       |  59.5µs     |  66.1µs        | 11526.31458     | 4.34KB            | 0            |   4.34ms           | 1.294197653 |
| common_cfa_ml_mean    | sigma_extra_false | baseline       |  13.6µs      |  14.3µs         | 54848.61781      | 1.62KB             | 0             | 911.6µs             | current       |  10.3µs     |  11.3µs        | 74615.72899     | 1.62KB            | 0            | 670.1µs            | 1.360393971 |
| common_cfa_ml_mean    | sigma_extra_true  | baseline       |  46.2µs      |  47.6µs         | 18921.47587      | 2.98KB             | 0             |   2.64ms            | current       |  32.2µs     |  33.8µs        | 27416.79004     | 2.98KB            | 0            |   1.82ms           | 1.448977354 |
| common_cfa_ml_no_mean | gradient          | baseline       | 115.9µs      | 125.8µs         | 7486.262708      | 7.62KB             | 0             |   6.68ms            | current       | 73.8µs      | 83µs           | 11291.52458     | 7.62KB            | 0            |   4.43ms           | 1.508299271 |
| common_cfa_ml_no_mean | mu                | baseline       |   5.7µs      |   6.1µs         | 149566.2578      | 0B                 | 0             | 334.3µs             | current       |  6.5µs      |  7.4µs         | 123701.138      | 0B                | 0            | 404.2µs            | 0.827065809 |
| common_cfa_ml_no_mean | objective         | baseline       |  72.8µs      |  76.7µs         | 10301.2073       | 3.66KB             | 0             |   4.85ms            | current       | 49.9µs      | 55.5µs         | 16046.72807     | 3.66KB            | 0            |   3.12ms           | 1.557752174 |
| common_cfa_ml_no_mean | sigma_extra_false | baseline       |  13.2µs      |  13.8µs         | 66737.85371      | 1.62KB             | 0             | 749.2µs             | current       | 12µs        | 14.1µs         | 60849.45844     | 1.62KB            | 0            | 821.7µs            | 0.911768285 |
| common_cfa_ml_no_mean | sigma_extra_true  | baseline       |  46.1µs      |  48.5µs         | 17284.88955      | 2.98KB             | 0             |   2.89ms            | current       | 36µs        | 39.5µs         | 23019.19801     | 2.98KB            | 0            |   2.17ms           | 1.331752682 |
| conditional_x_sem     | gradient          | baseline       | 202µs        | 230.8µs         | 3253.59848       | 0B                 | 0             |  15.37ms            | current       | 129µs       | 137µs          | 6548.10236      | 0B                | 0            |   7.64ms           | 2.012572357 |
| conditional_x_sem     | mu                | baseline       |  15µs        |  15.6µs         | 58582.30814      | 0B                 | 0             | 853.5µs             | current       |  11.8µs     |  12.2µs        | 75335.24182     | 0B                | 0            | 663.7µs            | 1.285972578 |
| conditional_x_sem     | objective         | baseline       |  92.4µs      | 101.4µs         | 6402.786493      | 0B                 | 0             |   7.81ms            | current       |  61µs       |  63.8µs        | 14822.72027     | 0B                | 0            |   3.37ms           | 2.315042097 |
| conditional_x_sem     | sigma_extra_false | baseline       |  17.2µs      |  18.4µs         | 42870.61648      | 0B                 | 0             |   1.17ms            | current       |  12.9µs     |  13.4µs        | 70008.40101     | 0B                | 0            | 714.2µs            | 1.633015962 |
| conditional_x_sem     | sigma_extra_true  | baseline       |  49µs        |  53.8µs         | 6782.664064      | 0B                 | 1             |   7.22ms            | current       |  32.7µs     |  34.6µs        | 26958.53777     | 0B                | 0            |   1.85ms           | 3.974623763 |
| larger_synthetic_cfa  | gradient          | baseline       | 304.8µs      | 388.1µs         | 2016.576257      | 143.8KB            | 0             |  24.79ms            | current       | 220.7µs     | 268.75µs       | 3664.131088     | 143.8KB           | 0            |  13.65ms           | 1.817005965 |
| larger_synthetic_cfa  | mu                | baseline       |  10.9µs      |  11.5µs         | 69793.4115       | 368B               | 0             | 716.4µs             | current       |   9.2µs     |   9.75µs       | 91962.4793      | 368B              | 0            | 543.7µs            | 1.317638404 |
| larger_synthetic_cfa  | objective         | baseline       | 126.2µs      | 155.2µs         | 4849.707563      |  79.1KB            | 0             |  10.31ms            | current       |  96.9µs     | 121.3µs        | 6938.662226     |  79.1KB           | 0            |   7.21ms           | 1.430738274 |
| larger_synthetic_cfa  | sigma_extra_false | baseline       |  20.3µs      |  21.9µs         | 36659.57915      |  26.7KB            | 0             |   1.36ms            | current       |  17.7µs     |  21.75µs       | 35976.39948     |  26.7KB           | 0            |   1.39ms           | 0.981364225 |
| larger_synthetic_cfa  | sigma_extra_true  | baseline       |  81.1µs      |  90.6µs         | 8487.523341      |  53.3KB            | 0             |   5.89ms            | current       |  59.9µs     |  73.35µs       | 10217.42684     |  53.3KB           | 0            |   4.89ms           | 1.203817231 |
| multigroup_cfa_mean   | gradient          | baseline       | 279.3µs      | 316.4µs         | 2594.610623      | 7.56KB             | 1             |  18.89ms            | current       | 178.6µs     | 197.8µs        | 4633.36206      | 8.22KB            | 0            | 10.79ms            | 1.785763929 |
| multigroup_cfa_mean   | mu                | baseline       |  16.4µs      |  17.1µs         | 53780.7895       | 0B                 | 0             | 929.7µs             | current       |  15.3µs     |  18.7µs        | 43956.04395     | 0B                | 0            |  1.14ms            | 0.817318681 |
| multigroup_cfa_mean   | objective         | baseline       | 150.3µs      | 162.9µs         | 5074.493566      | 3.94KB             | 0             |   9.85ms            | current       | 106µs       | 117µs          | 8002.048524     | 4.59KB            | 0            |  6.25ms            | 1.57691569  |
| multigroup_cfa_mean   | sigma_extra_false | baseline       |  20.7µs      |  21.9µs         | 39488.23251      | 1.31KB             | 0             |   1.27ms            | current       |  19.5µs     |  20.8µs        | 46382.18924     | 1.31KB            | 0            |  1.08ms            | 1.17458256  |
| multigroup_cfa_mean   | sigma_extra_true  | baseline       |  80.1µs      |  83µs           | 11250.1125       | 2.62KB             | 0             |   4.44ms            | current       |  57.2µs     |  59.9µs        | 14851.6352      | 3.28KB            | 1            |  3.3ms             | 1.320132149 |
| ram_cfa_guardrail     | gradient          | baseline       | 225.8µs      | 294.5µs         | 2409.952138      | 36.77KB            | 0             | 20.75ms             | current       | 147.8µs     | 163.5µs        | 5407.433566     | 36.77KB           | 1            |   9.06ms           | 2.243792928 |
| ram_cfa_guardrail     | mu                | baseline       |  23.9µs      |  25.4µs         | 29253.45191      |  2.95KB            | 0             |  1.71ms             | current       |  16.3µs     |  17.9µs        | 53039.14289     |  2.95KB           | 0            | 942.7µs            | 1.81309006  |
| ram_cfa_guardrail     | objective         | baseline       | 127.6µs      | 165µs           | 4713.02397       | 11.65KB            | 0             | 10.61ms             | current       |  75.2µs     |  82.5µs        | 11005.45871     | 11.65KB           | 0            |   4.54ms           | 2.335116218 |
| ram_cfa_guardrail     | sigma_extra_false | baseline       |  29.5µs      |  32.4µs         | 26712.25558      |  5.98KB            | 0             |  1.87ms             | current       |  20.1µs     |  22µs          | 36342.49164     |  5.98KB           | 0            |   1.38ms           | 1.360517517 |
| ram_cfa_guardrail     | sigma_extra_true  | baseline       |  63.8µs      |  68.5µs         | 13397.28303      |  7.34KB            | 0             |  3.73ms             | current       |  42.5µs     |  47.6µs        | 16067.35435     |  7.34KB           | 0            |   3.11ms           | 1.199299463 |

Thanks!