### PR TITLE
Fix typo. `cov` -> `icov`

### DIFF
--- a/R/lav_samplestats_icov.R
+++ b/R/lav_samplestats_icov.R
@@ -19,7 +19,7 @@ lav_samplestats_icov <- function(COV = NULL, ridge = 0.0, x.idx = integer(0L),
         lav_msg_stop(gettext(
           "sample covariance matrix is not positive-definite"))
       } else {
-        cov <- chol2inv(cS)
+        icov <- chol2inv(cS)
         d <- diag(cS)
         cov.log.det <- 2 * sum(log(d))
         # give a warning


### PR DESCRIPTION
This seems like a simple typo:

```r
cov <- chol2inv(cS) 
```

I think it should be this instead:

```r
icov <- chol2inv(cS) 
```

This matters if `chol(COV)` fails, and `icov` never get's defined, making the return statement fail

```r
list(icov = icov, cov.log.det = cov.log.det)
```