### PR TITLE
[SAM] fix se = "local" crash when := references step-2 free parameters

### DIFF
--- a/R/lav_sam_step2_se.R
+++ b/R/lav_sam_step2_se.R
@@ -144,8 +144,11 @@ lav_sam_step2_se <- function(fit = NULL, joint = NULL,
       vcov_1 <- vcov_1[-step2_rm_idx, -step2_rm_idx]
     }
     # order rows/cols of VCOV, so that they correspond with the (step 2)
-    # parameters of the JOINT model
-    idx <- sort.int(step2$pt.idx, index.return = TRUE)$ix
+    # parameters of the JOINT model.
+    # step2$pt.idx/pts.idx include rows for defined parameters (:=, <, >);
+    # vcov_1 only has rows for free parameters, so filter those out first.
+    is_free <- fit_pa@ParTable$free[step2$pts.idx] > 0L
+    idx <- sort.int(step2$pt.idx[is_free], index.return = TRUE)$ix
     vcov_1 <- vcov_1[idx, idx]
 
     out$VCOV <- vcov_1


### PR DESCRIPTION
Hi Yves, it seems like the SEs were not working for defined parameters. This was a quick fix, but let me know. Below a MRE:

```r
# reproducble example: sam() with se = "local" crashes
# when := defined parameters reference a coefficient of a latent interaction term. 
# bootstrapping SEs works

#library(lavaan); packageVersion("lavaan")  # 0.6-21
#library(modsem)

set.seed(1234); N <- 10000

# latent predictors X, W; latent mediator M; latent outcome Y
X <- rnorm(N)
W <- rnorm(N)
M <- 0.4*X + 0.3*W + 0.35*(X*W) + rnorm(N, sd = 0.7)
Y <- 0.5*M + 0.15*X            + rnorm(N, sd = 0.7)

# three indicators for each lat var
mk <- function(eta, prefix, loadings = c(1, 0.9, 0.85), err_sd = 0.5) {
  Z <- sapply(loadings, function(l) l*eta + rnorm(length(eta), sd = err_sd))
  colnames(Z) <- paste0(prefix, seq_along(loadings))
  as.data.frame(Z)
}
dat <- cbind(mk(X, "x"), mk(W, "w"), mk(M, "m"), mk(Y, "y"))

# model A (no defined parameters) 
model_A <- '
  X =~ x1 + x2 + x3
  W =~ w1 + w2 + w3
  M =~ m1 + m2 + m3
  Y =~ y1 + y2 + y3

  M ~ a1*X + a2*W + a3*X:W
  Y ~ b*M  + cp*X
'
fit_A <- sam(model_A, data = dat, se = "local"); summary(fit_A) # works as expected

# model B: same model + one := for a3 
model_B <- '
  X =~ x1 + x2 + x3
  W =~ w1 + w2 + w3
  M =~ m1 + m2 + m3
  Y =~ y1 + y2 + y3

  M ~ a1*X + a2*W + a3*X:W
  Y ~ b*M  + cp*X

  imm := a3 * b   # moderated mediation(?)
'
fit_B <- sam(model_B, data = dat, se = "local")
# Error in VCOV[idx, idx] : subscript out of bounds
# traceback:
#3: (function () 
#  traceback(2))()
#2: lav_sam_step2_se(FIT = FIT, JOINT = JOINT, STEP1 = STEP1, STEP2 = STEP2, 
#                    local.options = local.options)
#1: sam(model_B, data = dat, se = "local")

# model C: identical to B, but bootstrap SEs
fit_C <- sam(model_B, data = dat, se = "bootstrap", bootstrap = 200); summary(fit_C) # worls

# check against modsem on the same model_B
fit_dblcent <- modsem(model_B, data = dat); summary(fit_dblcent)
fit_lms     <- modsem_da(model_B, data = dat, method = "lms"); summary(fit_lms)
```
