### PR TITLE
Rename function args to snake_case, add backward-compatibility for ...

### DIFF
--- a/R/lav_lavaanList_simulate.R
+++ b/R/lav_lavaanList_simulate.R
@@ -4,16 +4,16 @@
 # YR - 26 Oct 2024: rm pop.model, add est.true argument
 
 lavSimulate <- function(model = NULL, # user model
-                        dataFunction = lav_data_simulate_old,
-                        dataFunction.args = list(),
-                        est.true = NULL,
+                        data_function = lav_data_simulate_old,
+                        data_function_args = list(),
+                        est_true = NULL,
                         ndat = 1000L,
                         cmd = "sem",
                         ...,
-                        store.slots = c("partable"),
-                        FUN = NULL,
-                        show.progress = FALSE,
-                        store.failed = FALSE,
+                        store_slots = c("partable"),
+                        fun = NULL,
+                        show_progress = FALSE,
+                        store_failed = FALSE,
                         parallel = c("no", "multicore", "snow"),
                         ncpus = max(1L, parallel::detectCores() - 1L),
                         cl = NULL,
@@ -21,27 +21,43 @@ lavSimulate <- function(model = NULL, # user model
   # dotdotdot
   dotdotdot <- list(...)
 
+  # convert old names of function arguments (now in ...)
+  oldargs <- c("dataFunction", "dataFunction.args", "est.true", "FUN", "show.progress", "store.failed", "store.slots")
+  newargs <- lav_snake_case(oldargs)
+  oldidx <- match(names(dotdotdot), oldargs, nomatch = 0L)
+  for (j in seq_along(oldidx)) {
+    if (oldidx[j] > 0L) {
+      k <- oldidx[j]                      # assign to new argument
+      assign(newargs[k], dotdotdot[[j]])
+    }
+  }
+  for (j in rev(seq_along(oldidx))) {
+    if (oldidx[j] > 0L) {                 # remove from dotdotdot
+      dotdotdot[[j]] <- NULL
+    }
+  }
+
   # dotdotdot for fit.pop
-  dotdotdot.pop <- dotdotdot
-  dotdotdot.pop$verbose <- FALSE
-  dotdotdot.pop$debug <- FALSE
-  dotdotdot.pop$data <- NULL
-  dotdotdot.pop$sample.cov <- NULL
+  dotdotdot_pop <- dotdotdot
+  dotdotdot_pop$verbose <- FALSE
+  dotdotdot_pop$debug <- FALSE
+  dotdotdot_pop$data <- NULL
+  dotdotdot_pop$sample.cov <- NULL
 
   # 'fit' model without data, check 'true' parameters
-  fit.pop <- do.call(cmd,
-    args = c(list(model = model), dotdotdot.pop)
+  fit_pop <- do.call(cmd,
+    args = c(list(model = model), dotdotdot_pop)
   )
 
   # check est.true= argument
-  stopifnot(!missing(est.true), is.numeric(est.true),
-            length(fit.pop@ParTable$lhs) == length(est.true))
-  fit.pop@ParTable$est <- est.true
-  fit.pop@ParTable$start <- est.true
+  stopifnot(!missing(est_true), is.numeric(est_true),
+            length(fit_pop@ParTable$lhs) == length(est_true))
+  fit_pop@ParTable$est <- est_true
+  fit_pop@ParTable$start <- est_true
 
   # per default, use 'true' values as starting values
   if (is.null(dotdotdot$start)) {
-    dotdotdot$start <- fit.pop
+    dotdotdot$start <- fit_pop
   }
 
   # no warnings during/after the simulations
@@ -50,12 +66,12 @@ lavSimulate <- function(model = NULL, # user model
   # generate simulations
   fit <- do.call("lavaanList", args = c(list(
     model = model,
-    dataFunction = dataFunction,
-    dataFunction.args = dataFunction.args,
+    dataFunction = data_function,
+    dataFunction.args = data_function_args,
     ndat = ndat, cmd = cmd,
-    store.slots = store.slots, FUN = FUN,
-    show.progress = show.progress,
-    store.failed = store.failed,
+    store.slots = store_slots, FUN = fun,
+    show.progress = show_progress,
+    store.failed = store_failed,
     parallel = parallel, ncpus = ncpus,
     cl = cl, iseed = iseed
   ), dotdotdot))
@@ -64,7 +80,7 @@ lavSimulate <- function(model = NULL, # user model
   fit@meta$lavSimulate <- TRUE
 
   # store 'true' parameters in meta$est.true
-  fit@meta$est.true <- est.true
+  fit@meta$est.true <- est_true
 
   fit
 }


### PR DESCRIPTION
…old arg names, and update internal variable names (e.g. dotdotdot_pop, fit_pop); use est_true and new arg names in lavaanList call and meta storage.
This is the first try-out for addign backward compatability for arguments with dotted names via ... argument.
