### PR TITLE
Add FMG defaults and clearer test labels

### DIFF
--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -183,6 +183,16 @@ lav_test_rename <- function(test, check = FALSE) {
     test[target_idx] <- "browne.residual.nt.model"
   }
 
+  if (length(target_idx <- which(vapply(
+    test, lav_test_fmg_is_preset, logical(1L)
+  ))) > 0L) {
+    test[target_idx] <- vapply(
+      test[target_idx],
+      lav_test_fmg_resolve_preset,
+      character(1L)
+    )
+  }
+
 
   # check?
   if (check) {

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -71,6 +71,11 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
 
   # shortcut for single argument (just plain LRT)
   if (!any(modp) && !user_h1_exists) {
+    if (lav_test_fmg_is_preset(test)) {
+      test <- lav_test_fmg_resolve_preset(
+        test, nested = FALSE, ngroups = ngroups
+      )
+    }
     if (type == "cf") {
       lav_msg_warn(gettext("`type' argument is ignored for a single model"))
     }
@@ -96,6 +101,12 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
   order_idx <- order(ndf)
   mods <- mods[order_idx]
   ndf <- ndf[order_idx]
+
+  if (lav_test_fmg_is_preset(test)) {
+    test <- lav_test_fmg_resolve_preset(
+      test, nested = TRUE, ngroups = ngroups
+    )
+  }
 
   # here come the checks -- eventually, an option may skip this
   if (TRUE) {
@@ -638,6 +649,12 @@ lav_test_lrt_fmg <- function(mods, test = "pall_ug_ml", method = "default",
 
   parsed <- lav_test_fmg_parse(test)
   chisq <- lav_test_fmg_resolve_chisq(parsed, lavoptions = mods[[1]]@Options)
+  unbiased <- lav_test_fmg_resolve_unbiased(
+    parsed, lavoptions = mods[[1]]@Options
+  )
+  label <- lav_test_fmg_label(parsed, unbiased = unbiased, chisq = chisq)
+  heading_label <- sub(" p-value test \\(", "; ", label)
+  heading_label <- sub("\\)$", "", heading_label)
 
   if (chisq == "rls") {
     TESTlist <- lapply(
@@ -724,8 +741,33 @@ lav_test_lrt_fmg <- function(mods, test = "pall_ug_ml", method = "default",
     lav_msg_warn(gettext("some models have the same degrees of freedom"))
   }
 
+  txt <- if (chisq == "rls") {
+    paste("The ", dQuote("Chisq"), " column contains source RLS ",
+      "test statistics, not the FMG test that should be reported per ",
+      "model. An FMG difference test is a function of two source ",
+      "statistics.",
+      sep = ""
+    )
+  } else {
+    paste("The ", dQuote("Chisq"), " column contains standard ",
+      "test statistics, not the FMG test that should be reported per ",
+      "model. An FMG difference test is a function of two standard ",
+      "(not FMG) statistics.",
+      sep = ""
+    )
+  }
+  note <- paste(strwrap(
+    paste("lavaan NOTE:", txt),
+    width = getOption("width", 80L) - 3L
+  ), collapse = "\n")
+  note <- paste0(
+    "lavaan->lavTestLRT():  \n   ",
+    gsub("\n", "\n   ", note, fixed = TRUE)
+  )
   attr(val, "heading") <- paste0(
-    "\nFMG Chi-Squared Difference Test (test = ", dQuote(test), ")\n"
+    "\nFMG Chi-Squared Difference Test (", heading_label, ")\n\n",
+    note,
+    "\n"
   )
   class(val) <- c("anova", class(val))
 

--- a/R/lav_test_fmg.R
+++ b/R/lav_test_fmg.R
@@ -20,10 +20,60 @@
 lav_test_fmg_is_fmg <- function(test) {
   test <- tolower(test)
   patterns <- c(
-    "^peba", "^pols", "^pall", "^all$",
+    "^fmg($|_)", "^peba", "^pols", "^pall", "^all$",
     "^all_", "^sb_", "^ss_", "^sf_", "^std_"
   )
   any(vapply(patterns, function(p) grepl(p, test), logical(1)))
+}
+
+lav_test_fmg_is_preset <- function(test) {
+  grepl("^fmg($|_)", tolower(test))
+}
+
+lav_test_fmg_resolve_preset <- function(test, nested = FALSE,
+                                        ngroups = 1L) {
+  if (!lav_test_fmg_is_preset(test)) {
+    return(test)
+  }
+
+  test <- tolower(test)
+  splitted <- strsplit(test, "_")[[1L]]
+  if (splitted[1L] != "fmg" || length(splitted) > 3L) {
+    lav_msg_stop(gettextf(
+      "FMG preset does not support test= %1$s.",
+      dQuote(test)
+    ))
+  }
+
+  unbiased <- isTRUE(nested)
+  chisq <- if (isTRUE(nested) && ngroups > 1L) "ml" else "rls"
+
+  if (length(splitted) > 1L) {
+    suffix <- splitted[-1L]
+    if (!all(suffix %in% c("ug", "ml", "rls")) ||
+        sum(suffix %in% c("ml", "rls")) > 1L ||
+        sum(suffix == "ug") > 1L) {
+      lav_msg_stop(gettextf(
+        "FMG preset does not support test= %1$s.",
+        dQuote(test)
+      ))
+    }
+    if ("ug" %in% suffix) {
+      unbiased <- TRUE
+    }
+    if ("ml" %in% suffix) {
+      chisq <- "ml"
+    } else if ("rls" %in% suffix) {
+      chisq <- "rls"
+    }
+  }
+
+  method <- if (isTRUE(nested)) "pall" else "peba4"
+  paste0(
+    method,
+    if (isTRUE(unbiased)) "_ug" else "",
+    "_", chisq
+  )
 }
 
 #' Parse FMG test string into components
@@ -201,9 +251,13 @@ lav_test_fmg_label <- function(parsed, unbiased = FALSE, chisq = "ml") {
     parsed$method
   )
   chisq_label <- if (chisq == "rls") "RLS" else toupper(chisq)
-  gamma_label <- if (isTRUE(unbiased)) "unbiased Gamma, " else ""
+  gamma_label <- if (isTRUE(unbiased)) "unbiased" else "biased"
 
-  paste0(method_label, " p-value test (", gamma_label, chisq_label, ")")
+  paste0(
+    method_label,
+    " p-value test (base: ", chisq_label,
+    ", Gamma: ", gamma_label, ")"
+  )
 }
 
 lav_test_fmg_chisq_equivalent <- function(pvalue, df) {

--- a/man/lavOptions.Rd
+++ b/man/lavOptions.Rd
@@ -329,12 +329,13 @@ Estimation options:
       \code{\link{lavTest}} function to extract (alternative) 
       test statistics from a fitted lavaan object. FMG test names such as
       \code{"peba4"}, \code{"pols3"}, \code{"pall"}, and \code{"all"} can be
-      requested here for supported ML-family models.}
+      requested here for supported ML-family models. The convenience value
+      \code{"fmg"} resolves to \code{"peba4_rls"} for one-model tests.}
    \item{\code{standard.test}:}{Character. Choose the test statistic
     that will be used to compute fit measures (like CFI or RSMEA).
     The default is \code{"standard"}, but it could also be (for example)
     \code{"Browne.residual.nt"}, or an FMG test name such as
-    \code{"peba4"}.}
+    \code{"peba4"} or \code{"fmg"}.}
    \item{\code{scaled.test}:}{Character. Choose the test statistic
     that will be scaled (if a scaled test statistic is requested).
     The default is \code{"standard"}, but it could also be (for example)

--- a/man/lavTest.Rd
+++ b/man/lavTest.Rd
@@ -32,8 +32,10 @@ the model.}
     Bollen-Stine bootstrap is used to compute the bootstrap probability value
     of the (regular) test statistic. FMG p-value tests can be requested using
     names such as \code{"peba4"}, \code{"pols3"}, \code{"pall"}, or
-    \code{"all"}. Suffixless FMG names use the standard ML chi-square statistic
-    by default; set \code{scaled.test = "Browne.residual.nt.model"} or
+    \code{"all"}. The convenience value \code{"fmg"} resolves to
+    \code{"peba4_rls"} for one-model tests. Suffixless FMG names use the
+    standard ML chi-square statistic by default; set
+    \code{scaled.test = "Browne.residual.nt.model"} or
     \code{scaled.test = "RLS"} to use the Browne residual normal-theory
     model-based statistic. Suffixes such as \code{"_ml"}, \code{"_rls"},
     and \code{"_ug"} can be used for explicit control, for example

--- a/man/lavTestLRT.Rd
+++ b/man/lavTestLRT.Rd
@@ -23,7 +23,8 @@ anova(object, ...)
 \item{test}{Character string specifying which scaled test statistics to use,
   in case multiple scaled \code{test=} options were requested when fitting the
   model(s). See details. FMG nested tests can be requested using names such as
-  \code{"pall"}, \code{"all"}, \code{"peba4"}, or \code{"pols3"}.}
+  \code{"pall"}, \code{"all"}, \code{"peba4"}, or \code{"pols3"}; the
+  convenience value \code{"fmg"} resolves to the recommended nested default.}
 \item{A.method}{Character string. The possible options are \code{"exact"}
   and \code{"delta"}. This is only used when method = \code{"satorra.2000"}.
   It determines how the Jacobian of the constraint function (the matrix A)
@@ -78,6 +79,9 @@ anova(object, ...)
     FMG nested tests are available when \code{type = "Chisq"} and
     \code{test} is an FMG test name. The supported nested FMG methods are
     \code{"pall"}, \code{"all"}, \code{"peba"} and \code{"pols"} variants.
+    The convenience value \code{"fmg"} resolves to \code{"pall_ug_rls"} for
+    single-group comparisons and \code{"pall_ug_ml"} for multiple-group
+    comparisons.
     They use the Satorra (2000) UGamma projection; \code{method} may be left
     at \code{"default"} or set to \code{"standard"} or
     \code{"satorra.2000"}. Other nested LRT methods are not used for FMG


### PR DESCRIPTION
## Summary

This PR adds a small FMG usability cleanup.

Users can now request the recommended FMG test with `test = "fmg"` or `test = "FMG"`. The request is resolved to an explicit test internally:

- one model: `peba4_rls`
- nested models without groups: `pall_ug_rls`
- nested models with groups: `pall_ug_ml`

These defaults follow the recommendations in Foldnes, Moss, & Grønneberg (2024), Foldnes, Grønneberg, & Moss (2026), and the current WIP paper on restricted nested-model defaults.

The printed labels are also a little clearer. They now show the base statistic and Gamma choice directly, for example:

`pEBA-4 p-value test (base: RLS, Gamma: biased)`

and for nested comparisons:

`FMG Chi-Squared Difference Test (PALL; base: RLS, Gamma: unbiased)`

The FMG nested output also includes the usual lavaan note clarifying what the `Chisq` column contains.

## Validation

- Behavior probe for `lavTest(..., test = "FMG")` and `lavTestLRT(..., test = "FMG")`
- `R CMD build .`
- `R CMD check lavaan_0.6-22.2642.tar.gz` - Status: OK

During `R CMD check`, repository index access for CRAN/Bioconductor emitted network warnings, but the dependency check continued and the final check status was OK.

## References

Foldnes, N., Moss, J., & Grønneberg, S. (2024). Improved goodness of fit procedures for structural equation models. *Structural Equation Modeling: A Multidisciplinary Journal*, 1-13. https://doi.org/10.1080/10705511.2024.2372028

Foldnes, N., Grønneberg, S., & Moss, J. (2026). Penalized eigenvalue block averaging: Extension to nested model comparison and Monte Carlo evaluations. *Behavior Research Methods, 58*(4). https://doi.org/10.3758/s13428-026-02968-4
