### PR TITLE
perf: Focus on simple CFA path

### DIFF
--- a/R/lav_constraints.R
+++ b/R/lav_constraints.R
@@ -71,6 +71,105 @@ lav_constraints_parse <- function(partable = NULL, constraints = NULL,
     }
   }
 
+  no_explicit_constraints <- is.null(list_1) &&
+    !any(partable$op %in% c(":=", "==", "<", ">")) &&
+    !ceq_simple
+  if (no_explicit_constraints) {
+    def_function <- function() NULL
+    ceq_function <- function() NULL
+    cin_function <- function() NULL
+    ceq_jacobian <- function() NULL
+    cin_jacobian <- function() NULL
+    ceq_jac <- matrix(0, nrow = 0L, ncol = npar)
+    ceq_rhs <- numeric(0L)
+    ceq_theta <- numeric(0L)
+    ceq_linear_idx <- integer(0L)
+    ceq_nonlinear_idx <- integer(0L)
+    ceq_jac_null <- matrix(0, 0L, 0L)
+    ceq_rhs_null <- numeric(0L)
+    ceq_simple_k <- matrix(0, 0, 0)
+
+    upper_idx <- if (is.null(partable$upper)) {
+      integer(0L)
+    } else {
+      which(partable$free > 0L & is.finite(partable$upper))
+    }
+    lower_idx <- if (is.null(partable$lower)) {
+      integer(0L)
+    } else {
+      which(partable$free > 0L & is.finite(partable$lower))
+    }
+    bound_idx <- c(upper_idx, lower_idx)
+    if (length(bound_idx) > 0L) {
+      free <- partable$free
+      free[free > 0L] <- seq_along(free[free > 0L])
+      cin_jac <- matrix(0, nrow = length(bound_idx), ncol = npar)
+      upper_rows <- seq_along(upper_idx)
+      lower_rows <- length(upper_idx) + seq_along(lower_idx)
+      if (length(upper_idx) > 0L) {
+        cin_jac[cbind(upper_rows, free[upper_idx])] <- -1
+      }
+      if (length(lower_idx) > 0L) {
+        cin_jac[cbind(lower_rows, free[lower_idx])] <- 1
+      }
+      cin_rhs <- c(-partable$upper[upper_idx], partable$lower[lower_idx])
+      cin_theta <- c(
+        partable$upper[upper_idx] - theta[free[upper_idx]],
+        theta[free[lower_idx]] - partable$lower[lower_idx]
+      )
+      attr(cin_rhs, "bound.idx") <- seq_along(bound_idx)
+      attr(cin_theta, "bound.idx") <- seq_along(bound_idx)
+      cin_linear_idx <- seq_along(bound_idx)
+      cin_function <- local({
+        upper_free <- free[upper_idx]
+        lower_free <- free[lower_idx]
+        upper <- partable$upper[upper_idx]
+        lower <- partable$lower[lower_idx]
+        function(.x., ...) {
+          out <- c(upper - .x.[upper_free], .x.[lower_free] - lower)
+          attr(out, "bound.idx") <- seq_along(out)
+          out
+        }
+      })
+    } else {
+      cin_jac <- matrix(0, nrow = 0L, ncol = npar)
+      cin_rhs <- numeric(0L)
+      cin_theta <- numeric(0L)
+      cin_linear_idx <- integer(0L)
+    }
+
+    return(list(
+      def.function = def_function,
+      ceq.function = ceq_function,
+      ceq.JAC = ceq_jac,
+      ceq.jacobian = ceq_jacobian,
+      ceq.rhs = ceq_rhs,
+      ceq.theta = ceq_theta,
+      ceq.linear.idx = ceq_linear_idx,
+      ceq.nonlinear.idx = ceq_nonlinear_idx,
+      ceq.linear.flag = FALSE,
+      ceq.nonlinear.flag = FALSE,
+      ceq.flag = FALSE,
+      ceq.linear.only.flag = FALSE,
+      ceq.JAC.NULL = ceq_jac_null,
+      ceq.rhs.NULL = ceq_rhs_null,
+      ceq.simple.only = FALSE,
+      ceq.simple.K = ceq_simple_k,
+      cin.function = cin_function,
+      cin.JAC = cin_jac,
+      cin.jacobian = cin_jacobian,
+      cin.rhs = cin_rhs,
+      cin.theta = cin_theta,
+      cin.linear.idx = cin_linear_idx,
+      cin.nonlinear.idx = integer(0L),
+      cin.linear.flag = length(cin_linear_idx) > 0L,
+      cin.nonlinear.flag = FALSE,
+      cin.flag = FALSE,
+      cin.only.flag = FALSE,
+      cin.simple.only = length(cin_linear_idx) > 0L
+    ))
+  }
+
   # variable definitions
   def_function <- lav_partable_constraints_def(partable,
     con = list_1,

--- a/R/lav_lavaan_step17_lavaan.R
+++ b/R/lav_lavaan_step17_lavaan.R
@@ -34,7 +34,7 @@ lav_lavaan_step17_lavaan <- function(lavmc = NULL,
   lavpartable <- lav_partable_remove_cache(lavpartable)
   lavaan <- new("lavaan", # type_of_slot - where created or modified ?
     # ------------   ------------------------- -
-    version = packageDescription("lavaan", fields = "Version"),
+    version = lav_version(),
     call = lavmc, # match.call - ldw_adapt_match_call
     timing = timing, # list - ldw_add_timing
     Options = lavoptions, # list - options (2) / data (3) / partable (4)
@@ -83,11 +83,11 @@ lav_lavaan_step17_lavaan <- function(lavmc = NULL,
 
   # post-fitting check of parameters
   if (!is.null(lavoptions$check.post) && lavoptions$check.post &&
-    lavTech(lavaan, "converged")) {
+    lavaan@optim$converged) {
     if (lav_verbose()) {
       cat("post check  ...")
     }
-    lavInspect(lavaan, "post.check")
+    lav_object_post_check(lavaan)
     if (lav_verbose()) {
       cat(" done.\n")
     }

--- a/R/lav_object_check_version.R
+++ b/R/lav_object_check_version.R
@@ -11,6 +11,16 @@
 
 # YR 16 Oct 2025 + LDW 22 Oct 2025
 
+lav_version <- local({
+  version <- NULL
+  function() {
+    if (is.null(version)) {
+      version <<- packageDescription("lavaan", fields = "Version")
+    }
+    version
+  }
+})
+
 lav_object_check_version <- function(object = NULL) {
 
   is_lavaan_object <- inherits(object, "lavaan")
@@ -27,10 +37,7 @@ lav_object_check_version <- function(object = NULL) {
   if (.hasSlot(object, "version")) {
     has_version_flag <- TRUE
     lavobject_version <- object@version[1] # lavaan.mi has two
-    lavaanpkg_version <- read.dcf(
-      file = system.file("DESCRIPTION", package = "lavaan"),
-      fields = "Version"
-    )[1]
+    lavaanpkg_version <- lav_version()
     if (lavobject_version != lavaanpkg_version) {
       check_not_needed_flag <- FALSE
     }

--- a/R/lav_object_generate.R
+++ b/R/lav_object_generate.R
@@ -104,7 +104,9 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
       lavoptions$se <- "standard"
     }
   } else {
-    # 0.6-18: slower, but safer to just keep it
+    if (identical(lavoptions$test, "standard")) {
+      lavoptions$se <- "none"
+    }
 
     # 0.6-20 -- except if se = "bootstrap" -> "none"
     if (lavoptions$se == "bootstrap") {

--- a/R/lav_object_post_check.R
+++ b/R/lav_object_post_check.R
@@ -10,7 +10,7 @@ lav_object_post_check <- function(object) {
 
   # 1a. check for negative variances ov
   var_idx <- which(lavpartable$op == "~~" &
-    lavpartable$lhs %in% lav_object_vnames(object, "ov") &
+    lavpartable$lhs %in% lav_partable_vnames(lavpartable, "ov") &
     lavpartable$lhs == lavpartable$rhs)
   if (any(is.na(lavpartable$est[var_idx]))) {
     # perhaps estimator = "IV" + stage 1 only
@@ -22,7 +22,7 @@ lav_object_post_check <- function(object) {
 
   # 1b. check for negative variances lv
   var_idx <- which(lavpartable$op == "~~" &
-    lavpartable$lhs %in% lav_object_vnames(object, "lv") &
+    lavpartable$lhs %in% lav_partable_vnames(lavpartable, "lv") &
     lavpartable$lhs == lavpartable$rhs)
   if (any(is.na(lavpartable$est[var_idx]))) {
     # perhaps estimator = "IV" + stage 1 only

--- a/R/lav_partable_attributes.R
+++ b/R/lav_partable_attributes.R
@@ -23,16 +23,16 @@ lav_partable_attributes <- function(partable, pta = NULL) {
     lapply(seq_len(nblocks), function(b) {
       if (v == "lv.marker") {
         match(pta$vnames[[v]][[b]], tmp_ov[[b]])
-      } else if (grepl("lv", v)) {
+      } else if (startsWith(v, "lv")) {
         match(pta$vnames[[v]][[b]], tmp_lv[[b]])
-      } else if (grepl("th", v)) {
+      } else if (startsWith(v, "th")) {
         # thresholds have '|t' pattern
         tmp_th <- sapply(strsplit(pta$vnames[[v]][[b]],
           "|t",
           fixed = TRUE
         ), "[[", 1L)
         match(tmp_th, tmp_ov[[b]])
-      } else if (grepl("eqs", v)) {
+      } else if (startsWith(v, "eqs")) {
         # mixture of tmp.ov/tmp.lv
         integer(0L)
       } else {

--- a/R/lav_partable_vnames.R
+++ b/R/lav_partable_vnames.R
@@ -70,6 +70,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
   }
   # dotdotdot
   dotdotdot <- list(...)
+  ndotdotdot <- length(dotdotdot)
   type_list <- c(
     "ov", # observed variables (ov)
     "ov.x", # (pure) exogenous observed variables
@@ -124,6 +125,19 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
     } else {
       return_value <- attr(partable, "vnames")[type]
     }
+    if (ndotdotdot == 0L) {
+      if (type[1L] == "all") {
+        return(return_value)
+      } else if (length(type) == 1L) {
+        if (type == "lv.marker") {
+          return(unlist(return_value[[type]]))
+        } else {
+          return(unique(unlist(return_value[[type]])))
+        }
+      } else {
+        return(return_value)
+      }
+    }
   }
   # ----- lav_partable_vnames ---- common ----------------------------------
   if (type[1L] == "all" || type[1L] == "*") {
@@ -136,7 +150,6 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
   # per default, use full partable
   block_select <- lav_partable_block_values(partable)
   # check for ... selection argument(s)
-  ndotdotdot <- length(dotdotdot)
   if (ndotdotdot > 0L) {
     dot_names <- names(dotdotdot)
     row_select <- rep(TRUE, length(partable$lhs))


### PR DESCRIPTION
## Summary

This branch improves latency for the simple Holzinger CFA profiling scenario by trimming avoidable overhead in lavaan’s hot fit path, especially around baseline model work, whch took up a majority of the time

### Changes

- Added a fast path in `lav_constraints_parse()` for parameter tables with no explicit constraints, avoiding dynamic constraint-function construction and numerical Jacobian work for simple bounds-only cases.
- Skipped unnecessary standard error computation for standard-test baseline independence fits, since the baseline stage stores only the baseline parameter table and test results.
- Cached the current lavaan package version to avoid repeatedly reading package metadata during object creation/version checks.
- Avoided extra `lavInspect()`/`lavTech()` dispatch during post-fit checks by calling internal helpers directly where the object is freshly created.
- Added a cached `lav_partable_vnames()` return path for common no-filter lookups.
- Replaced a few regex checks with `startsWith()` in partable attribute handling.

### Profiling Result

For my `cfa_holzinger_ml` scenario:

- Median latency improved from about `129 ms` to about `22 ms`.
- Mean latency improved from about `129 ms` to about `24 ms`.
- Final 400-iteration profiling run showed a $5x$ speedup.

### Verification

- Confirmed key CFA fit statistics and baseline test results stayed equivalent.
- Ran `rcmdcheck` with `--no-manual`: `0 errors`, `0 warnings`, `0 notes`.

== scenario latency summary ==

scenario | iterations | mean_ms | median_ms | p90_ms | p95_ms | p99_ms | max_ms | mem_alloc | gc_count
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
cfa_holzinger_ml | 400 | 23.99 | 22.11 | 28.37 | 29.36 | 53.30 | 245.33 | 78.75 MB | 80
