### PR TITLE
Shorten function names, also adapt arguments of changed exported …

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -180,7 +180,66 @@ export("lavaan", "cfa", "sem", "growth",
        "lav_plotinfo_tikzcode",
        "lav_plotinfo_rgraph",
        "lav_plotinfo_svgcode",
-       "lav_plot"
+       "lav_plot",
+
+       # shortened function names
+       "lav_mat_dup_ginv_pre_post",
+       "lav_mat_ortho_complement",
+       "lav_func_grad_complex",
+       "lav_mat_dup_ginv_post",
+       "lav_func_grad_simple",
+       "lav_mat_vech_row_idx",
+       "lav_mat_vech_col_idx",
+       "lav_mat_antidiag_idx",
+       "lav_mat_dup_pre_post",
+       "lav_mat_dup_ginv_pre",
+       "lav_mat_com_pre_post",
+       "lav_pt_unrestricted",
+       "lav_pt_independence",
+       "lav_mat_vechru_idx",
+       "lav_mat_upper2full",
+       "lav_mat_lower2full",
+       "lav_mat_com_mn_pre",
+       "lav_samp_from_data",
+       "lav_mat_vechru_rev",
+       "lav_mat_vechr_idx",
+       "lav_mat_vechu_idx",
+       "lav_mat_diagh_idx",
+       "lav_pt_attributes",
+       "lav_mat_vechr_rev",
+       "lav_mat_vechu_rev",
+       "lav_mat_vech_idx",
+       "lav_mat_diag_idx",
+       "lav_mat_dup_post",
+       "lav_mat_dup_ginv",
+       "lav_mat_com_post",
+       "lav_mat_sym_sqrt",
+       "lav_mat_vech_rev",
+       "lav_mat_dup_pre",
+       "lav_mat_com_pre",
+       "lav_pt_complete",
+       "lav_mat_vechru",
+       "lav_pt_con_def",
+       "lav_pt_con_ceq",
+       "lav_pt_con_ciq",
+       "lav_pt_from_lm",
+       "lav_con_parse",
+       "lav_mat_vechr",
+       "lav_mat_vechu",
+       "lav_mat_bdiag",
+       "lav_mat_trace",
+       "lav_pt_labels",
+       "lav_mat_vecr",
+       "lav_mat_vech",
+       "lav_pt_merge",
+       "lav_mat_vec",
+       "lav_mat_dup",
+       "lav_mat_com",
+       "lav_mat_cov",
+       "lav_pt_ndat",
+       "lav_pt_npar",
+       "lav_pt_add",
+       "lav_pt_df"
 
        # deprecated functions
        #"vech", "vech.reverse", "vechru", "vechru.reverse", "lower2full",
@@ -209,8 +268,8 @@ exportMethods(
 
 S3method(print, lavaan.data.frame, lav_dataframe_print)
 S3method(print, lavaan.list, lav_lavaanlist_print)
-S3method(print, lavaan.matrix, lav_matrix_print)
-S3method(print, lavaan.matrix.symmetric, lav_matrix_symmetric_print)
+S3method(print, lavaan.matrix, lav_mat_print)
+S3method(print, lavaan.matrix.symmetric, lav_mat_sym_print)
 S3method(print, lavaan.vector, lav_vector_print)
 S3method(print, lavaan.parameterEstimates, lav_parameterestimates_print)
 S3method(print, lavaan.fitMeasures, lav_fitmeasures_print)

--- a/R/lav_bootstrap.R
+++ b/R/lav_bootstrap.R
@@ -235,8 +235,8 @@ lav_bootstrap_internal <- function(object = NULL,
   # if bollen.stine, transform data here
   if (type == "bollen.stine") {
     for (g in 1:lavsamplestats_1@ngroups) {
-      sigma_sqrt <- lav_matrix_symmetric_sqrt(sigma_hat[[g]])
-      s_inv_sqrt <- lav_matrix_symmetric_sqrt(lavsamplestats_1@icov[[g]])
+      sigma_sqrt <- lav_mat_sym_sqrt(sigma_hat[[g]])
+      s_inv_sqrt <- lav_mat_sym_sqrt(lavsamplestats_1@icov[[g]])
 
       # center (needed???)
       x_1 <- scale(lavdata_1@X[[g]], center = TRUE, scale = FALSE)
@@ -320,8 +320,8 @@ lav_bootstrap_internal <- function(object = NULL,
       }
 
       # Transform the data (p. 263)
-      s_a_sqrt <- lav_matrix_symmetric_sqrt(s_a)
-      s_inv_sqrt <- lav_matrix_symmetric_sqrt(lavsamplestats_1@icov[[g]])
+      s_a_sqrt <- lav_mat_sym_sqrt(s_a)
+      s_inv_sqrt <- lav_mat_sym_sqrt(lavsamplestats_1@icov[[g]])
 
       x_1 <- lavdata_1@X[[g]]
       x_1 <- x_1 %*% s_inv_sqrt %*% s_a_sqrt
@@ -369,7 +369,7 @@ lav_bootstrap_internal <- function(object = NULL,
       cat(if (interactive()) "\r" else "",
           "  ... bootstrap draw number:", sprintf("%4d", b))
     }
-    boot_sample_stats <- try(lav_samplestats_from_data(
+    boot_sample_stats <- try(lav_samp_from_data(
       lavdata       = new_data,
       lavoptions    = lavoptions_1
     ), silent = TRUE)
@@ -395,7 +395,7 @@ lav_bootstrap_internal <- function(object = NULL,
     # do we need to update Model slot? only if we have fixed exogenous
     # covariates, as their variances/covariances are stored in GLIST
     if (lavmodel_1@fixed.x &&
-        length(lav_partable_vnames(lavpartable_1, "ov.x")) > 0L) {
+        length(lav_pt_vnames(lavpartable_1, "ov.x")) > 0L) {
       model_boot <- NULL
     } else {
       model_boot <- lavmodel_1

--- a/R/lav_bvmix.R
+++ b/R/lav_bvmix.R
@@ -35,7 +35,7 @@ lav_bvmix_cor_twostep_fit <- function(y1, y2, exo = NULL, wt = NULL,
 
   # optim.method
   min_objective <- lav_bvmix_min_objective
-  min_gradient <- lav_bvmix_min_gradient
+  min_gradient <- lav_bvmix_min_grad
   min_hessian <- lav_bvmix_min_hessian
   if (optim_method == "nlminb" || optim_method == "nlminb2") {
     # nothing to do
@@ -165,7 +165,7 @@ lav_bvmix_init_cache <- function(fit_y1 = NULL,
     } else {
       tmp <- na.omit(cbind(z, y2, wt))
       cor_1 <- cov.wt(x = tmp[, 1:2], wt = tmp[, 3], cor = TRUE)$cor[2, 1]
-      sd_1 <- sqrt(lav_matrix_var_wt(tmp[, 2], wt = tmp[, 3]))
+      sd_1 <- sqrt(lav_mat_var_wt(tmp[, 2], wt = tmp[, 3]))
     }
     rho_init <- (cor_1 * sd_1 / sum(dnorm(th_y2)))
   } else {
@@ -176,7 +176,7 @@ lav_bvmix_init_cache <- function(fit_y1 = NULL,
     } else {
       tmp <- na.omit(cbind(y1, y2, wt))
       cor_1 <- cov.wt(x = tmp[, 1:2], wt = tmp[, 3], cor = TRUE)$cor[2, 1]
-      sd_1 <- sqrt(lav_matrix_var_wt(tmp[, 2], wt = tmp[, 3]))
+      sd_1 <- sqrt(lav_mat_var_wt(tmp[, 2], wt = tmp[, 3]))
     }
     rho_init <- (cor_1 * sd_1 / sum(dnorm(th_y2)))
   }
@@ -259,7 +259,7 @@ lav_bvmix_logl_cache <- function(cache = NULL) {
   })                                # nolint end
 }
 
-lav_bvmix_gradient_cache <- function(cache = NULL) {
+lav_bvmix_grad_cache <- function(cache = NULL) {
   with(cache, {                     # nolint start
     rho <- theta[1L]
 
@@ -329,14 +329,14 @@ lav_bvmix_min_objective <- function(x, cache = NULL) {
 }
 
 # compute gradient, for specific 'x' (nlminb)
-lav_bvmix_min_gradient <- function(x, cache = NULL) {
+lav_bvmix_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_bvmix_logl_cache(cache = cache)
     rm(tmp)
   }
-  -1 * lav_bvmix_gradient_cache(cache = cache) / cache$n
+  -1 * lav_bvmix_grad_cache(cache = cache) / cache$n
 }
 
 # compute hessian, for specific 'x' (nlminb)
@@ -344,14 +344,14 @@ lav_bvmix_min_hessian <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     tmp <- lav_bvmix_logl_cache(cache = cache)
-    tmp <- lav_bvmix_gradient_cache(cache = cache)
+    tmp <- lav_bvmix_grad_cache(cache = cache)
     rm(tmp)
   }
   -1 * lav_bvmix_hessian_cache(cache = cache) / cache$n
 }
 
 
-lav_bvmix_cor_scores_cache <- function(cache = NULL,
+lav_bvmix_cor_sc_cache <- function(cache = NULL,
                                        sigma_correction = FALSE,
                                        na_zero = FALSE) {
   with(cache, {                           # nolint start
@@ -445,7 +445,7 @@ lav_bvmix_cor_scores_cache <- function(cache = NULL,
 #
 # Y1 = linear
 # Y2 = ordinal
-lav_bvmix_cor_scores <- function(y1, y2, exo = NULL, wt = NULL,
+lav_bvmix_cor_sc <- function(y1, y2, exo = NULL, wt = NULL,
                                  rho = NULL,
                                  fit_y1 = NULL, fit_y2 = NULL,
                                  evar_y1 = NULL, beta_y1 = NULL,
@@ -477,7 +477,7 @@ lav_bvmix_cor_scores <- function(y1, y2, exo = NULL, wt = NULL,
   )
   cache$theta <- rho
 
-  sc <- lav_bvmix_cor_scores_cache(
+  sc <- lav_bvmix_cor_sc_cache(
     cache = cache,
     sigma_correction = sigma_correction,
     na_zero = na_zero

--- a/R/lav_bvord.R
+++ b/R/lav_bvord.R
@@ -167,7 +167,7 @@ lav_bvord_cor_twostep_fit <- function(y1, y2, exo = NULL, wt = NULL,
 
   # optim.method
   min_objective <- lav_bvord_min_objective
-  min_gradient <- lav_bvord_min_gradient
+  min_gradient <- lav_bvord_min_grad
   min_hessian <- lav_bvord_min_hessian
   if (optim_method == "nlminb" || optim_method == "nlminb2") {
     # nothing to do
@@ -509,7 +509,7 @@ lav_bvord_logl_cache <- function(cache = NULL) {
   })                                     # nolint end
 }
 
-lav_bvord_gradient_cache <- function(cache = NULL) {
+lav_bvord_grad_cache <- function(cache = NULL) {
   with(cache, {              # nolint start
     rho <- theta[1L]
 
@@ -601,14 +601,14 @@ lav_bvord_min_objective <- function(x, cache = NULL) {
 }
 
 # compute gradient, for specific 'x' (nlminb)
-lav_bvord_min_gradient <- function(x, cache = NULL) {
+lav_bvord_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_bvord_logl_cache(cache = cache)
     rm(tmp)
   }
-  -1 * lav_bvord_gradient_cache(cache = cache) / cache$n
+  -1 * lav_bvord_grad_cache(cache = cache) / cache$n
 }
 
 # compute hessian, for specific 'x' (nlminb)
@@ -617,7 +617,7 @@ lav_bvord_min_hessian <- function(x, cache = NULL) {
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_bvord_logl_cache(cache = cache)
-    tmp <- lav_bvord_gradient_cache(cache = cache)
+    tmp <- lav_bvord_grad_cache(cache = cache)
     rm(tmp)
   }
   -1 * lav_bvord_hessian_cache(cache = cache) / cache$n
@@ -627,7 +627,7 @@ lav_bvord_min_hessian <- function(x, cache = NULL) {
 
 
 # casewise scores
-lav_bvord_cor_scores_cache <- function(cache = NULL, na_zero = FALSE,
+lav_bvord_cor_sc_cache <- function(cache = NULL, na_zero = FALSE,
                                        use_weights = TRUE) {
   with(cache, {                 # nolint start
     rho <- theta[1L]
@@ -726,7 +726,7 @@ lav_bvord_cor_scores_cache <- function(cache = NULL, na_zero = FALSE,
 
 
 # casewise scores - no cache
-lav_bvord_cor_scores <- function(y1, y2, exo = NULL, wt = NULL,
+lav_bvord_cor_sc <- function(y1, y2, exo = NULL, wt = NULL,
                                  rho = NULL,
                                  fit_y1 = NULL, fit_y2 = NULL,
                                  th_y1 = NULL, th_y2 = NULL,
@@ -757,7 +757,7 @@ lav_bvord_cor_scores <- function(y1, y2, exo = NULL, wt = NULL,
   )
   cache$theta <- rho
 
-  sc <- lav_bvord_cor_scores_cache(
+  sc <- lav_bvord_cor_sc_cache(
     cache = cache, na_zero = na_zero,
     use_weights = use_weights
   )

--- a/R/lav_bvreg.R
+++ b/R/lav_bvreg.R
@@ -109,7 +109,7 @@ lav_bvreg_cor_twostep_fit <- function(y1, y2, exo = NULL, wt = NULL,
 
   # optim.method
   min_objective <- lav_bvreg_min_objective
-  min_gradient <- lav_bvreg_min_gradient
+  min_gradient <- lav_bvreg_min_grad
   min_hessian <- lav_bvreg_min_hessian
   if (optim_method == "nlminb" || optim_method == "nlminb2") {
     # nothing to do
@@ -156,7 +156,7 @@ lav_bvreg_cor_twostep_fit <- function(y1, y2, exo = NULL, wt = NULL,
   # try 3 (start = 0, step.min = 0.1)
   if (optim$convergence != 0L) {
     control$step.min <- 0.1
-    min_gradient <- lav_bvreg_min_gradient
+    min_gradient <- lav_bvreg_min_grad
     # try again, with different starting value
     optim <- nlminb(
       start = 0, objective = min_objective,
@@ -288,7 +288,7 @@ lav_bvreg_lik_cache <- function(cache = NULL) {
 
     cov_y12 <- rho * sqrt(evar_y1) * sqrt(evar_y2)
     sigma <- matrix(c(evar_y1, cov_y12, cov_y12, evar_y2), 2L, 2L)
-    lik <- exp(lav_mvnorm_loglik_data(
+    lik <- exp(lav_mvn_loglik_data(
       y = cbind(y1c, y2c), wt = NULL,
       mu = c(0, 0), sigma_1 = sigma,
       casewise = TRUE
@@ -315,7 +315,7 @@ lav_bvreg_logl_cache <- function(cache = NULL) {
   })                # nolint end
 }
 
-lav_bvreg_gradient_cache <- function(cache = NULL) {
+lav_bvreg_grad_cache <- function(cache = NULL) {
   with(cache, {     # nolint start
     rho <- theta[1L]
     r <- (1 - rho * rho)
@@ -374,14 +374,14 @@ lav_bvreg_min_objective <- function(x, cache = NULL) {
 }
 
 # compute gradient, for specific 'x' (nlminb)
-lav_bvreg_min_gradient <- function(x, cache = NULL) {
+lav_bvreg_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_bvreg_logl_cache(cache = cache)
     rm(tmp)
   }
-  -1 * lav_bvreg_gradient_cache(cache = cache) / cache$n
+  -1 * lav_bvreg_grad_cache(cache = cache) / cache$n
 }
 
 # compute hessian, for specific 'x' (nlminb)
@@ -389,7 +389,7 @@ lav_bvreg_min_hessian <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     tmp <- lav_bvreg_logl_cache(cache = cache)
-    tmp <- lav_bvreg_gradient_cache(cache = cache)
+    tmp <- lav_bvreg_grad_cache(cache = cache)
     rm(tmp)
   }
   -1 * lav_bvreg_hessian_cache(cache = cache) / cache$n
@@ -397,7 +397,7 @@ lav_bvreg_min_hessian <- function(x, cache = NULL) {
 
 # casewise scores - cache
 # FIXME: should we also set 'lik.toosmall.idx' cases to NA?
-lav_bvreg_cor_scores_cache <- function(cache = NULL) {
+lav_bvreg_cor_sc_cache <- function(cache = NULL) {
   with(cache, {           # nolint start
     rho <- theta[1L]
     r <- (1 - rho * rho)
@@ -463,7 +463,7 @@ lav_bvreg_cor_scores_cache <- function(cache = NULL) {
 #
 # Y1 = linear
 # Y2 = linear
-lav_bvreg_cor_scores <- function(y1, y2, exo = NULL, wt = NULL,
+lav_bvreg_cor_sc <- function(y1, y2, exo = NULL, wt = NULL,
                                  rho = NULL,
                                  fit_y1 = NULL, fit_y2 = NULL,
                                  evar_y1 = NULL, beta_y1 = NULL,
@@ -496,7 +496,7 @@ lav_bvreg_cor_scores <- function(y1, y2, exo = NULL, wt = NULL,
   )
   cache$theta <- rho
 
-  sc <- lav_bvreg_cor_scores_cache(cache = cache)
+  sc <- lav_bvreg_cor_sc_cache(cache = cache)
 
   sc
 }

--- a/R/lav_cfa_bentler1982.R
+++ b/R/lav_cfa_bentler1982.R
@@ -63,7 +63,7 @@ lav_cfa_bentler1982 <- function(s,
   #     theta.y <- matrix(0, p, p)
   #     # insert 'free' parameters only
   #     diag(theta.y) <- x
-  #     lav_matrix_vec(theta.y)
+  #     lav_mat_vec(theta.y)
   # }
   # P <- t(numDeriv::jacobian(func = theta.fy, x = rep(1, q)))
 
@@ -86,7 +86,7 @@ lav_cfa_bentler1982 <- function(s,
     tmp2 <- s_yy - g %*% s_yy %*% g
   }
 
-  # Theta.f    <- as.numeric(solve(tmp1) %*% P %*% lav_matrix_vec(tmp2))
+  # Theta.f    <- as.numeric(solve(tmp1) %*% P %*% lav_mat_vec(tmp2))
   # Note:
   # if only the 'diagonal' element of Theta are free (as usual), then we
   # can write Theta.f as
@@ -107,7 +107,7 @@ lav_cfa_bentler1982 <- function(s,
   theta_yhat <- diag(theta_f, p)
 
   # force (S.yy - Theta.yhat) to be positive definite
-  lambda <- try(lav_matrix_symmetric_diff_smallest_root(s_yy, theta_yhat),
+  lambda <- try(lav_mat_sym_diff_smallest_root(s_yy, theta_yhat),
     silent = TRUE
   )
   if (inherits(lambda, "try-error")) {
@@ -146,7 +146,7 @@ lav_cfa_bentler1982 <- function(s,
   }
 
   # in addition, force PSI to be PD
-  mm_psi <- lav_matrix_symmetric_force_pd(mm_psi, tol = 1e-04)
+  mm_psi <- lav_mat_sym_force_pd(mm_psi, tol = 1e-04)
 
   # residual variances markers
   theta_x <- diag(s_xx - mm_psi)
@@ -161,7 +161,7 @@ lav_cfa_bentler1982 <- function(s,
   if (quadprog) {
     # only really needed if we need to impose (in)equality constraints
     # (TODO)
-    dmat <- lav_matrix_bdiag(rep(list(mm_psi), p))
+    dmat <- lav_mat_bdiag(rep(list(mm_psi), p))
     dvec <- as.vector(t(s_yx))
     eq_idx <- which(t(b_y) != 1) # these must be zero (row-wise!)
     rmat <- diag(nrow(dmat))[eq_idx, , drop = FALSE]
@@ -224,14 +224,14 @@ lav_cfa_bentler1982_internal <- function(lavobject = NULL, # convenience
     # extract slots
     lavmodel <- lavobject@Model
     lavsamplestats <- lavobject@SampleStats
-    lavpartable <- lav_partable_set_cache(lavobject@ParTable, lavobject@pta)
+    lavpartable <- lav_pt_set_cache(lavobject@ParTable, lavobject@pta)
     lavpta <- lavobject@pta
     lavdata <- lavobject@Data
     lavoptions <- lavobject@Options
   }
   if (is.null(lavpta)) {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
   # no structural part!
   if (any(lavpartable$op == "~")) {
@@ -248,7 +248,7 @@ lav_cfa_bentler1982_internal <- function(lavobject = NULL, # convenience
       "bentler1982 estimator not available if std.lv = TRUE"))
   }
 
-  nblocks <- lav_partable_nblocks(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
   stopifnot(nblocks == 1L) # for now
   b <- 1L
   sample_cov <- lavsamplestats@cov[[b]]
@@ -262,7 +262,7 @@ lav_cfa_bentler1982_internal <- function(lavobject = NULL, # convenience
   # (see MIIV)
   theta_idx <- which(names(lavmodel@GLIST) == "theta") # usually '2'
   m_theta <- lavmodel@m.free.idx[[theta_idx]]
-  nondiag_idx <- m_theta[!m_theta %in% lav_matrix_diag_idx(nvar)]
+  nondiag_idx <- m_theta[!m_theta %in% lav_mat_diag_idx(nvar)]
   if (length(nondiag_idx) > 0L) {
     lav_msg_warn(gettext(
       "this implementation of FABIN does not handle correlated residuals yet!"))

--- a/R/lav_cfa_fabin.R
+++ b/R/lav_cfa_fabin.R
@@ -66,7 +66,7 @@ lav_cfa_fabin3 <- function(s, marker_idx = NULL, lambda_nonzero_idx = NULL) {
     fac_idx <- marker_idx[free_idx]
     rm3_idx <- rm3_idx + 1L
     # update inverse
-    s33_inv <- lav_matrix_symmetric_inverse_update(
+    s33_inv <- lav_mat_sym_inverse_update(
       s_inv = s33_inv_1,
       rm_idx = rm3_idx
     )
@@ -93,8 +93,8 @@ lav_cfa_fabin3 <- function(s, marker_idx = NULL, lambda_nonzero_idx = NULL) {
 lav_cfa_fabin_internal <- function(lavmodel = NULL, lavsamplestats = NULL,
                                    lavpartable = NULL,
                                    lavdata = NULL, lavoptions = NULL) {
-  lavpta <- lav_partable_attributes(lavpartable)
-  lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+  lavpta <- lav_pt_attributes(lavpartable)
+  lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   # no structural part!
   if (any(lavpartable$op == "~")) {
     lav_msg_stop(gettext("FABIN estimator only available for CFA models"))
@@ -110,7 +110,7 @@ lav_cfa_fabin_internal <- function(lavmodel = NULL, lavsamplestats = NULL,
       gettext("FABIN estimator not available if std.lv = TRUE"))
   }
 
-  nblocks <- lav_partable_nblocks(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
   stopifnot(nblocks == 1L) # for now
   b <- 1L
   sample_cov <- lavsamplestats@cov[[b]]
@@ -124,7 +124,7 @@ lav_cfa_fabin_internal <- function(lavmodel = NULL, lavsamplestats = NULL,
   # (see MIIV)
   theta_idx <- which(names(lavmodel@GLIST) == "theta") # usually '2'
   m_theta <- lavmodel@m.free.idx[[theta_idx]]
-  nondiag_idx <- m_theta[!m_theta %in% lav_matrix_diag_idx(nvar)]
+  nondiag_idx <- m_theta[!m_theta %in% lav_mat_diag_idx(nvar)]
   if (length(nondiag_idx) > 0L) {
     lav_msg_warn(gettext(
       "this implementation of FABIN does not handle correlated residuals yet!"

--- a/R/lav_cfa_guttman1952.R
+++ b/R/lav_cfa_guttman1952.R
@@ -64,7 +64,7 @@ lav_cfa_guttman1952 <- function(s,
   diag_theta <- diag(theta, nvar)
   s_min_theta <- s - diag_theta
   if (force_pd) {
-    lambda <- try(lav_matrix_symmetric_diff_smallest_root(s, diag_theta),
+    lambda <- try(lav_mat_sym_diff_smallest_root(s, diag_theta),
       silent = TRUE
     )
     if (inherits(lambda, "try-error")) {
@@ -121,10 +121,10 @@ lav_cfa_guttman1952 <- function(s,
     # only useful if (in)equality constraints are needed (TODo)
 
     # PHI MUST be positive-definite
-    phi <- cov2cor(lav_matrix_symmetric_force_pd(phi,
+    phi <- cov2cor(lav_mat_sym_force_pd(phi,
       tol = 1e-04
     )) # option?
-    dmat <- lav_matrix_bdiag(rep(list(phi), nvar))
+    dmat <- lav_mat_bdiag(rep(list(phi), nvar))
     dvec <- as.vector(ys_cor)
     eq_idx <- which(t(m_b) != 1) # these must be zero (row-wise!)
     rmat <- diag(nrow(dmat))[eq_idx, , drop = FALSE]
@@ -198,14 +198,14 @@ lav_cfa_guttman1952_internal <- function(lavobject = NULL, # convenience
     # extract slots
     lavmodel <- lavobject@Model
     lavsamplestats <- lavobject@SampleStats
-    lavpartable <- lav_partable_set_cache(lavobject@ParTable, lavobject@pta)
+    lavpartable <- lav_pt_set_cache(lavobject@ParTable, lavobject@pta)
     lavpta <- lavobject@pta
     lavdata <- lavobject@Data
     lavoptions <- lavobject@Options
   }
   if (is.null(lavpta)) {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
 
   if (missing(zero_after_efa) &&
@@ -238,7 +238,7 @@ lav_cfa_guttman1952_internal <- function(lavobject = NULL, # convenience
       "GUTTMAN1952 estimator not available if std.lv = TRUE"))
   }
 
-  nblocks <- lav_partable_nblocks(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
   stopifnot(nblocks == 1L) # for now
   b <- 1L
   sample_cov <- lavsamplestats@cov[[b]]
@@ -254,7 +254,7 @@ lav_cfa_guttman1952_internal <- function(lavobject = NULL, # convenience
   # (see MIIV)
   theta_idx <- which(names(lavmodel@GLIST) == "theta") # usually '2'
   m_theta <- lavmodel@m.free.idx[[theta_idx]]
-  nondiag_idx <- m_theta[!m_theta %in% lav_matrix_diag_idx(nvar)]
+  nondiag_idx <- m_theta[!m_theta %in% lav_mat_diag_idx(nvar)]
   if (length(nondiag_idx) > 0L) {
     lav_msg_warn(gettext(
       "this implementation of FABIN does not handle correlated residuals yet!"))

--- a/R/lav_cfa_jamesstein.R
+++ b/R/lav_cfa_jamesstein.R
@@ -138,14 +138,14 @@ lav_cfa_jamesstein_internal <- function(lavobject = NULL, # convenience
     # extract slots
     lavmodel <- lavobject@Model
     lavsamplestats <- lavobject@SampleStats
-    lavpartable <- lav_partable_set_cache(lavobject@ParTable, lavobject@pta)
+    lavpartable <- lav_pt_set_cache(lavobject@ParTable, lavobject@pta)
     lavpta <- lavobject@pta
     lavdata <- lavobject@Data
     lavoptions <- lavobject@Options
   }
   if (is.null(lavpta)) {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
 
   # no structural part!
@@ -163,7 +163,7 @@ lav_cfa_jamesstein_internal <- function(lavobject = NULL, # convenience
     lav_msg_stop(gettext("JS(A) estimator not available if std.lv = TRUE"))
   }
 
-  nblocks <- lav_partable_nblocks(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
   stopifnot(nblocks == 1L) # for now
   b <- 1L
   sample_cov <- lavsamplestats@cov[[b]]
@@ -176,7 +176,7 @@ lav_cfa_jamesstein_internal <- function(lavobject = NULL, # convenience
   # only diagonal THETA for now...
   theta_idx <- which(names(lavmodel@GLIST) == "theta") # usually '2'
   m_theta <- lavmodel@m.free.idx[[theta_idx]]
-  nondiag_idx <- m_theta[!m_theta %in% lav_matrix_diag_idx(nvar)]
+  nondiag_idx <- m_theta[!m_theta %in% lav_mat_diag_idx(nvar)]
   if (length(nondiag_idx) > 0L) {
     lav_msg_warn(gettext(
       "this implementation of JS/JSA does not handle correlated residuals yet!"

--- a/R/lav_cfa_utils.R
+++ b/R/lav_cfa_utils.R
@@ -74,7 +74,7 @@ lav_cfa_lambda2thetapsi <- function(lambda = NULL, s = NULL, s_inv = NULL,
 
   # psi
   diag_theta <- diag(theta, nvar)
-  lambda <- try(lav_matrix_symmetric_diff_smallest_root(s, diag_theta),
+  lambda <- try(lav_mat_sym_diff_smallest_root(s, diag_theta),
     silent = TRUE
   )
   if (inherits(lambda, "try-error")) {
@@ -138,7 +138,7 @@ lav_cfa_lambdatheta2psi <- function(lambda = NULL, theta = NULL, # vector!
 
   # psi
   diag_theta <- diag(theta, nvar)
-  lambda <- try(lav_matrix_symmetric_diff_smallest_root(s, diag_theta),
+  lambda <- try(lav_mat_sym_diff_smallest_root(s, diag_theta),
     silent = TRUE
   )
   if (inherits(lambda, "try-error")) {
@@ -190,8 +190,8 @@ lav_cfa_theta_spearman <- function(s, bounds = "wide") {
   r <- cov2cor(s)
   for (p_idx in seq_len(p)) {
     x <- r[, p_idx][-p_idx]
-    aa <- lav_matrix_vech(tcrossprod(x), diagonal = FALSE)
-    ss <- lav_matrix_vech(r[-p_idx, -p_idx, drop = FALSE], diagonal = FALSE)
+    aa <- lav_mat_vech(tcrossprod(x), diagonal = FALSE)
+    ss <- lav_mat_vech(r[-p_idx, -p_idx, drop = FALSE], diagonal = FALSE)
     h2 <- mean(aa / ss) # communaliteit
     if (bounds == "standard") {
       h2[h2 < 0] <- 0

--- a/R/lav_constraints.R
+++ b/R/lav_constraints.R
@@ -1,4 +1,4 @@
-lav_constraints_parse <- function(partable = NULL, constraints = NULL,
+lav_con_parse <- function(partable = NULL, constraints = NULL,
                                   theta = NULL,
                                   debug = FALSE) {
   if (!missing(debug)) {
@@ -72,38 +72,38 @@ lav_constraints_parse <- function(partable = NULL, constraints = NULL,
   }
 
   # variable definitions
-  def_function <- lav_partable_constraints_def(partable,
+  def_function <- lav_pt_con_def(partable,
     con = list_1,
     debug = debug
   )
 
   # construct ceq/ciq functions
-  ceq_function <- lav_partable_constraints_ceq(partable,
+  ceq_function <- lav_pt_con_ceq(partable,
     con = list_1,
     debug = debug
   )
   # linear or nonlinear?
-  ceq_linear_idx <- lav_constraints_linear_idx(
+  ceq_linear_idx <- lav_con_linear_idx(
     func = ceq_function,
     npar = npar
   )
-  ceq_nonlinear_idx <- lav_constraints_nonlinear_idx(
+  ceq_nonlinear_idx <- lav_con_nonlinear_idx(
     func = ceq_function,
     npar = npar
   )
 
   # inequalities
-  cin_function <- lav_partable_constraints_ciq(partable,
+  cin_function <- lav_pt_con_ciq(partable,
     con = list_1,
     debug = debug
   )
 
   # linear or nonlinear?
-  cin_linear_idx <- lav_constraints_linear_idx(
+  cin_linear_idx <- lav_con_linear_idx(
     func = cin_function,
     npar = npar
   )
-  cin_nonlinear_idx <- lav_constraints_nonlinear_idx(
+  cin_nonlinear_idx <- lav_con_nonlinear_idx(
     func = cin_function,
     npar = npar
   )
@@ -314,7 +314,7 @@ lav_constraints_parse <- function(partable = NULL, constraints = NULL,
   out
 }
 
-lav_constraints_linear_idx <- function(func = NULL, npar = NULL) {
+lav_con_linear_idx <- function(func = NULL, npar = NULL) {
   if (is.null(func) || is.null(body(func))) {
     return(integer(0L))
   }
@@ -330,7 +330,7 @@ lav_constraints_linear_idx <- function(func = NULL, npar = NULL) {
   which(linear)
 }
 
-lav_constraints_nonlinear_idx <- function(func = NULL, npar = NULL) {
+lav_con_nonlinear_idx <- function(func = NULL, npar = NULL) {
   if (is.null(func) || is.null(body(func))) {
     return(integer(0L))
   }
@@ -347,7 +347,7 @@ lav_constraints_nonlinear_idx <- function(func = NULL, npar = NULL) {
 }
 
 # check if the equality constraints are 'simple' (a == b)
-lav_constraints_check_simple <- function(lavmodel = NULL) {
+lav_con_check_simple <- function(lavmodel = NULL) {
   ones <- (lavmodel@ceq.JAC == 1 | lavmodel@ceq.JAC == -1)
   simple <- all(lavmodel@ceq.rhs == 0) &&
     all(apply(lavmodel@ceq.JAC != 0, 1, sum) == 2) &&
@@ -358,7 +358,7 @@ lav_constraints_check_simple <- function(lavmodel = NULL) {
   simple
 }
 
-lav_constraints_r2k <- function(lavmodel = NULL) {
+lav_con_r2k <- function(lavmodel = NULL) {
   # constraint matrix
   m_r <- NULL
   if (!is.null(lavmodel)) {
@@ -384,7 +384,7 @@ lav_constraints_r2k <- function(lavmodel = NULL) {
   m_k
 }
 
-lav_constraints_lambda_pre <- function(lavobject = NULL, method = "Don") {
+lav_con_lambda_pre <- function(lavobject = NULL, method = "Don") {
   # compute factor 'pre' so that pre %*% g = lambda
   method <- tolower(method)
 

--- a/R/lav_cor.R
+++ b/R/lav_cor.R
@@ -159,7 +159,7 @@ lav_object_cor <- function(object,                 # nolint start
 
   # generate partable for unrestricted model
   pt_un <-
-    lav_partable_unrestricted(
+    lav_pt_unrestricted(
       lavobject = NULL,
       lavdata = lav_data,
       lavoptions = list(
@@ -172,9 +172,9 @@ lav_object_cor <- function(object,                 # nolint start
         estimator = estimator,
         mimic = mimic
       ),
-      sample.cov = NULL,
-      sample.mean = NULL,
-      sample.th = NULL
+      sample_cov = NULL,
+      sample_mean = NULL,
+      sample_th = NULL
     )
 
 
@@ -191,7 +191,7 @@ lav_object_cor <- function(object,                 # nolint start
   # smooth correlation matrix? (only if output = "cor")
   if (output == "cor" && cor.smooth) {
     tmp_attr <- attributes(out)
-    out <- cov2cor(lav_matrix_symmetric_force_pd(out, tol = cor.smooth.tol))
+    out <- cov2cor(lav_mat_sym_force_pd(out, tol = cor.smooth.tol))
     # we lost most of the attributes
     attributes(out) <- tmp_attr
   }

--- a/R/lav_data.R
+++ b/R/lav_data.R
@@ -441,7 +441,7 @@ lav_lavdata <- function(data = NULL, # data.frame
       if (nlevels > 1L) {
         # ALWAYS add ov.names.x at the end, even if conditional.x
         ov_names_1 <- unique(c(ov_names[[g]], ov_names_x[[g]]))
-        lp[[g]] <- lav_data_cluster_patterns(
+        lp[[g]] <- lav_data_cl_patterns(
           y = NULL, clus = NULL,
           cluster = cluster,
           multilevel = TRUE,
@@ -837,7 +837,7 @@ lav_data_full <- function(data = NULL, # data.frame
     # replace any NAs by 0 (as we only wish to detect perfect correlations)
     cor_1[is.na(cor_1)] <- 0
     if (!inherits(cor_1, "try-error") &&
-        any(lav_matrix_vech(cor_1, diagonal = FALSE) == 1)) {
+        any(lav_mat_vech(cor_1, diagonal = FALSE) == 1)) {
       cor_1[upper.tri(cor_1, diag = TRUE)] <- 0
       idx <- which(cor_1 == 1)
       this_names <- ov$name[num_idx]
@@ -1073,7 +1073,7 @@ lav_data_full <- function(data = NULL, # data.frame
       }
       # ALWAYS add ov.names.x at the end, even if conditional.x (0.6-7)
       ov_names_2 <- unique(c(ov_names[[g]], ov_names_x[[g]]))
-      lp[[g]] <- lav_data_cluster_patterns(
+      lp[[g]] <- lav_data_cl_patterns(
         y = x[[g]], clus = clus,
         cluster = cluster,
         multilevel = multilevel,
@@ -1180,13 +1180,13 @@ lav_data_full <- function(data = NULL, # data.frame
     if (missing != "listwise") {
       if (length(cluster) > 0L) {
         # get missing patterns
-        mp[[g]] <- lav_data_missing_patterns(x[[g]],
+        mp[[g]] <- lav_data_mi_patterns(x[[g]],
           sort_freq = TRUE, coverage = TRUE,
           lp = lp[[g]]
         )
       } else {
         # get missing patterns
-        mp[[g]] <- lav_data_missing_patterns(x[[g]],
+        mp[[g]] <- lav_data_mi_patterns(x[[g]],
           sort_freq = TRUE, coverage = TRUE,
           lp = NULL
         )
@@ -1201,7 +1201,7 @@ lav_data_full <- function(data = NULL, # data.frame
           paste(empty_case_idx, collapse = " ")))
       }
     if (any(mp[[g]]$coverage < 0.1)) {
-      coverage_vech <- lav_matrix_vech(mp[[g]]$coverage, diagonal = FALSE)
+      coverage_vech <- lav_mat_vech(mp[[g]]$coverage, diagonal = FALSE)
       small_idx <- which(coverage_vech < 0.1)
       if (all(coverage_vech[small_idx] == 0)) {
       # 0.6-18: no warning --> this could be due to missing by design

--- a/R/lav_data_patterns.R
+++ b/R/lav_data_patterns.R
@@ -1,5 +1,5 @@
 # get missing patterns
-lav_data_missing_patterns <- function(y, sort_freq = FALSE, coverage = FALSE,
+lav_data_mi_patterns <- function(y, sort_freq = FALSE, coverage = FALSE,
                                       lp = NULL) {
   # handle two-level data
   if (!is.null(lp)) {
@@ -88,7 +88,7 @@ lav_data_missing_patterns <- function(y, sort_freq = FALSE, coverage = FALSE,
 
     # between-level patterns
     if (!is.null(z)) {
-      mp$Zp <- lav_data_missing_patterns(z,
+      mp$Zp <- lav_data_mi_patterns(z,
         sort_freq = FALSE,
         coverage = FALSE, lp = NULL
       )
@@ -145,7 +145,7 @@ lav_data_resp_patterns <- function(y) {
 # get cluster information
 # - cluster can be a vector!
 # - clus can contain multiple columns!
-lav_data_cluster_patterns <- function(y = NULL,
+lav_data_cl_patterns <- function(y = NULL,
                                       clus = NULL, # the cluster ids
                                       cluster = NULL, # the cluster 'names'
                                       multilevel = FALSE,

--- a/R/lav_data_update.R
+++ b/R/lav_data_update.R
@@ -22,7 +22,7 @@ lav_data_update <- function(lavdata = NULL, newX = NULL, # nolint start
 
     # Mp + nobs
     if (lavoptions$missing != "listwise") {
-      newdata@Mp[[g]] <- lav_data_missing_patterns(newX[[g]],
+      newdata@Mp[[g]] <- lav_data_mi_patterns(newX[[g]],
         sort_freq = FALSE, coverage = TRUE
       )
       newdata@nobs[[g]] <-
@@ -44,7 +44,7 @@ lav_data_update <- function(lavdata = NULL, newX = NULL, # nolint start
       for (l in 2:lavdata@nlevels) {
         clus[, (l - 1L)] <- lavdata@Lp[[g]]$cluster.idx[[l]]
       }
-      newdata@Lp[[g]] <- lav_data_cluster_patterns(
+      newdata@Lp[[g]] <- lav_data_cl_patterns(
         y = newX[[g]],
         clus = clus,
         cluster = lavdata@cluster,
@@ -129,7 +129,7 @@ lav_data_update_subset <- function(lavdata = NULL, ov_names = NULL) {
 
     # Mp + nobs
     if (lavdata@missing != "listwise") {
-      newdata@Mp[[g]] <- lav_data_missing_patterns(newdata@X[[g]],
+      newdata@Mp[[g]] <- lav_data_mi_patterns(newdata@X[[g]],
         sort_freq = FALSE, coverage = TRUE
       )
       newdata@nobs[[g]] <-
@@ -158,7 +158,7 @@ lav_data_update_subset <- function(lavdata = NULL, ov_names = NULL) {
         multilevel <- FALSE
       }
       ov_names_1 <- unique(c(ov_names[[g]], newdata@ov.names.x[[g]]))
-      newdata@Lp[[g]] <- lav_data_cluster_patterns(
+      newdata@Lp[[g]] <- lav_data_cl_patterns(
         y = newdata@X[[g]],
         clus = clus,
         cluster = newdata@cluster,

--- a/R/lav_efa_extraction.R
+++ b/R/lav_efa_extraction.R
@@ -22,7 +22,7 @@ lav_efa_extraction <- function(s, nfactors = 1L,
   s_var <- diag(s)
 
   # force S to be pd (eg if we have polychoric correlations)
-  s <- lav_matrix_symmetric_force_pd(s, tol = 1e-08)
+  s <- lav_mat_sym_force_pd(s, tol = 1e-08)
 
   # convert to correlation matrix (ULS is not scale invariant!)
   r <- cov2cor(s)
@@ -30,11 +30,11 @@ lav_efa_extraction <- function(s, nfactors = 1L,
   # optim.method
   if (method == "uls") {
     min_objective <- lav_efa_uls_min_objective
-    min_gradient <- lav_efa_uls_min_gradient
+    min_gradient <- lav_efa_uls_min_grad
     cache <- lav_efa_uls_init_cache(r = r, nfactors = nfactors)
   } else if (method == "ml") {
     min_objective <- lav_efa_ml_min_objective
-    min_gradient <- lav_efa_ml_min_gradient
+    min_gradient <- lav_efa_ml_min_grad
     cache <- lav_efa_ml_init_cache(r = r, nfactors = nfactors)
   } else {
     lav_msg_stop(gettext("method must be uls or ml (for now)"))
@@ -212,7 +212,7 @@ lav_efa_uls_min_objective <- function(x, cache = NULL) {
   })               # nolint end
 }
 
-lav_efa_uls_min_gradient <- function(x, cache = NULL) {
+lav_efa_uls_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
@@ -270,7 +270,7 @@ lav_efa_ml_min_objective <- function(x, cache = NULL) {
   })                  # nolint end
 }
 
-lav_efa_ml_min_gradient <- function(x, cache = NULL) {
+lav_efa_ml_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
@@ -339,7 +339,7 @@ lav_efa_extraction_uls_corner <- function(s, nfactors = 1L, reflect = TRUE,
 
   # optim.method
   min_objective <- lav_efa_uls_corner_min_objective
-  min_gradient <- lav_efa_uls_corner_min_gradient
+  min_gradient <- lav_efa_uls_corner_min_grad
   min_hessian <- NULL
 
   # create cache environment
@@ -429,13 +429,13 @@ lav_efa_uls_corner_min_objective <- function(x, cache = NULL) { # nolint
   cache$theta <- x
   with(cache, {               # nolint start
     mm_lambda[lambda_idx] <- theta
-    res1 <- lav_matrix_vech(r - tcrossprod(mm_lambda), diagonal = FALSE)
+    res1 <- lav_mat_vech(r - tcrossprod(mm_lambda), diagonal = FALSE)
     res2 <- res1 * res1
     return(sum(res2))
   })                          # nolint end
 }
 
-lav_efa_uls_corner_min_gradient <- function(x, cache = NULL) { # nolint
+lav_efa_uls_corner_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x

--- a/R/lav_export.R
+++ b/R/lav_export.R
@@ -33,10 +33,10 @@ lav_export <- function(object, target = "lavaan", prefix = "sem", # nolint start
       data_file = data_file,
       group_label = object@Data@group.label,
       ov_names = c(
-        lav_partable_vnames(object@ParTable, "ov"),
+        lav_pt_vnames(object@ParTable, "ov"),
         object@Data@sampling.weights
       ),
-      ov_ord_names = lav_partable_vnames(object@ParTable, "ov.ord"),
+      ov_ord_names = lav_pt_vnames(object@ParTable, "ov.ord"),
       weight_name = object@Data@sampling.weights,
       listwise = lavInspect(object, "options")$missing == "listwise",
       estimator = lav_mplus_estimator(object),

--- a/R/lav_export_estimation.R
+++ b/R/lav_export_estimation.R
@@ -155,7 +155,7 @@ lav_export_estimation <- function(lavaan_model) {
     current_verbose <- lav_verbose()
     if (lav_verbose(FALSE))
       on.exit(lav_verbose(current_verbose), TRUE)
-    dx <- lav_model_gradient(
+    dx <- lav_model_grad(
       lavmodel = lavaan_model@Model,
       glist = glist,
       lavsamplestats = lavaan_model@SampleStats,
@@ -199,7 +199,7 @@ lav_export_estimation <- function(lavaan_model) {
       parameter_values <- as.numeric(lavaan_model@Model@eq.constraints.K %*%
                   parameter_values) + lavaan_model@Model@eq.constraints.k0
     }
-    names(parameter_values) <- lav_partable_labels(lavaan_model@ParTable,
+    names(parameter_values) <- lav_pt_labels(lavaan_model@ParTable,
       type = "free"
     )
     parameter_values

--- a/R/lav_export_mplus.R
+++ b/R/lav_export_mplus.R
@@ -6,7 +6,7 @@ lav_export_mplus <- function(lav, group_label = NULL) {
   footer <- "\n"
 
   lav <- as.data.frame(lav, stringsAsFactors = FALSE)
-  ngroups <- lav_partable_ngroups(lav)
+  ngroups <- lav_pt_ngroups(lav)
 
   lav_one_group <- function(lav) {
     # mplus does not like variable names with a 'dot'
@@ -47,7 +47,7 @@ lav_export_mplus <- function(lav, group_label = NULL) {
     )
 
     # remove variances for ordered variables
-    ov_names_ord <- lav_partable_vnames(lav, type = "ov.ord")
+    ov_names_ord <- lav_pt_vnames(lav, type = "ov.ord")
     ord_idx <- which(lav$lhs %in% ov_names_ord &
       lav$op == "~~" &
       lav$free == 0L &
@@ -99,7 +99,7 @@ lav_export_mplus <- function(lav, group_label = NULL) {
   if (ngroups == 1L) {
     body <- lav_one_group(lav)
   } else {
-    group_values <- lav_partable_group_values(lav)
+    group_values <- lav_pt_group_values(lav)
     # group 1
     body <- lav_one_group(lav[lav$group == group_values[1], ])
 

--- a/R/lav_fit_cfi.R
+++ b/R/lav_fit_cfi.R
@@ -351,7 +351,7 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit_measures = "cfi",
   x2 <- test[[test_idx]]$stat
   df <- test[[test_idx]]$df
   # g <- lavobject@Data@ngroups # number of groups
-  # n <- lav_object_inspect_ntotal(object = lavobject) # N vs N-1
+  # n <- lav_inspect_ntotal(object = lavobject) # N vs N-1
 
   # scaled X2
   if (scaled_flag) {
@@ -429,7 +429,7 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit_measures = "cfi",
   # 1. user-provided baseline model
   if (!is.null(baseline_model)) {
     baseline_test <-
-      lav_fit_measures_check_baseline(
+      lav_fit_check_baseline(
         fit_indep = baseline_model,
         object = lavobject,
         fit_h1 = h1_model # okay if NULL
@@ -438,7 +438,7 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit_measures = "cfi",
   } else if (!is.null(lavobject@external$baseline.model)) {
     fit_indep <- lavobject@external$baseline.model
     baseline_test <-
-      lav_fit_measures_check_baseline(
+      lav_fit_check_baseline(
         fit_indep = fit_indep,
         object = lavobject,
         fit_h1 = h1_model # okay if NULL
@@ -453,7 +453,7 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit_measures = "cfi",
   } else {
     fit_indep <- try(lav_object_independence(lavobject), silent = TRUE)
     baseline_test <-
-      lav_fit_measures_check_baseline(
+      lav_fit_check_baseline(
         fit_indep = fit_indep,
         object = lavobject,
         fit_h1 = h1_model # okay if NULL
@@ -635,7 +635,7 @@ lav_fit_cfi_lavobject <- function(lavobject = NULL, fit_measures = "cfi",
 # new in 0.6-5
 # internal function to check the (external) baseline model, and
 # return baseline 'test' list if everything checks out (and NULL otherwise)
-lav_fit_measures_check_baseline <- function(fit_indep = NULL, object = NULL, # nolint
+lav_fit_check_baseline <- function(fit_indep = NULL, object = NULL,
                                             fit_h1 = NULL) {
   test <- NULL
 
@@ -694,7 +694,7 @@ lav_fit_measures_check_baseline <- function(fit_indep = NULL, object = NULL, # n
         silent = TRUE
       )
       # try again
-      test <- lav_fit_measures_check_baseline(
+      test <- lav_fit_check_baseline(
         fit_indep = fit_indep,
         object = object
       )

--- a/R/lav_fit_gfi.R
+++ b/R/lav_fit_gfi.R
@@ -122,9 +122,9 @@ lav_fit_gfi_lavobject <- function(lavobject = NULL, fit_measures = "gfi") {
   }
 
   # extract ingredients
-  wls_obs <- lav_object_inspect_wls_obs(lavobject)
-  wls_est <- lav_object_inspect_wls_est(lavobject)
-  wls_v <- lav_object_inspect_wls_v(lavobject)
+  wls_obs <- lav_inspect_wls_obs(lavobject)
+  wls_est <- lav_inspect_wls_est(lavobject)
+  wls_v <- lav_inspect_wls_v(lavobject)
   nobs_1 <- lavobject@SampleStats@nobs
 
   # compute GFI

--- a/R/lav_fit_measures.R
+++ b/R/lav_fit_measures.R
@@ -41,7 +41,7 @@ setMethod(
     if (!is.list(fit_measures))
         fit_measures <- list(fit.measures = fit_measures)
     if (!missing(fm.args)) fit_measures <- c(fit_measures, fm.args)
-    lav_fit_measures(
+    lav_fit(
       object = object, fit_measures = fit.measures,
       baseline_model = baseline.model, h1_model = h1.model,
       output = output
@@ -76,7 +76,7 @@ setMethod(
     if (!is.list(fit_measures))
                   fit_measures <- list(fit.measures = fit_measures)
     if (!missing(fm.args)) fit_measures <- c(fit_measures, fm.args)
-    lav_fit_measures(
+    lav_fit(
       object = object, fit_measures = fit.measures,
       baseline_model = baseline.model, h1_model = h1.model,
       output = output
@@ -109,7 +109,7 @@ lav_efalist_fitmeasures <- function(         # nolint start
   res <- simplify2array(lapply(
     object,
     function(x) {
-      lav_fit_measures(
+      lav_fit(
         object = x,
         fit_measures = fit_measures, h1_model = h1.model,
         baseline_model = baseline.model,
@@ -143,7 +143,7 @@ lav_efalist_fitmeasures <- function(         # nolint start
 }
 
 
-lav_fit_measures <- function(object, fit_measures = "all",
+lav_fit <- function(object, fit_measures = "all",
                              baseline_model = NULL, h1_model = NULL,
                              fm_args = list(
                                standard.test = "default",
@@ -353,8 +353,8 @@ lav_fit_measures <- function(object, fit_measures = "all",
     x2_scaled <- test[[scaled_idx]]$stat
     df_scaled <- test[[scaled_idx]]$df
   }
-  npar <- lav_object_inspect_npar(object = object, ceq = TRUE)
-  n <- lav_object_inspect_ntotal(object = object) # N vs N-1
+  npar <- lav_inspect_npar(object = object, ceq = TRUE)
+  n <- lav_inspect_ntotal(object = object) # N vs N-1
 
 
   # define 'sets' of fit measures:

--- a/R/lav_fit_rmsea.R
+++ b/R/lav_fit_rmsea.R
@@ -328,7 +328,7 @@ lav_fit_rmsea_lavobject <- function(lavobject = NULL, fit_measures = "rmsea",
   x2 <- test[[test_idx]]$stat
   df <- test[[test_idx]]$df
   g <- lavobject@Data@ngroups # number of groups
-  n <- lav_object_inspect_ntotal(object = lavobject) # N vs N-1
+  n <- lav_inspect_ntotal(object = lavobject) # N vs N-1
 
   # scaled X2/df values
   if (scaled_flag) {

--- a/R/lav_fit_srmr.R
+++ b/R/lav_fit_srmr.R
@@ -122,8 +122,8 @@ lav_fit_srmr_twolevel <- function(lavobject = NULL) {
     # mu_between <- implied$mean[[b_between]]
 
     # force pd for between
-    #    S.between <- lav_matrix_symmetric_force_pd(S.between)
-    sigma_between <- lav_matrix_symmetric_force_pd(sigma_between)
+    #    S.between <- lav_mat_sym_force_pd(S.between)
+    sigma_between <- lav_mat_sym_force_pd(sigma_between)
 
     # Bollen approach: simply using cov2cor ('residual correlations')
     s_within_cor <- cov2cor(s_within)
@@ -146,9 +146,9 @@ lav_fit_srmr_twolevel <- function(lavobject = NULL) {
     pstar_between <- nvar_between * (nvar_between + 1) / 2
 
     # SRMR
-    srmr_within[g] <- sqrt(sum(lav_matrix_vech(r_within_cor)^2) /
+    srmr_within[g] <- sqrt(sum(lav_mat_vech(r_within_cor)^2) /
       pstar_within)
-    srmr_between[g] <- sqrt(sum(lav_matrix_vech(r_between_cor)^2) /
+    srmr_between[g] <- sqrt(sum(lav_mat_vech(r_between_cor)^2) /
       pstar_between)
   }
 

--- a/R/lav_fit_utils.R
+++ b/R/lav_fit_utils.R
@@ -72,7 +72,7 @@ lav_fit_catml_dwls <- function(lavobject, check_pd = TRUE) {
   fg <- unlist(lavsamplestats@nobs) / lavsamplestats@ntotal
 
   # Fixme: as we only need the trace, perhaps we could do this
-  # group-specific? (see lav_test_satorra_bentler_trace_original)
+  # group-specific? (see lav_test_sb_trace_original)
   v_g <- v
   w_dwls_g <- w_dwls
   gamma_f <- gamma
@@ -91,9 +91,9 @@ lav_fit_catml_dwls <- function(lavobject, check_pd = TRUE) {
     gamma_f[[g]] <- 1 / fg[g] * gamma[[g]][-rm_idx, -rm_idx]
   }
   # create 'big' matrices
-  w_dwls_all <- lav_matrix_bdiag(w_dwls_g)
-  v_all <- lav_matrix_bdiag(v_g)
-  gamma_all <- lav_matrix_bdiag(gamma_f)
+  w_dwls_all <- lav_mat_bdiag(w_dwls_g)
+  v_all <- lav_mat_bdiag(v_g)
+  gamma_all <- lav_mat_bdiag(gamma_f)
   delta_all <- do.call("rbind", delta_g)
 
   # compute trace
@@ -190,16 +190,16 @@ lav_fit_fiml_corrected <- function(lavobject, baseline_model,
   fit_tilde@Options$h1.information <- c("unstructured", "unstructured")
   fit_tilde@Options$observed.information <- c("h1", "h1")
 
-  wm <- wm_g <- lav_model_h1_information_observed(lavobject)
-  wc <- wc_g <- lav_model_h1_information_observed(fit_tilde)
+  wm <- wm_g <- lav_model_h1_info_observed(lavobject)
+  wc <- wc_g <- lav_model_h1_info_observed(fit_tilde)
 
   if (version == "V3") {
-    jm <- jm_g <- lav_model_h1_information_firstorder(lavobject)
+    jm <- jm_g <- lav_model_h1_info_firstorder(lavobject)
     gamma_f <- vector("list", length = lavdata@ngroups)
   }
   delta <- lavTech(lavobject, "delta")
   e_inv <- lavTech(lavobject, "inverted.information")
-  wmi <- wmi_g <- try(lapply(wm, lav_matrix_symmetric_inverse),
+  wmi <- wmi_g <- try(lapply(wm, lav_mat_sym_inverse),
     silent = TRUE
   )
   if (inherits(wmi, "try-error")) {
@@ -208,7 +208,7 @@ lav_fit_fiml_corrected <- function(lavobject, baseline_model,
 
   fg <- unlist(lavsamplestats@nobs) / lavsamplestats@ntotal
   # Fixme: as we only need the trace, perhaps we could do this
-  # group-specific? (see lav_test_satorra_bentler_trace_original)
+  # group-specific? (see lav_test_sb_trace_original)
   for (g in seq_len(lavdata@ngroups)) {
     # group weight
     wc_g[[g]] <- fg[g] * wc[[g]]
@@ -223,9 +223,9 @@ lav_fit_fiml_corrected <- function(lavobject, baseline_model,
     }
   }
   # create 'big' matrices
-  wc_all <- lav_matrix_bdiag(wc_g)
-  wm_all <- lav_matrix_bdiag(wm_g)
-  wmi_all <- lav_matrix_bdiag(wmi_g)
+  wc_all <- lav_mat_bdiag(wc_g)
+  wm_all <- lav_mat_bdiag(wm_g)
+  wmi_all <- lav_mat_bdiag(wmi_g)
   delta_all <- do.call("rbind", delta)
 
   e_comp <- t(delta_all) %*% wc_all %*% delta_all
@@ -234,10 +234,10 @@ lav_fit_fiml_corrected <- function(lavobject, baseline_model,
 
   # compute trace
   if (version == "V3") {
-    gamma_all <- lav_matrix_bdiag(gamma_f)
+    gamma_all <- lav_mat_bdiag(gamma_f)
     # VS: Simplification of k.fimlc to minimize matrix multiplication
     #                                                 of big matrices
-    jm_all <- lav_matrix_bdiag(jm_g)
+    jm_all <- lav_mat_bdiag(jm_g)
 
     # VS: tr11 is also used for baseline
     # VS: tr(AB) = sum(A*t(B)) is more efficient

--- a/R/lav_fsr.R
+++ b/R/lav_fsr.R
@@ -63,7 +63,7 @@ lav_fsr_delta21 <- function(object, fsm = NULL) {
 
         delta_group[, x_el_idx[[mm]]] <- delta[, m_el_idx[[mm]]]
       } else if (mname == "theta") {
-        d_t <- lav_matrix_vec((t(al_inv) %*% fsm_1) %x%
+        d_t <- lav_mat_vec((t(al_inv) %*% fsm_1) %x%
           (t(fsm_1) %*% al_inv))
         delta_scoffset <- d_t
         delta_scale <- matrix(0,
@@ -97,7 +97,7 @@ lav_fsr_pa2si <- function(pt_1 = NULL, lvinfo) {
   }
 
   # ngroups
-  ngroups <- lav_partable_ngroups(pt_1)
+  ngroups <- lav_pt_ngroups(pt_1)
 
   lhs <- rhs <- op <- character(0)
   group <- block <- free <- exo <- integer(0)
@@ -152,7 +152,7 @@ lav_fsr_pa2si <- function(pt_1 = NULL, lvinfo) {
     est = est
   )
 
-  pt_si <- lav_partable_merge(pt_1, list_1)
+  pt_si <- lav_pt_merge(pt_1, list_1)
 
   pt_si
 }

--- a/R/lav_func_deriv.R
+++ b/R/lav_func_deriv.R
@@ -7,13 +7,13 @@
 
 # YR 17 July 2012
 
-lav_func_gradient_complex <- function(func, x,                        # nolint start
+lav_func_grad_complex <- function(func, x,                        # nolint start
                                       h = .Machine$double.eps, ...,
-                                      fallback.simple = TRUE) {       #nolint end
+                                      fallback_simple = TRUE) {       #nolint end
   f0 <- try(func(x * (0 + 1i), ...), silent = TRUE)
   if (!is.complex(f0)) {
-    if (fallback.simple) {
-      dx <- lav_func_gradient_simple(func = func, x = x, h = sqrt(h), ...)
+    if (fallback_simple) {
+      dx <- lav_func_grad_simple(func = func, x = x, h = sqrt(h), ...)
       return(dx)
     } else {
       lav_msg_stop(gettext(
@@ -21,8 +21,8 @@ lav_func_gradient_complex <- function(func, x,                        # nolint s
     }
   }
   if (inherits(f0, "try-error")) {
-    if (fallback.simple) {
-      dx <- lav_func_gradient_simple(func = func, x = x, h = sqrt(h), ...)
+    if (fallback_simple) {
+      dx <- lav_func_grad_simple(func = func, x = x, h = sqrt(h), ...)
       return(dx)
     } else {
       lav_msg_stop(gettext(
@@ -53,7 +53,7 @@ lav_func_gradient_complex <- function(func, x,                        # nolint s
 }
 
 # as a backup, if func() is not happy about non-numeric arguments
-lav_func_gradient_simple <- function(func, x,
+lav_func_grad_simple <- function(func, x,
                                      h = sqrt(.Machine$double.eps), ...) {
   # check current point, see if it is a scalar function
   f0 <- func(x, ...)
@@ -262,11 +262,11 @@ lav_deriv_cov2cor_b <- function(m_cov = NULL) {
   m_r <- cov2cor(m_cov)
   m_a <- -m_r %x% (0.5 * diag(ds_inv))
   m_b <- (0.5 * diag(ds_inv)) %x% -m_r
-  m_dd <- diag(lav_matrix_vec(diag(nvar)))
+  m_dd <- diag(lav_mat_vec(diag(nvar)))
   a2 <- m_a %*% m_dd
   b2 <- m_b %*% m_dd
-  out <- a2 + b2 + diag(lav_matrix_vec(tcrossprod(sqrt(ds_inv))))
-  m_d <- lav_matrix_duplication(nvar)
+  out <- a2 + b2 + diag(lav_mat_vec(tcrossprod(sqrt(ds_inv))))
+  m_d <- lav_mat_dup(nvar)
   out_vech <- 0.5 * (t(m_d) %*% out %*% m_d)
   out_vech
 }
@@ -280,7 +280,7 @@ lav_deriv_cov2cor <- function(cov_1 = NULL, num_idx = NULL) {
   # dCor/dvar2 = - cov / (2*var2 * sqrt(var1) * sqrt(var2))
   # dCor/dcov  =  1/(sqrt(var1) * sqrt(var2))
 
-  # diagonal: diag(lav_matrix_vech(tcrossprod(1/delta)))
+  # diagonal: diag(lav_mat_vech(tcrossprod(1/delta)))
 
   nvar <- ncol(cov_1)
   pstar <- nvar * (nvar + 1) / 2
@@ -297,10 +297,10 @@ lav_deriv_cov2cor <- function(cov_1 = NULL, num_idx = NULL) {
   a2 <- diag(nvar) %x% t(a)
 
   out <- diag(pstar)
-  diag(out) <- lav_matrix_vech(tcrossprod(1 / delta))
-  var_idx <- lav_matrix_diagh_idx(nvar)
-  dup <- lav_matrix_duplication(nvar)
-  out[, var_idx] <- t(dup) %*% a2[, lav_matrix_diag_idx(nvar)]
+  diag(out) <- lav_mat_vech(tcrossprod(1 / delta))
+  var_idx <- lav_mat_diagh_idx(nvar)
+  dup <- lav_mat_dup(nvar)
+  out[, var_idx] <- t(dup) %*% a2[, lav_mat_diag_idx(nvar)]
 
   if (length(num_idx) > 0L) {
     var_idx <- var_idx[-num_idx]

--- a/R/lav_graph.R
+++ b/R/lav_graph.R
@@ -92,7 +92,7 @@ lav_graph_get_connected_nodes <- function(a) {
   m <- ncol(a)
 
   # catch diagonal A
-  if (all(lavaan::lav_matrix_vech(a, diagonal = FALSE) == 0L)) {
+  if (all(lav_mat_vech(a, diagonal = FALSE) == 0L)) {
     return(seq_len(m))
   }
 
@@ -219,7 +219,7 @@ lav_graph_topological_sort <- function(defined, definedby, warn = TRUE) {
 # (*4) if there are nodes forced to the top border in columns 2 through
 #     maxcol-1, the items in column1s 1 and maxcol cannot occupy the first row;
 #     analogue for the bottom
-lav_graph_topological_matrix <- function(
+lav_graph_topological_mat <- function(
   defined,
   definedby,
   bordernodes = character(0),

--- a/R/lav_h1_implied.R
+++ b/R/lav_h1_implied.R
@@ -6,8 +6,8 @@ lav_h1_implied_logl <- function(lavdata = NULL,
                                 lavoptions = NULL) {
   lavpta <- NULL
   if (!is.null(lavpartable)) {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
 
   # single-level case
@@ -27,9 +27,9 @@ lav_h1_implied_logl <- function(lavdata = NULL,
         # insert ML estimates
         for (g in 1:lavdata@ngroups) {
           # zero coverage?
-          if (any(lav_matrix_vech(lavdata@Mp[[g]]$coverage,
+          if (any(lav_mat_vech(lavdata@Mp[[g]]$coverage,
                                   diagonal = FALSE) == 0L)) {
-            out <- lav_mvnorm_missing_h1_estimate_moments_chol(
+            out <- lav_mvn_mi_h1_est_moments_chol(
               lavdata = lavdata, lavsamplestats = lavsamplestats,
               lavoptions = lavoptions, group = g)
             implied$cov[[g]] <- out$Sigma
@@ -101,7 +101,7 @@ lav_h1_implied_logl <- function(lavdata = NULL,
         #                })[,-1]))
         # YLp = lavsamplestats@YLp[[g]]
         # YLp[[2]]$Y2 <- Y2.complete
-        # OUT <- lav_mvnorm_cluster_em_sat(
+        # OUT <- lav_mvn_cl_em_sat(
         #    YLp      = YLp,
         #    Lp       = lavdata@Lp[[g]],
         #    verbose  = TRUE, # for now
@@ -115,7 +115,7 @@ lav_h1_implied_logl <- function(lavdata = NULL,
         # implied$mean[[(g-1)*nlevels + 2L]] <- OUT$Mu.B
         # loglik.group[g] <- OUT$logl
         # lavh1 <- list(implied = implied, logl = sum(loglik.group))
-        # lavpartable <- lav_partable_unrestricted(lavdata = lavdata,
+        # lavpartable <- lav_pt_unrestricted(lavdata = lavdata,
         #     lavsamplestats = lavsamplestats, lavoptions = lavoptions,
         #     lavpta = lavpta, lavh1 = lavh1)
         # lavpartable$lower <- rep(-Inf, length(lavpartable$lhs))
@@ -124,7 +124,7 @@ lav_h1_implied_logl <- function(lavdata = NULL,
         #                 lavpartable$lhs == lavpartable$rhs)
         # lavpartable$lower[var.idx] <- 1e-05
 
-        lavpartable <- lav_partable_unrestricted_chol(
+        lavpartable <- lav_pt_unrestricted_chol(
           lavdata = lavdata,
           lavoptions = lavoptions, lavpta = lavpta
         )
@@ -166,7 +166,7 @@ lav_h1_implied_logl <- function(lavdata = NULL,
         # }
       } else {
         # complete data
-        out_1 <- lav_mvnorm_cluster_em_sat(
+        out_1 <- lav_mvn_cl_em_sat(
           ylp = lavsamplestats@YLp[[g]],
           lp = lavdata@Lp[[g]],
           tol = 1e-04, # option?

--- a/R/lav_h1_logl.R
+++ b/R/lav_h1_logl.R
@@ -47,7 +47,7 @@ lav_h1_logl <- function(lavdata = NULL,
         current_verbose <- lav_verbose()
         if (lav_verbose(FALSE))
             on.exit(lav_verbose(current_verbose), TRUE)
-        out_1 <- lav_mvnorm_cluster_em_sat(
+        out_1 <- lav_mvn_cl_em_sat(
           ylp = lavsamplestats@YLp[[g]],
           lp = lavdata@Lp[[g]],
           tol = 1e-04, # option?
@@ -59,7 +59,7 @@ lav_h1_logl <- function(lavdata = NULL,
         logl_group[g] <- out_1$logl
       } else if (lavsamplestats@missing.flag) {
         logl_group[g] <-
-          lav_mvnorm_missing_loglik_samplestats(
+          lav_mvn_mi_loglik_samp(
             yp     = lavsamplestats@missing[[g]],
             #Mu     = lavsamplestats@missing.h1[[g]]$mu,
             mu     = h1_implied$mean[[g]],
@@ -73,7 +73,7 @@ lav_h1_logl <- function(lavdata = NULL,
         # all we need is: logdet of covariance matrix, nobs and nvar
         if (lavoptions$conditional.x) {
           logl_group[g] <-
-            lav_mvnorm_h1_loglik_samplestats(
+            lav_mvn_h1_loglik_samp(
               sample_cov_logdet =
                 lavsamplestats@res.cov.log.det[[g]],
               sample_nvar =
@@ -82,7 +82,7 @@ lav_h1_logl <- function(lavdata = NULL,
             )
         } else {
           logl_group[g] <-
-            lav_mvnorm_h1_loglik_samplestats(
+            lav_mvn_h1_loglik_samp(
               sample_cov_logdet = lavsamplestats@cov.log.det[[g]],
               sample_nvar       = NCOL(lavsamplestats@cov[[g]]),
               sample_nobs       = lavsamplestats@nobs[[g]],

--- a/R/lav_integrate.R
+++ b/R/lav_integrate.R
@@ -33,7 +33,7 @@ lav_integration_gauss_hermite_xw <- function(n = 21L, revert = FALSE) {  # nolin
     # diagonal = 0, -1/+1 diagonal is sqrt(1:(n-1)/2)
     u <- sqrt(seq.int(n - 1L) / 2) # upper diagonal of J
     jn <- matrix(0, n, n)
-    didx <- lav_matrix_diag_idx(n)
+    didx <- lav_mat_diag_idx(n)
     jn[(didx + 1)[-n]] <- u
     # Jn[(didx-1)[-1]] <- u # only lower matrix is used anyway
 

--- a/R/lav_lavaanList_inspect.R
+++ b/R/lav_lavaanList_inspect.R
@@ -120,49 +120,49 @@ lavListInspect <- function(object,                                       # nolin
   } else if (what == "nlevels") {
     object@Data@nlevels
   } else if (what == "nclusters") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "nclusters",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "ncluster.size") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "ncluster.size",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "cluster.size") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "cluster.size",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "cluster.id") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "cluster.id",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "cluster.idx") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "cluster.idx",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "cluster.label") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "cluster.label",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "cluster.sizes") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "cluster.sizes",
       drop_list_single_group = drop.list.single.group
     )
   } else if (what == "average.cluster.size") {
-    lav_object_inspect_cluster_info(object,
+    lav_inspect_cl_info(object,
       level = 2L,
       what = "average.cluster.size",
       drop_list_single_group = drop.list.single.group
@@ -282,7 +282,7 @@ lav_lavaanlist_inspect_mms <- function(
     rownames(con_1) <- NULL
 
     # replace 'labels' by parameter numbers
-    id <- lav_partable_constraints_label_id(pt_1)
+    id <- lav_pt_con_label_id(pt_1)
     label <- names(id)
     for (con in seq_len(nrow(con_1))) {
       # lhs

--- a/R/lav_lavaanList_methods.R
+++ b/R/lav_lavaanList_methods.R
@@ -119,11 +119,11 @@ lav_lavaanlist_summary <- function(object,
       nel <- length(pe$est.true)
 
       # always compute EST
-      est <- lav_lavaanlist_partable(object, what = "est", type = "all")
+      est <- lav_lavaanlist_pt(object, what = "est", type = "all")
 
       # sometimes compute SE
       if (sim_args$se.bias || sim_args$prop.sig || sim_args$coverage) {
-        se <- lav_lavaanlist_partable(object, what = "se", type = "all")
+        se <- lav_lavaanlist_pt(object, what = "se", type = "all")
       }
 
       # est.bias?
@@ -218,9 +218,9 @@ lav_lavaanlist_summary <- function(object,
                the 95% level; the requested `level' only affects the
                symmetric (SE-based) intervals."))
           }
-          ci_lower_a1 <- lav_lavaanlist_partable(object, what = "ci.lower",
+          ci_lower_a1 <- lav_lavaanlist_pt(object, what = "ci.lower",
                                                  type = "all")
-          ci_upper_a1 <- lav_lavaanlist_partable(object, what = "ci.upper",
+          ci_upper_a1 <- lav_lavaanlist_pt(object, what = "ci.upper",
                                                  type = "all")
           # average bounds
           ci_lower_a <- apply(ci_lower_a1, 1L, mean, na.rm = TRUE,
@@ -256,13 +256,13 @@ lav_lavaanlist_summary <- function(object,
       # scenario 2: bootstrap
     } else if (!is.null(object@meta$lavBootstrap)) {
       # print the average value for est
-      est <- lav_lavaanlist_partable(object, what = "est", type = "all")
+      est <- lav_lavaanlist_pt(object, what = "est", type = "all")
       pe$est.ave <- rowMeans(est, na.rm = TRUE)
 
       # scenario 3: multiple imputation
     } else if (!is.null(object@meta$lavMultipleImputation)) {
       # pool est: take the mean
-      est <- lav_lavaanlist_partable(object, what = "est", type = "all")
+      est <- lav_lavaanlist_pt(object, what = "est", type = "all")
       m <- NCOL(est)
       pe$est <- rowMeans(est, na.rm = TRUE)
 
@@ -275,7 +275,7 @@ lav_lavaanlist_summary <- function(object,
       b_var <- (est2 - est1 * est1) * m / (m - 1)
 
       # within-imputation variance
-      se <- lav_lavaanlist_partable(object, what = "se", type = "all")
+      se <- lav_lavaanlist_pt(object, what = "se", type = "all")
       w_var <- rowMeans(se^2, na.rm = TRUE)
 
       # total variance: T.var = W.var + B.var + B.var/m
@@ -292,7 +292,7 @@ lav_lavaanlist_summary <- function(object,
       # scenario 4: multiple groups/sets
     } else if (!is.null(object@meta$lavMultipleGroups)) {
       # show individual estimates, for each group
-      est <- lav_lavaanlist_partable(object, what = "est", type = "all")
+      est <- lav_lavaanlist_pt(object, what = "est", type = "all")
       est <- as.list(as.data.frame(est))
       names(est) <- object@meta$group.label
       attr_1 <- attributes(pe)
@@ -303,7 +303,7 @@ lav_lavaanlist_summary <- function(object,
     } else {
       # scenario 5: just a bunch of fits, using different datasets
       # print the average value for est
-      est <- lav_lavaanlist_partable(object, what = "est", type = "all")
+      est <- lav_lavaanlist_pt(object, what = "est", type = "all")
       pe$est.ave <- rowMeans(est, na.rm = TRUE)
 
       # more?
@@ -343,14 +343,14 @@ setMethod(
         )
       }
     }
-    lav_lavaanlist_partable(
+    lav_lavaanlist_pt(
       object = object, what = "est", type = type,
       labels = labels
     )
   }
 )
 
-lav_lavaanlist_partable <- function(object, what = "est",
+lav_lavaanlist_pt <- function(object, what = "est",
                                     type = "free", labels = TRUE) {
   # check object
   object <- lav_object_check_version(object)
@@ -378,7 +378,7 @@ lav_lavaanlist_partable <- function(object, what = "est",
   out <- out[idx, , drop = FALSE]
 
   if (labels) {
-    rownames(out) <- lav_partable_labels(object@ParTable, type = type)
+    rownames(out) <- lav_pt_labels(object@ParTable, type = type)
   }
 
   out

--- a/R/lav_lavaan_step00_init.R
+++ b/R/lav_lavaan_step00_init.R
@@ -1,4 +1,4 @@
-lav_lavaan_step00_parameters <- function(matchcall = NULL,
+lav_step00_parameters <- function(matchcall = NULL,
                                          syscall = NULL,
                                          dotdotdot = NULL) {
   # 1. resolve a problem where parameter 'cl' is matched to 'cluster'
@@ -79,7 +79,7 @@ lav_lavaan_step00_parameters <- function(matchcall = NULL,
   list(mc = mc, dotdotdot = ddd)
 }
 
-lav_lavaan_step00_checkdata <- function(data = NULL,
+lav_step00_checkdata <- function(data = NULL,
                                         dotdotdot = NULL,
                                         sample_cov = NULL,
                                         sample_nobs = NULL,

--- a/R/lav_lavaan_step01_ovnames.R
+++ b/R/lav_lavaan_step01_ovnames.R
@@ -1,4 +1,4 @@
-lav_lavaan_step01_ovnames_initflat <- function(slot_par_table     = NULL, # nolint
+lav_step01_ovnames_initflat <- function(slot_par_table     = NULL,
                                                model            = NULL,
                                                dotdotdot_parser = "new") {
   # if slotPartable not NULL copy to flat.model
@@ -117,7 +117,7 @@ lav_lavaan_step01_ovnames_initflat <- function(slot_par_table     = NULL, # noli
 # For example: "f <~ 1*income + occup + educ" is replaced by:
 # "f =~ 0; f ~~ 0*f; f ~ 1*income + occup + educ"
 #
-lav_lavaan_step01_ovnames_composites <- function(flat_model = NULL) {  # nolint
+lav_step01_ovnames_composites <- function(flat_model = NULL) {
 
   # get composite idx
   c_idx <- which(flat_model$op == "<~")
@@ -180,7 +180,7 @@ lav_lavaan_step01_ovnames_composites <- function(flat_model = NULL) {  # nolint
   flat_model
 }
 
-lav_lavaan_step01_ovnames_ovorder <- function(flat_model = NULL,       # nolint
+lav_step01_ovnames_ovorder <- function(flat_model = NULL,
                                               ov_order   = "model",
                                               data       = NULL,
                                               sample_cov = NULL,
@@ -199,7 +199,7 @@ lav_lavaan_step01_ovnames_ovorder <- function(flat_model = NULL,       # nolint
   if (ov_order == "data") {
     flat_model_orig <- flat_model
     try(
-      flat_model <- lav_partable_ov_from_data(flat_model,
+      flat_model <- lav_pt_ov_from_data(flat_model,
         data = data,
         sample_cov = sample_cov,
         slot_data = slot_data
@@ -219,11 +219,11 @@ lav_lavaan_step01_ovnames_ovorder <- function(flat_model = NULL,       # nolint
   flat_model
 }
 
-lav_lavaan_step01_ovnames_group <- function(flat_model = NULL,        # nolint
+lav_step01_ovnames_group <- function(flat_model = NULL,
                                             ngroups    = 1L) {
   # if "group :" appears in flat.model
   #   tmp.group.values: set of names in corresponding right hand sides
-  #   copy flat.model without attributes and call lav_model_partable,
+  #   copy flat.model without attributes and call lav_model_pt,
   #     store result in tmp.lav
   #   extract ov.names, ov.names.y, ov.names.x, lv.names from tmp.lav
   #     via lav_partable_vnames
@@ -237,7 +237,7 @@ lav_lavaan_step01_ovnames_group <- function(flat_model = NULL,        # nolint
   #     extract ov.names, ov.names.y, ov.names.x, lv.names from flat.model
   #     via lav_partable_vnames
   #
-  #     TODO: call lav_partable_vnames only ones and not for each type
+  #     TODO: call lav_pt_vnames only ones and not for each type
 
   flat_model_2 <- NULL
   tmp_lav <- NULL
@@ -249,7 +249,7 @@ lav_lavaan_step01_ovnames_group <- function(flat_model = NULL,        # nolint
     # - ov's per group
     #
     # - FIXME: we need a more efficient way, avoiding
-    #          lav_model_partable/lav_partable_vnames
+    #          lav_model_pt/lav_partable_vnames
     #
     group_idx <- which(flat_model$op == ":" &
                        tolower(flat_model$lhs) == "group")
@@ -262,63 +262,63 @@ lav_lavaan_step01_ovnames_group <- function(flat_model = NULL,        # nolint
     attr(flat_model_2, "modifiers") <- NULL
     attr(flat_model_2, "constraints") <- NULL
     tmp_lav <-
-      lav_model_partable(flat_model_2, ngroups = tmp_ngroups, warn = FALSE)
+      lav_model_pt(flat_model_2, ngroups = tmp_ngroups, warn = FALSE)
     ov_names <- ov_names_y <- ov_names_x <- lv_names <- vector("list",
       length = tmp_ngroups
     )
-    attr(tmp_lav, "vnames") <- lav_partable_vnames(tmp_lav, type = "*")
+    attr(tmp_lav, "vnames") <- lav_pt_vnames(tmp_lav, type = "*")
     for (g in seq_len(tmp_ngroups)) {
-      ov_names[[g]] <- unique(unlist(lav_partable_vnames(tmp_lav,
+      ov_names[[g]] <- unique(unlist(lav_pt_vnames(tmp_lav,
         type = "ov", group = tmp_group_values[g]
       )))
-      ov_names_y[[g]] <- unique(unlist(lav_partable_vnames(tmp_lav,
+      ov_names_y[[g]] <- unique(unlist(lav_pt_vnames(tmp_lav,
         type = "ov.nox", group = tmp_group_values[g]
       )))
-      ov_names_x[[g]] <- unique(unlist(lav_partable_vnames(tmp_lav,
+      ov_names_x[[g]] <- unique(unlist(lav_pt_vnames(tmp_lav,
         type = "ov.x", group = tmp_group_values[g]
       )))
-      lv_names[[g]] <- unique(unlist(lav_partable_vnames(tmp_lav,
+      lv_names[[g]] <- unique(unlist(lav_pt_vnames(tmp_lav,
         type = "lv", group = tmp_group_values[g]
       )))
     }
   } else if (!is.null(flat_model$group)) {
     # user-provided full partable with group column!
-    attr(flat_model, "vnames") <- lav_partable_vnames(flat_model, type = "*")
-    ngroups <- lav_partable_ngroups(flat_model)
+    attr(flat_model, "vnames") <- lav_pt_vnames(flat_model, type = "*")
+    ngroups <- lav_pt_ngroups(flat_model)
     if (ngroups > 1L) {
-      group_values <- lav_partable_group_values(flat_model)
+      group_values <- lav_pt_group_values(flat_model)
       ov_names <- ov_names_y <- ov_names_x <- lv_names <- vector("list",
         length = ngroups
       )
       for (g in seq_len(ngroups)) {
         # collapsed over levels (if any)
-        ov_names[[g]] <- unique(unlist(lav_partable_vnames(flat_model,
+        ov_names[[g]] <- unique(unlist(lav_pt_vnames(flat_model,
           type = "ov", group = group_values[g]
         )))
-        ov_names_y[[g]] <- unique(unlist(lav_partable_vnames(flat_model,
+        ov_names_y[[g]] <- unique(unlist(lav_pt_vnames(flat_model,
           type = "ov.nox", group = group_values[g]
         )))
-        ov_names_x[[g]] <- unique(unlist(lav_partable_vnames(flat_model,
+        ov_names_x[[g]] <- unique(unlist(lav_pt_vnames(flat_model,
           type = "ov.x", group = group_values[g]
         )))
-        lv_names[[g]] <- unique(unlist(lav_partable_vnames(flat_model,
+        lv_names[[g]] <- unique(unlist(lav_pt_vnames(flat_model,
           type = "lv", group = group_values[g]
         )))
       }
     } else {
-      ov_names   <- lav_partable_vnames(flat_model, type = "ov")
-      ov_names_y <- lav_partable_vnames(flat_model, type = "ov.nox")
-      ov_names_x <- lav_partable_vnames(flat_model, type = "ov.x")
-      lv_names   <- lav_partable_vnames(flat_model, type = "lv")
+      ov_names   <- lav_pt_vnames(flat_model, type = "ov")
+      ov_names_y <- lav_pt_vnames(flat_model, type = "ov.nox")
+      ov_names_x <- lav_pt_vnames(flat_model, type = "ov.x")
+      lv_names   <- lav_pt_vnames(flat_model, type = "lv")
     }
   } else {
     # collapse over levels (if any)
-    attr(flat_model, "vnames") <- lav_partable_vnames(flat_model, type = "*")
-    ov_names   <- unique(unlist(lav_partable_vnames(flat_model, type = "ov")))
-    ov_names_y <- unique(unlist(lav_partable_vnames(flat_model,
+    attr(flat_model, "vnames") <- lav_pt_vnames(flat_model, type = "*")
+    ov_names   <- unique(unlist(lav_pt_vnames(flat_model, type = "ov")))
+    ov_names_y <- unique(unlist(lav_pt_vnames(flat_model,
       type = "ov.nox")))
-    ov_names_x <- unique(unlist(lav_partable_vnames(flat_model, type = "ov.x")))
-    lv_names   <- unique(unlist(lav_partable_vnames(flat_model, type = "lv")))
+    ov_names_x <- unique(unlist(lav_pt_vnames(flat_model, type = "ov.x")))
+    lv_names   <- unique(unlist(lav_pt_vnames(flat_model, type = "lv")))
   }
 
   # sanity check (new in 0.6-8): do we have any ov.names?
@@ -340,7 +340,7 @@ lav_lavaan_step01_ovnames_group <- function(flat_model = NULL,        # nolint
   )
 }
 
-lav_lavaan_step01_ovnames_checklv <- function(                    # nolint
+lav_step01_ovnames_checklv <- function(
     lv_names    = character(0L),
     ov_names    = character(0L),
     data        = NULL,
@@ -408,7 +408,7 @@ lav_lavaan_step01_ovnames_checklv <- function(                    # nolint
   invisible(NULL)
 }
 
-lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
+lav_step01_ovnames_namesl <- function(data         = NULL,
                                              cluster      = NULL,
                                              flat_model   = NULL,
                                              group_values = NULL,
@@ -417,12 +417,12 @@ lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
   #   if data not NULL, cluster must not be NULL, if it is: *** error ***
   #   compute tmp.group.values and tmp.level.values from flat.model
   #   there should be at least 2 levels, if not *** error ***
-  #   copy flat.model without attributes and lav_model_partable -> tmp.lav
+  #   copy flat.model without attributes and lav_model_pt -> tmp.lav
   #   check at least 2 levels for tmp.lav, if not *** error ***
   #   compute ov.names.l per group and per level (via lav_partable_vnames
   #     on tmp.lav)
   # else
-  #   if lav_partable_nlevels(flat.model) > 0
+  #   if lav_pt_nlevels(flat.model) > 0
   #   if data not NULL, cluster must not be NULL, if it is: *** error ***
   #     compute ov.names.l per group and per level (via lav_partable_vnames
   #     on flat.model)
@@ -439,7 +439,7 @@ lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
     # here, we only need to figure out:
     # - nlevels
     # - ov's per level
-    # - FIXME: we need a more efficient way, avoiding lav_model_partable/vnames
+    # - FIXME: we need a more efficient way, avoiding lav_model_pt/vnames
 
     group_idx <- which(flat_model$op == ":" & flat_model$lhs == "group")
     tmp_group_values <- unique(flat_model$rhs[group_idx])
@@ -465,7 +465,7 @@ lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
     attr(flat_model_2, "modifiers") <- NULL
     attr(flat_model_2, "constraints") <- NULL
     tmp_lav <-
-      lav_model_partable(flat_model_2, ngroups = tmp_ngroups, warn = FALSE)
+      lav_model_pt(flat_model_2, ngroups = tmp_ngroups, warn = FALSE)
     # check for empty levels
     if (max(tmp_lav$level) < 2L) {
       lav_msg_stop(
@@ -481,14 +481,14 @@ lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
       for (l in seq_len(tmp_nlevels)) {
         if (tmp_ngroups > 1L) {
           ov_names_l[[g]][[l]] <-
-            unique(unlist(lav_partable_vnames(tmp_lav,
+            unique(unlist(lav_pt_vnames(tmp_lav,
               type = "ov",
               group = tmp_group_values[g],
               level = tmp_level_values[l]
             )))
         } else {
           ov_names_l[[g]][[l]] <-
-            unique(unlist(lav_partable_vnames(tmp_lav,
+            unique(unlist(lav_pt_vnames(tmp_lav,
               type = "ov",
               level = tmp_level_values[l]
             )))
@@ -497,15 +497,15 @@ lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
     } # groups
   } else {
     # perhaps model is already a parameter table
-    nlevels <- lav_partable_nlevels(flat_model)
+    nlevels <- lav_pt_nlevels(flat_model)
     if (nlevels > 1L) {
       # check for cluster argument (only if we have data)
       if (!is.null(data) && is.null(cluster)) {
         lav_msg_stop(gettext("cluster argument is missing."))
       }
 
-      ngroups <- lav_partable_ngroups(flat_model)
-      group_values <- lav_partable_group_values(flat_model)
+      ngroups <- lav_pt_ngroups(flat_model)
+      group_values <- lav_pt_group_values(flat_model)
       ov_names_l <- vector("list", length = ngroups)
       for (g in 1:ngroups) {
         # note: lav_object_vnames() will return a list if any level:
@@ -524,7 +524,7 @@ lav_lavaan_step01_ovnames_namesl <- function(data         = NULL,  # nolint
   )
 }
 
-lav_lavaan_step01_ovnames_ordered <- function(ordered    = NULL,  # nolint
+lav_step01_ovnames_ordered <- function(ordered    = NULL,
                                               flat_model = NULL,
                                               data       = NULL) {
   # interpretation and check ordered parameter, modify if needed

--- a/R/lav_lavaan_step02_options.R
+++ b/R/lav_lavaan_step02_options.R
@@ -1,4 +1,4 @@
-lav_lavaan_step02_options <- function(slot_options = NULL, # nolint
+lav_step02_options <- function(slot_options = NULL,
                                       slot_data = NULL, # nolint
                                       flat_model = NULL,
                                       ordered = NULL,

--- a/R/lav_lavaan_step03_data.R
+++ b/R/lav_lavaan_step03_data.R
@@ -1,4 +1,4 @@
-lav_lavaan_step03_data <- function(slot_data = NULL, # nolint
+lav_step03_data <- function(slot_data = NULL,
                                    lavoptions = NULL,
                                    ov_names = NULL,
                                    ov_names_y = NULL,

--- a/R/lav_lavaan_step04_partable.R
+++ b/R/lav_lavaan_step04_partable.R
@@ -1,4 +1,4 @@
-lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
+lav_step04_pt <- function(slot_par_table = NULL,
                                        model = NULL,
                                        flat_model = NULL,
                                        lavoptions = NULL,
@@ -17,7 +17,7 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
   #       set meanstructure to FALSE
   #       set the member type in the temporary variable tmp.data.ov to a
   #         numeric vector with all zeroes
-  #     create lavpartable via function lavParTable (=lav_model_partable)
+  #     create lavpartable via function lavParTable (=lav_model_pt)
   #                     using the temporary variable for parameter varTable
   #   else
   #     if model is lavaan object
@@ -25,7 +25,7 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
   #     else
   #       if model is a list
   #         set lavpartable to
-  #           as.list(lav_partable_complete(as.list(flat.model)))
+  #           as.list(lav_pt_complete(as.list(flat.model)))
   #       else
   #         *** error ***
   # if slotParTable is NULL check lavpartable via lav_partable_check
@@ -35,7 +35,7 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
   #    lavoptions$em.zerovar.offset
 
   if (!is.null(slot_par_table)) {
-    lavpartable <- lav_partable_set_cache(slot_par_table)
+    lavpartable <- lav_pt_set_cache(slot_par_table)
   } else if (is.character(model) ||
     inherits(model, "formula") ||
   # model was already a flat.model
@@ -49,12 +49,12 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
       print(as.data.frame(flat_model))
     }
     # catch ~~ of fixed.x covariates if fixed.x = TRUE
-    # --> done inside lav_model_partable!
+    # --> done inside lav_model_pt!
 
     # if(lavoptions$fixed.x) {
-    #    tmp <- lav_partable_vnames(flat.model, type = "ov.x",
+    #    tmp <- lav_pt_vnames(flat.model, type = "ov.x",
     #                               ov.x.fatal = FALSE, warn = TRUE)
-    # tmp <- try(lav_partable_vnames(flat.model, type = "ov.x",
+    # tmp <- try(lav_pt_vnames(flat.model, type = "ov.x",
     #                                         ov.x.fatal = TRUE),
     #           silent = TRUE)
     # if(inherits(tmp, "try-error")) {
@@ -64,7 +64,7 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
     # }
     # }
     # if(lavoptions$conditional.x) {
-    #    tmp <- lav_partable_vnames(flat.model,
+    #    tmp <- lav_pt_vnames(flat.model,
     #                  type = "ov.x", ov.x.fatal = TRUE)
     # }
     tmp_data_ov <- lavdata@ov
@@ -107,19 +107,19 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
         group.w.free = lavoptions$group.w.free,
         as.data.frame. = FALSE
       )
-    lavpartable <- lav_partable_set_cache(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable)
     if (lav_verbose()) {
       cat(" done.\n")
     }
   } else if (inherits(model, "lavaan")) {
-    lavpartable <- lav_partable_set_cache(as.list(parTable(model)), model@pta)
+    lavpartable <- lav_pt_set_cache(as.list(parTable(model)), model@pta)
   } else if (is.list(model)) {
     # we already checked this when creating flat.model
     # but we may need to complete it
     lavpartable <- as.list(flat_model) # in case model is a data.frame
     # complete table
-    lavpartable <- as.list(lav_partable_complete(lavpartable))
-    lavpartable <- lav_partable_set_cache(lavpartable)
+    lavpartable <- as.list(lav_pt_complete(lavpartable))
+    lavpartable <- lav_pt_set_cache(lavpartable)
   } else {
     lav_msg_stop(gettextf(
       "model [type = %s] is not of type character or list", class(model)))
@@ -132,7 +132,7 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
   # or not; this is especially relevant if the lavaan() function
   # was used, but the user has forgotten some variances/intercepts...
   if (is.null(slot_par_table)) {
-    junk <- lav_partable_check(lavpartable,
+    junk <- lav_pt_check(lavpartable,
       categorical = lavoptions$.categorical
     )
     rm(junk)
@@ -148,7 +148,7 @@ lav_lavaan_step04_partable <- function(slot_par_table = NULL, # nolint
     if (length(zero_var_idx) > 0L) {
       lavpartable$ustart[zero_var_idx] <- lavoptions$em.zerovar.offset
     }
-    lavpartable <- lav_partable_set_cache(lavpartable, NULL, force = TRUE)
+    lavpartable <- lav_pt_set_cache(lavpartable, NULL, force = TRUE)
   }
 
   list(

--- a/R/lav_lavaan_step05_samplestats.R
+++ b/R/lav_lavaan_step05_samplestats.R
@@ -1,4 +1,4 @@
-lav_lavaan_step05_samplestats <- function(slot_sample_stats = NULL, # nolint
+lav_step05_samp <- function(slot_sample_stats = NULL,
                                           lavdata = NULL,
                                           lavoptions = NULL,
                                           wls_v = NULL, # nolint
@@ -34,11 +34,11 @@ lav_lavaan_step05_samplestats <- function(slot_sample_stats = NULL, # nolint
     if (lav_verbose()) {
       cat("lavsamplestats     ...")
     }
-    lavsamplestats <- lav_samplestats_from_data(
+    lavsamplestats <- lav_samp_from_data(
       lavdata       = lavdata,
       lavoptions    = lavoptions,
-      WLS.V         = wls_v,
-      NACOV         = nacov
+      wls_v         = wls_v,
+      nacov         = nacov
     )
     if (lav_verbose()) {
       cat(" done.\n")
@@ -53,7 +53,7 @@ lav_lavaan_step05_samplestats <- function(slot_sample_stats = NULL, # nolint
         gettext("sample.mean= argument is missing, but model contains
                 mean/intercept parameters."))
     }
-    lavsamplestats <- lav_samplestats_from_moments(
+    lavsamplestats <- lav_samp_from_moments(
       sample_cov    = sample_cov,
       sample_mean   = sample_mean,
       sample_th     = sample_th,

--- a/R/lav_lavaan_step06_h1.R
+++ b/R/lav_lavaan_step06_h1.R
@@ -1,4 +1,4 @@
-lav_lavaan_step06_h1 <- function(sloth1 = NULL,
+lav_step06_h1 <- function(sloth1 = NULL,
                                  lavoptions = NULL,
                                  lavsamplestats = NULL,
                                  lavdata = NULL,

--- a/R/lav_lavaan_step07_bounds.R
+++ b/R/lav_lavaan_step07_bounds.R
@@ -1,4 +1,4 @@
-lav_lavaan_step07_bounds <- function(lavoptions = NULL,
+lav_step07_bounds <- function(lavoptions = NULL,
                                      lavh1 = NULL,
                                      lavdata = NULL,
                                      lavsamplestats = NULL,
@@ -18,7 +18,7 @@ lav_lavaan_step07_bounds <- function(lavoptions = NULL,
     if (lav_verbose()) {
       cat("lavpartable bounds ...")
     }
-    lavpartable <- lav_partable_add_bounds(
+    lavpartable <- lav_pt_add_bounds(
       partable = lavpartable,
       lavh1 = lavh1, lavdata = lavdata, lavsamplestats = lavsamplestats,
       lavoptions = lavoptions

--- a/R/lav_lavaan_step08_start.R
+++ b/R/lav_lavaan_step08_start.R
@@ -1,4 +1,4 @@
-lav_lavaan_step08_start <- function(slot_model = NULL, # nolint
+lav_step08_start <- function(slot_model = NULL,
                                     lavoptions = NULL,
                                     lavpartable = NULL,
                                     lavsamplestats = NULL,

--- a/R/lav_lavaan_step09_model.R
+++ b/R/lav_lavaan_step09_model.R
@@ -1,4 +1,4 @@
-lav_lavaan_step09_model <- function(slot_model = NULL, # nolint
+lav_step09_model <- function(slot_model = NULL,
                                     lavoptions = NULL,
                                     lavpartable = NULL,
                                     lavsamplestats = NULL,

--- a/R/lav_lavaan_step10_cache.R
+++ b/R/lav_lavaan_step10_cache.R
@@ -1,4 +1,4 @@
-lav_lavaan_step10_cache <- function(slot_cache = NULL, # nolint
+lav_step10_cache <- function(slot_cache = NULL,
                                     lavdata = NULL,
                                     lavmodel = NULL,
                                     lavpartable = NULL,
@@ -19,7 +19,7 @@ lav_lavaan_step10_cache <- function(slot_cache = NULL, # nolint
   #     th = lav_model_th(lavmodel)
   #     bi = lav_tables_pairwise_freq_cells(lavdata)
   #     if lavoptions$missing is "available.cases" or "doubly.robust"
-  #       uni = lav_tables_univariate_freq_cell(lavdata)
+  #       uni = lav_tables_uni_freq_cell(lavdata)
   #       if lavoptions$missing is "doubly.robust"
   #         if lavoptions$control$pairwiseProbGivObs NULL: *** error ***
   #         if lavoptions$control$univariateProbGivObs NULL: *** error ***
@@ -81,7 +81,7 @@ lav_lavaan_step10_cache <- function(slot_cache = NULL, # nolint
       # handle option missing = "available.cases" or "doubly.robust"
       if (lavoptions$missing == "available.cases" ||
         lavoptions$missing == "doubly.robust") {
-        uni <- lav_tables_univariate_freq_cell(lavdata)
+        uni <- lav_tables_uni_freq_cell(lavdata)
         # checks for missing = "double.robust"
         if (lavoptions$missing == "doubly.robust") {
           # check whether the probabilities pairwiseProbGivObs and
@@ -354,7 +354,7 @@ lav_lavaan_step10_cache <- function(slot_cache = NULL, # nolint
           mean = 0, sd = 1,
           ndim = nfac
         )
-      # lavcache[[g]]$DD <- lav_model_gradient_dd(lavmodel, group = g)
+      # lavcache[[g]]$DD <- lav_model_grad_dd(lavmodel, group = g)
     }
   }
 

--- a/R/lav_lavaan_step11_optim.R
+++ b/R/lav_lavaan_step11_optim.R
@@ -1,4 +1,4 @@
-lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
+lav_step11_estoptim <- function(lavdata = NULL,
                                        lavmodel = NULL,
                                        lavcache = NULL,
                                        lavsamplestats = NULL,
@@ -16,12 +16,12 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
   #     try x <- lav_optim_noniter(...)
   #   case "em"
   #     if nlevels < 2L *** error ***
-  #     try x <- lav_mvnorm_cluster_em_h0(...)
+  #     try x <- lav_mvn_cl_em_h0(...)
   #   case "gn"
   #     try x <- lav_optim_gn(...)
   #   case else
   #     set 1 in lavoptions$optim.attempts if it wasn't specified
-  #     try x <- lav_model_estimate(...)
+  #     try x <- lav_model_est(...)
   #     if not successful and optim.attempts > 1L
   #       try x <- lav_optim_estimate(...) with
   #         options$optim.parscale = "standardized"
@@ -75,7 +75,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
       # multilevel only for now
       stopifnot(lavdata@nlevels > 1L)
       x <- try(
-        lav_mvnorm_cluster_em_h0(
+        lav_mvn_cl_em_h0(
           lavsamplestats = lavsamplestats,
           lavdata = lavdata,
           lavimplied = NULL,
@@ -114,7 +114,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
         cat("attempt 1 -- default options\n")
       }
       x <- try(
-        lav_model_estimate(
+        lav_model_est(
           lavmodel = lavmodel,
           lavpartable = lavpartable,
           lavsamplestats = lavsamplestats,
@@ -136,7 +136,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
           cat("attempt 2 -- optim.parscale = \"standardized\"\n")
         }
         x <- try(
-          lav_model_estimate(
+          lav_model_est(
             lavmodel = lavmodel,
             lavpartable = lavpartable,
             lavsamplestats = lavsamplestats,
@@ -157,7 +157,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
           cat("attempt 3 -- start = \"simple\"\n")
         }
         x <- try(
-          lav_model_estimate(
+          lav_model_est(
             lavmodel = lavmodel,
             lavpartable = lavpartable,
             lavsamplestats = lavsamplestats,
@@ -184,7 +184,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
           )
         }
         x <- try(
-          lav_model_estimate(
+          lav_model_est(
             lavmodel = lavmodel,
             lavpartable = lavpartable,
             lavsamplestats = lavsamplestats,
@@ -216,7 +216,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
           }
           x_rstarts[[i]] <-
             try(
-              lav_model_estimate(
+              lav_model_est(
                 lavmodel = lavmodel,
                 lavpartable = lavpartable,
                 lavsamplestats = lavsamplestats,
@@ -366,7 +366,7 @@ lav_lavaan_step11_estoptim <- function(lavdata = NULL, # nolint
     lavoptim$x.rstarts <- attr(x, "x.rstarts")
   }
 
-  lavpartable <- lav_partable_set_cache(lavpartable, force = TRUE)
+  lavpartable <- lav_pt_set_cache(lavpartable, force = TRUE)
   list(
     lavoptim = lavoptim, lavmodel = lavmodel, lavpartable = lavpartable,
     x = x

--- a/R/lav_lavaan_step12_implied.R
+++ b/R/lav_lavaan_step12_implied.R
@@ -1,4 +1,4 @@
-lav_lavaan_step12_implied <- function(lavoptions = NULL,
+lav_step12_implied <- function(lavoptions = NULL,
                                       lavmodel = NULL) {
   # # # # # # # # # # # #
   # #  12. lavimplied # #
@@ -19,7 +19,7 @@ lav_lavaan_step12_implied <- function(lavoptions = NULL,
   lavimplied
 }
 
-lav_lavaan_step12_loglik <- function(lavoptions = NULL,
+lav_step12_loglik <- function(lavoptions = NULL,
                                      lavdata = NULL,
                                      lavsamplestats = NULL,
                                      lavh1 = NULL,

--- a/R/lav_lavaan_step13_vcov.R
+++ b/R/lav_lavaan_step13_vcov.R
@@ -1,4 +1,4 @@
-lav_lavaan_step13_vcov_boot <- function(lavoptions = NULL,
+lav_step13_vcov_boot <- function(lavoptions = NULL,
                                         lavmodel = NULL,
                                         lavsamplestats = NULL,
                                         lavdata = NULL,

--- a/R/lav_lavaan_step14_test.R
+++ b/R/lav_lavaan_step14_test.R
@@ -1,4 +1,4 @@
-lav_lavaan_step14_test <- function(lavoptions = NULL,
+lav_step14_test <- function(lavoptions = NULL,
                                    lavmodel = NULL,
                                    lavsamplestats = NULL,
                                    lavdata = NULL,
@@ -52,7 +52,7 @@ lav_lavaan_step14_test <- function(lavoptions = NULL,
   lavtest
 }
 
-lav_lavaan_step14_fit <- function(lavpartable = NULL,
+lav_step14_fit <- function(lavpartable = NULL,
                                   lavmodel = NULL,
                                   lavimplied = NULL,
                                   x = NULL,

--- a/R/lav_lavaan_step15_baseline.R
+++ b/R/lav_lavaan_step15_baseline.R
@@ -1,4 +1,4 @@
-lav_lavaan_step15_baseline <- function(lavoptions = NULL,
+lav_step15_baseline <- function(lavoptions = NULL,
                                        lavsamplestats = NULL,
                                        lavdata = NULL,
                                        lavcache = NULL,

--- a/R/lav_lavaan_step16_rotation.R
+++ b/R/lav_lavaan_step16_rotation.R
@@ -1,4 +1,4 @@
-lav_lavaan_step16_rotation <- function(lavoptions = NULL,
+lav_step16_rotation <- function(lavoptions = NULL,
                                        lavmodel = NULL,
                                        lavpartable = NULL,
                                        lavh1 = NULL,
@@ -83,7 +83,7 @@ lav_lavaan_step16_rotation <- function(lavoptions = NULL,
         attr(lavmodel_unrot@con.jac, "inactive.idx")
       attr(con_jac, "cin.idx") <- attr(lavmodel_unrot@con.jac, "cin.idx")
       # use nrow(lavmodel@ceq.JAC), not lavmodel.unrot (which may have had
-      # zero rows removed by lav_constraints_parse for temporarily-fixed
+      # zero rows removed by lav_con_parse for temporarily-fixed
       # user=7 EFA identification parameters)
       attr(con_jac, "ceq.idx") <- seq_len(nrow(lavmodel@ceq.JAC))
       lavmodel@con.jac <- con_jac
@@ -120,7 +120,7 @@ lav_lavaan_step16_rotation <- function(lavoptions = NULL,
         ) # important!
 
         # force VCOV to be pd, before we transform (not very elegant)
-        vcov_in <- lav_matrix_symmetric_force_pd(lavvcov$vcov, # nolint
+        vcov_in <- lav_mat_sym_force_pd(lavvcov$vcov,
           tol = 1e-10
         )
         # apply Delta rule

--- a/R/lav_lavaan_step17_lavaan.R
+++ b/R/lav_lavaan_step17_lavaan.R
@@ -1,4 +1,4 @@
-lav_lavaan_step17_lavaan <- function(lavmc = NULL,
+lav_step17_lavaan <- function(lavmc = NULL,
                                      timing = NULL,
                                      lavoptions = NULL,
                                      lavpartable = NULL,
@@ -31,8 +31,8 @@ lav_lavaan_step17_lavaan <- function(lavmc = NULL,
   #
   timing$total <- (proc.time()[3] - start_time0)
   timing$start.time <- NULL
-  lavpta <- lav_partable_attributes(lavpartable)
-  lavpartable <- lav_partable_remove_cache(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
+  lavpartable <- lav_pt_remove_cache(lavpartable)
   lavaan <- new("lavaan", # type_of_slot - where created or modified ?
     # ------------   ------------------------- -
     version = packageDescription("lavaan", fields = "Version"),

--- a/R/lav_matrix.R
+++ b/R/lav_matrix.R
@@ -10,8 +10,8 @@
 # M&N book: page 30
 #
 # note: we do not coerce to 'double/numeric' storage-mode (like as.numeric)
-lav_matrix_vec <- function(A) {          # nolint
-  as.vector(A)
+lav_mat_vec <- function(a) {
+  as.vector(a)
 }
 
 
@@ -19,14 +19,14 @@ lav_matrix_vec <- function(A) {          # nolint
 #
 # the vecr operator transforms a matrix into
 # a vector by stacking the *rows* of the matrix one underneath the other
-lav_matrix_vecr <- function(A) {         # nolint
+lav_mat_vecr <- function(a) {
   # faster way??
   # nRow <- NROW(A); nCol <- NCOL(A)
   # idx <- (seq_len(nCol) - 1L) * nRow + rep(seq_len(nRow), each = nCol)
   # if (lav_use_lavaanC() && is.numeric(A)) {
   #   return(lavaanC::m_vecr(A))
   # }
-  lav_matrix_vec(t(A))
+  lav_mat_vec(t(a))
 }
 
 
@@ -40,35 +40,35 @@ lav_matrix_vecr <- function(A) {         # nolint
 #
 # M&N book: page 48-49
 #
-lav_matrix_vech <- function(S, diagonal = TRUE) {     # nolint
+lav_mat_vech <- function(s, diagonal = TRUE) {
   # if (lav_use_lavaanC() && is.numeric(S)) {
   #   return(lavaanC::m_vech(S, diagonal))
   # }
-  row_1 <- row(S)
-  col_1 <- col(S)
-  if (diagonal) S[row_1 >= col_1] else S[row_1 > col_1]
+  row_1 <- row(s)
+  col_1 <- col(s)
+  if (diagonal) s[row_1 >= col_1] else s[row_1 > col_1]
 }
 
 
 # the vechr operator transforms a *symmetric* matrix
 # into a vector by stacking the *rows* of the matrix one after the
 # other, but eliminating all supradiagonal elements
-lav_matrix_vechr <- function(S, diagonal = TRUE) {      # nolint
+lav_mat_vechr <- function(s, diagonal = TRUE) {
   # if (lav_use_lavaanC() && is.numeric(S)) {
   #   return(lavaanC::m_vechr(S, diagonal))
   # }
-  S[lav_matrix_vechr_idx(n = NCOL(S), diagonal = diagonal)]
+  s[lav_mat_vechr_idx(n = NCOL(s), diagonal = diagonal)]
 }
 
 
 # the vechu operator transforms a *symmetric* matrix
 # into a vector by stacking the *columns* of the matrix one after the
 # other, but eliminating all infradiagonal elements
-lav_matrix_vechu <- function(S, diagonal = TRUE) {     # nolint
+lav_mat_vechu <- function(s, diagonal = TRUE) {
   # if (lav_use_lavaanC() && is.numeric(S)) {
   #   return(lavaanC::m_vechu(S, diagonal))
   # }
-  S[lav_matrix_vechu_idx(n = NCOL(S), diagonal = diagonal)]
+  s[lav_mat_vechu_idx(n = NCOL(s), diagonal = diagonal)]
 }
 
 # the vechru operator transforms a *symmetric* matrix
@@ -76,16 +76,16 @@ lav_matrix_vechu <- function(S, diagonal = TRUE) {     # nolint
 # other, but eliminating all infradiagonal elements
 #
 # same as vech (but using upper-diagonal elements)
-lav_matrix_vechru <- function(S, diagonal = TRUE) {     # nolint
+lav_mat_vechru <- function(s, diagonal = TRUE) {
   # if (lav_use_lavaanC() && is.numeric(S)) {
   #   return(lavaanC::m_vechru(S, diagonal))
   # }
-  S[lav_matrix_vechru_idx(n = NCOL(S), diagonal = diagonal)]
+  s[lav_mat_vechru_idx(n = NCOL(s), diagonal = diagonal)]
 }
 
 # return the *vector* indices of the lower triangular elements of a
 # symmetric matrix of size 'n'
-lav_matrix_vech_idx <- function(n = 1L, diagonal = TRUE) {
+lav_mat_vech_idx <- function(n = 1L, diagonal = TRUE) {
   n <- as.integer(n)
   # if (lav_use_lavaanC() && n > 1L) {
   #   return(lavaanC::m_vech_idx(n, diagonal))
@@ -106,7 +106,7 @@ lav_matrix_vech_idx <- function(n = 1L, diagonal = TRUE) {
 
 # return the *row* indices of the lower triangular elements of a
 # symmetric matrix of size 'n'
-lav_matrix_vech_row_idx <- function(n = 1L, diagonal = TRUE) {
+lav_mat_vech_row_idx <- function(n = 1L, diagonal = TRUE) {
   n <- as.integer(n)
   # if (lav_use_lavaanC() && n > 1L) {
   #   return(lavaanC::m_vech_row_idx(n, diagonal))
@@ -123,7 +123,7 @@ lav_matrix_vech_row_idx <- function(n = 1L, diagonal = TRUE) {
 
 # return the *col* indices of the lower triangular elements of a
 # symmetric matrix of size 'n'
-lav_matrix_vech_col_idx <- function(n = 1L, diagonal = TRUE) {
+lav_mat_vech_col_idx <- function(n = 1L, diagonal = TRUE) {
   n <- as.integer(n)
   # if (lav_use_lavaanC() && n > 1L) {
   #   return(lavaanC::m_vech_col_idx(n, diagonal))
@@ -137,7 +137,7 @@ lav_matrix_vech_col_idx <- function(n = 1L, diagonal = TRUE) {
 
 # return the *vector* indices of the lower triangular elements of a
 # symmetric matrix of size 'n' -- ROW-WISE
-lav_matrix_vechr_idx <- function(n = 1L, diagonal = TRUE) {
+lav_mat_vechr_idx <- function(n = 1L, diagonal = TRUE) {
   n <- as.integer(n)
   # if (lav_use_lavaanC() && n > 1L) {
   #   return(lavaanC::m_vechr_idx(n, diagonal))
@@ -160,7 +160,7 @@ lav_matrix_vechr_idx <- function(n = 1L, diagonal = TRUE) {
 
 # return the *vector* indices of the upper triangular elements of a
 # symmetric matrix of size 'n' -- COLUMN-WISE
-lav_matrix_vechu_idx <- function(n = 1L, diagonal = TRUE) {
+lav_mat_vechu_idx <- function(n = 1L, diagonal = TRUE) {
   n <- as.integer(n)
   # if (lav_use_lavaanC() && n > 1L) {
   #   return(lavaanC::m_vechu_idx(n, diagonal))
@@ -180,7 +180,7 @@ lav_matrix_vechu_idx <- function(n = 1L, diagonal = TRUE) {
 
 # return the *vector* indices of the upper triangular elements of a
 # symmetric matrix of size 'n' -- ROW-WISE
-lav_matrix_vechru_idx <- function(n = 1L, diagonal = TRUE) {
+lav_mat_vechru_idx <- function(n = 1L, diagonal = TRUE) {
   n <- as.integer(n)
   # if (lav_use_lavaanC() && n > 1L) {
   #   return(lavaanC::m_vechru_idx(n, diagonal))
@@ -206,8 +206,8 @@ lav_matrix_vechru_idx <- function(n = 1L, diagonal = TRUE) {
 #
 # given the output of vech(S) --or vechru(S) which is identical--
 # reconstruct S
-lav_matrix_vech_reverse <- lav_matrix_vechru_reverse <-
-  lav_matrix_upper2full <-
+lav_mat_vech_rev <- lav_mat_vechru_rev <-
+  lav_mat_upper2full <-
   function(x, diagonal = TRUE) {
     # if (lav_use_lavaanC()) {
     #   return(lavaanC::m_vech_reverse(x, diagonal))
@@ -221,8 +221,8 @@ lav_matrix_vech_reverse <- lav_matrix_vechru_reverse <-
     stopifnot(p == round(p, 0))
 
     s <- numeric(p * p)
-    s[lav_matrix_vech_idx(p, diagonal = diagonal)] <- x
-    s[lav_matrix_vechru_idx(p, diagonal = diagonal)] <- x
+    s[lav_mat_vech_idx(p, diagonal = diagonal)] <- x
+    s[lav_mat_vechru_idx(p, diagonal = diagonal)] <- x
 
     attr(s, "dim") <- c(p, p)
     s
@@ -233,8 +233,8 @@ lav_matrix_vech_reverse <- lav_matrix_vechru_reverse <-
 #
 # given the output of vechr(S) --or vechu(S) which is identical--
 # reconstruct S
-lav_matrix_vechr_reverse <- lav_matrix_vechu_reverse <-
-  lav_matrix_lower2full <- function(x, diagonal = TRUE) {
+lav_mat_vechr_rev <- lav_mat_vechu_rev <-
+  lav_mat_lower2full <- function(x, diagonal = TRUE) {
     # if (lav_use_lavaanC()) {
     #   return(lavaanC::m_vechr_reverse(x, diagonal))
     # }
@@ -247,8 +247,8 @@ lav_matrix_vechr_reverse <- lav_matrix_vechu_reverse <-
     stopifnot(p == round(p, 0))
 
     s <- numeric(p * p)
-    s[lav_matrix_vechr_idx(p, diagonal = diagonal)] <- x
-    s[lav_matrix_vechu_idx(p, diagonal = diagonal)] <- x
+    s[lav_mat_vechr_idx(p, diagonal = diagonal)] <- x
+    s[lav_mat_vechu_idx(p, diagonal = diagonal)] <- x
 
     attr(s, "dim") <- c(p, p)
     s
@@ -257,7 +257,7 @@ lav_matrix_vechr_reverse <- lav_matrix_vechu_reverse <-
 
 # return the *vector* indices of the diagonal elements of a symmetric
 # matrix of size 'n'
-lav_matrix_diag_idx <- function(n = 1L) {
+lav_mat_diag_idx <- function(n = 1L) {
   # if(n < 1L) return(integer(0L))
   n <- as.integer(n)
   if (n < 1L) {
@@ -272,7 +272,7 @@ lav_matrix_diag_idx <- function(n = 1L) {
 
 # return the *vector* indices of the diagonal elements of the LOWER part
 # of a symmetric matrix of size 'n'
-lav_matrix_diagh_idx <- function(n = 1L) {
+lav_mat_diagh_idx <- function(n = 1L) {
   n <- as.integer(n)
   if (n < 1L) {
     return(integer(0L))
@@ -289,7 +289,7 @@ lav_matrix_diagh_idx <- function(n = 1L) {
 
 # return the *vector* indices of the ANTI diagonal elements of a symmetric
 # matrix of size 'n'
-lav_matrix_antidiag_idx <- function(n = 1L) {
+lav_mat_antidiag_idx <- function(n = 1L) {
   if (n < 1L) {
     return(integer(0L))
   }
@@ -321,7 +321,7 @@ lav_matrix_antidiag_idx <- function(n = 1L) {
 #
 # and the result is c(2, 4, 5, 6, 7, 9, 10)
 #
-lav_matrix_vech_which_idx <- function(n = 1L, diagonal = TRUE,
+lav_mat_vech_which_idx <- function(n = 1L, diagonal = TRUE,
                                       idx = integer(0L), type = "and",
                                       add_idx_at_start = FALSE) {
   if (length(idx) == 0L) {
@@ -340,7 +340,7 @@ lav_matrix_vech_which_idx <- function(n = 1L, diagonal = TRUE,
     a[idx, ] <- TRUE
     a[, idx] <- TRUE
   }
-  pstar_idx <- which(lav_matrix_vech(a, diagonal = diagonal))
+  pstar_idx <- which(lav_mat_vech(a, diagonal = diagonal))
 
   if (add_idx_at_start) {
     pstar_idx <- c(idx, pstar_idx + n)
@@ -349,10 +349,10 @@ lav_matrix_vech_which_idx <- function(n = 1L, diagonal = TRUE,
   pstar_idx
 }
 
-# similar to lav_matrix_vech_which_idx(), but
+# similar to lav_mat_vech_which_idx(), but
 # - only 'type = and'
 # - order of idx matters!
-lav_matrix_vech_match_idx <- function(n = 1L, diagonal = TRUE,
+lav_mat_vech_match_idx <- function(n = 1L, diagonal = TRUE,
                                       idx = integer(0L)) {
   if (length(idx) == 0L) {
     return(integer(0L))
@@ -363,13 +363,13 @@ lav_matrix_vech_match_idx <- function(n = 1L, diagonal = TRUE,
   #   return(lavaanC::m_vech_match_idx(n, diagonal, idx))
   # }
   pstar <- n * (n + 1) / 2
-  a <- lav_matrix_vech_reverse(seq_len(pstar))
+  a <- lav_mat_vech_rev(seq_len(pstar))
   m_b <- a[idx, idx, drop = FALSE]
-  lav_matrix_vech(m_b, diagonal = diagonal)
+  lav_mat_vech(m_b, diagonal = diagonal)
 }
 
 # check if square matrix is diagonal
-lav_matrix_is_diagonal <- function(a = NULL, tol = .Machine$double.eps) {
+lav_mat_is_diagonal <- function(a = NULL, tol = .Machine$double.eps) {
   a <- as.matrix.default(a)
   stopifnot(nrow(a) == ncol(a))
   # if (lav_use_lavaanC()) {
@@ -390,7 +390,7 @@ lav_matrix_is_diagonal <- function(a = NULL, tol = .Machine$double.eps) {
 
 # dup3: using col idx only
 # D7 <- dup(7L); x<- apply(D7, 1, function(x) which(x > 0)); matrix(x,7,7)
-lav_matrix_duplication <- function(n = 1L) {
+lav_mat_dup <- function(n = 1L) {
   n <- as.integer(n)
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_duplication(n))
@@ -409,10 +409,10 @@ lav_matrix_duplication <- function(n = 1L) {
   x <- numeric(n2 * nstar)
 
   tmp <- matrix(0L, n, n)
-  tmp[lav_matrix_vech_idx(n)] <- seq_len(nstar)
-  tmp[lav_matrix_vechru_idx(n)] <- seq_len(nstar)
+  tmp[lav_mat_vech_idx(n)] <- seq_len(nstar)
+  tmp[lav_mat_vechru_idx(n)] <- seq_len(nstar)
 
-  idx <- seq_len(n2) + (lav_matrix_vec(tmp) - 1L) * n2
+  idx <- seq_len(n2) + (lav_mat_vec(tmp) - 1L) * n2
 
   x[idx] <- 1.0
 
@@ -423,23 +423,23 @@ lav_matrix_duplication <- function(n = 1L) {
 # compute t(D) %*% A (without explicitly computing D)
 # sqrt(nrow(A)) is an integer
 # A is not symmetric, and not even square, only n^2 ROWS
-lav_matrix_duplication_pre <- function(A = matrix(0, 0, 0)) { # nolint
+lav_mat_dup_pre <- function(a = matrix(0, 0, 0)) {
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_duplication_pre(A))
   # }
   # number of rows
-  n2 <- NROW(A)
+  n2 <- NROW(a)
 
   # square nrow(A) only, n2 = n^2
   n <- as.integer(round(sqrt(n2)))
   stopifnot(n * n == n2)
 
   # dup idx
-  idx1 <- lav_matrix_vech_idx(n)
-  idx2 <- lav_matrix_vechru_idx(n)
+  idx1 <- lav_mat_vech_idx(n)
+  idx2 <- lav_mat_vechru_idx(n)
 
-  out <- A[idx1, , drop = FALSE] + A[idx2, , drop = FALSE]
-  u <- lav_matrix_diagh_idx(n)
+  out <- a[idx1, , drop = FALSE] + a[idx2, , drop = FALSE]
+  u <- lav_mat_diagh_idx(n)
   out[u, ] <- out[u, ] / 2.0
 
   out
@@ -448,23 +448,23 @@ lav_matrix_duplication_pre <- function(A = matrix(0, 0, 0)) { # nolint
 # compute A %*% D (without explicitly computing D)
 # sqrt(ncol(A)) must be an integer
 # A is not symmetric, and not even square, only n^2 COLUMNS
-lav_matrix_duplication_post <- function(A = matrix(0, 0, 0)) { # nolint
+lav_mat_dup_post <- function(a = matrix(0, 0, 0)) {
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_duplication_post(A))
   # }
   # number of columns
-  n2 <- NCOL(A)
+  n2 <- NCOL(a)
 
-  # square A only, n2 = n^2
+  # square a only, n2 = n^2
   n <- as.integer(round(sqrt(n2)))
   stopifnot(n * n == n2)
 
   # dup idx
-  idx1 <- lav_matrix_vech_idx(n)
-  idx2 <- lav_matrix_vechru_idx(n)
+  idx1 <- lav_mat_vech_idx(n)
+  idx2 <- lav_mat_vechru_idx(n)
 
-  out <- A[, idx1, drop = FALSE] + A[, idx2, drop = FALSE]
-  u <- lav_matrix_diagh_idx(n)
+  out <- a[, idx1, drop = FALSE] + a[, idx2, drop = FALSE]
+  u <- lav_mat_diagh_idx(n)
   out[, u] <- out[, u] / 2.0
 
   out
@@ -473,23 +473,23 @@ lav_matrix_duplication_post <- function(A = matrix(0, 0, 0)) { # nolint
 
 # compute t(D) %*% A %*% D (without explicitly computing D)
 # A must be a square matrix and sqrt(ncol) an integer
-lav_matrix_duplication_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
+lav_mat_dup_pre_post <- function(a = matrix(0, 0, 0)) {
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_duplication_pre_post(A))
   # }
   # number of columns
-  n2 <- NCOL(A)
+  n2 <- NCOL(a)
 
   # square A only, n2 = n^2
   n <- as.integer(round(sqrt(n2)))
-  stopifnot(NROW(A) == n2, n * n == n2)
+  stopifnot(NROW(a) == n2, n * n == n2)
 
   # dup idx
-  idx1 <- lav_matrix_vech_idx(n)
-  idx2 <- lav_matrix_vechru_idx(n)
+  idx1 <- lav_mat_vech_idx(n)
+  idx2 <- lav_mat_vechru_idx(n)
 
-  out <- A[idx1, , drop = FALSE] + A[idx2, , drop = FALSE]
-  u <- lav_matrix_diagh_idx(n)
+  out <- a[idx1, , drop = FALSE] + a[idx2, , drop = FALSE]
+  u <- lav_mat_diagh_idx(n)
   out[u, ] <- out[u, ] / 2.0
   out <- out[, idx1, drop = FALSE] + out[, idx2, drop = FALSE]
   out[, u] <- out[, u] / 2.0
@@ -500,7 +500,7 @@ lav_matrix_duplication_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
 # compute t(D) %*% A %*% D (without explicitly computing D)
 # A must be a square matrix and sqrt(ncol) an integer
 # correlation version: ignoring diagonal elements
-lav_matrix_duplication_cor_pre_post <- function(a = matrix(0, 0, 0)) { # nolint
+lav_mat_dup_cor_pre_post <- function(a = matrix(0, 0, 0)) {
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_duplication_cor_pre_post(A))
   # }
@@ -512,8 +512,8 @@ lav_matrix_duplication_cor_pre_post <- function(a = matrix(0, 0, 0)) { # nolint
   stopifnot(NROW(a) == n2, n * n == n2)
 
   # dup idx
-  idx1 <- lav_matrix_vech_idx(n, diagonal = FALSE)
-  idx2 <- lav_matrix_vechru_idx(n, diagonal = FALSE)
+  idx1 <- lav_mat_vech_idx(n, diagonal = FALSE)
+  idx2 <- lav_mat_vechru_idx(n, diagonal = FALSE)
 
   out <- a[idx1, , drop = FALSE] + a[idx2, , drop = FALSE]
   out <- out[, idx1, drop = FALSE] + out[, idx2, drop = FALSE]
@@ -533,7 +533,7 @@ lav_matrix_duplication_cor_pre_post <- function(a = matrix(0, 0, 0)) { # nolint
 # D^+ == solve(t(D_n %*% D_n) %*% t(D_n)
 
 # create DUP.ginv without transpose
-lav_matrix_duplication_ginv <- function(n = 1L) {
+lav_mat_dup_ginv <- function(n = 1L) {
   # if (lav_use_lavaanC()) {
   #   n <- as.integer(n)
   #   return(lavaanC::m_duplication_ginv(n))
@@ -551,9 +551,9 @@ lav_matrix_duplication_ginv <- function(n = 1L) {
   # THIS is the real bottleneck: allocating an ocean of zeroes...
   x <- numeric(nstar * n2)
 
-  x[(lav_matrix_vech_idx(n) - 1L) * nstar + seq_len(nstar)] <- 0.5
-  x[(lav_matrix_vechru_idx(n) - 1L) * nstar + seq_len(nstar)] <- 0.5
-  x[(lav_matrix_diag_idx(n) - 1L) * nstar + lav_matrix_diagh_idx(n)] <- 1.0
+  x[(lav_mat_vech_idx(n) - 1L) * nstar + seq_len(nstar)] <- 0.5
+  x[(lav_mat_vechru_idx(n) - 1L) * nstar + seq_len(nstar)] <- 0.5
+  x[(lav_mat_diag_idx(n) - 1L) * nstar + lav_mat_diagh_idx(n)] <- 1.0
 
   attr(x, "dim") <- c(nstar, n2)
   x
@@ -561,8 +561,8 @@ lav_matrix_duplication_ginv <- function(n = 1L) {
 
 # pre-multiply with D^+
 # number of rows in A must be 'square' (n*n)
-lav_matrix_duplication_ginv_pre <- function(A = matrix(0, 0, 0)) { # nolint
-  m_a <- as.matrix.default(A)
+lav_mat_dup_ginv_pre <- function(a = matrix(0, 0, 0)) {
+  m_a <- as.matrix.default(a)
 
   # number of rows
   n2 <- NROW(m_a)
@@ -572,16 +572,16 @@ lav_matrix_duplication_ginv_pre <- function(A = matrix(0, 0, 0)) { # nolint
   stopifnot(n * n == n2)
   nstar <- n * (n + 1) / 2
 
-  idx1 <- lav_matrix_vech_idx(n)
-  idx2 <- lav_matrix_vechru_idx(n)
+  idx1 <- lav_mat_vech_idx(n)
+  idx2 <- lav_mat_vechru_idx(n)
   out <- (m_a[idx1, , drop = FALSE] + m_a[idx2, , drop = FALSE]) / 2
   out
 }
 
 # post-multiply with t(D^+)
 # number of columns in A must be 'square' (n*n)
-lav_matrix_duplication_ginv_post <- function(A = matrix(0, 0, 0)) { #  nolint
-  m_a <- as.matrix.default(A)
+lav_mat_dup_ginv_post <- function(a = matrix(0, 0, 0)) { #  nolint
+  m_a <- as.matrix.default(a)
 
   # number of columns
   n2 <- NCOL(m_a)
@@ -590,16 +590,16 @@ lav_matrix_duplication_ginv_post <- function(A = matrix(0, 0, 0)) { #  nolint
   n <- as.integer(round(sqrt(n2)))
   stopifnot(n * n == n2)
 
-  idx1 <- lav_matrix_vech_idx(n)
-  idx2 <- lav_matrix_vechru_idx(n)
+  idx1 <- lav_mat_vech_idx(n)
+  idx2 <- lav_mat_vechru_idx(n)
   out <- (m_a[, idx1, drop = FALSE] + m_a[, idx2, drop = FALSE]) / 2
   out
 }
 
 # pre AND post-multiply with D^+: D^+ %*% A %*% t(D^+)
 # for square matrices only, with ncol = nrow = n^2
-lav_matrix_duplication_ginv_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
-  m_a <- as.matrix.default(A)
+lav_mat_dup_ginv_pre_post <- function(a = matrix(0, 0, 0)) {
+  m_a <- as.matrix.default(a)
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_duplication_ginv_pre_post(A))
   # }
@@ -610,8 +610,8 @@ lav_matrix_duplication_ginv_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
   n <- as.integer(round(sqrt(n2)))
   stopifnot(NROW(m_a) == n2, n * n == n2)
 
-  idx1 <- lav_matrix_vech_idx(n)
-  idx2 <- lav_matrix_vechru_idx(n)
+  idx1 <- lav_mat_vech_idx(n)
+  idx2 <- lav_mat_vechru_idx(n)
   out <- (m_a[idx1, , drop = FALSE] + m_a[idx2, , drop = FALSE]) / 2
   out <- (out[, idx1, drop = FALSE] + out[, idx2, drop = FALSE]) / 2
   out
@@ -639,7 +639,7 @@ lav_matrix_duplication_ginv_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
 #   vec(A %x% B) == (I_n %x% K_qm %x% I_p)(vec A %x% vec B)
 
 # first attempt
-lav_matrix_commutation <- function(m = 1L, n = 1L) {
+lav_mat_com <- function(m = 1L, n = 1L) {
   # if (lav_use_lavaanC()) {
   #   m <- as.integer(m)
   #   n <- as.integer(n)
@@ -669,15 +669,15 @@ lav_matrix_commutation <- function(m = 1L, n = 1L) {
 # compute K_n %*% A without explicitly computing K
 # K_n = K_nn, so sqrt(nrow(A)) must be an integer!
 # = permuting the rows of A
-lav_matrix_commutation_pre <- function(A = matrix(0, 0, 0)) {
-  A <- as.matrix(A)
+lav_mat_com_pre <- function(a = matrix(0, 0, 0)) {
+  a <- as.matrix(a)
 
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_commutation_pre(A))
   # }
 
   # number of rows of A
-  n2 <- nrow(A)
+  n2 <- nrow(a)
 
   # K_nn only (n2 = m * n)
   n <- as.integer(round(sqrt(n2)))
@@ -687,21 +687,21 @@ lav_matrix_commutation_pre <- function(A = matrix(0, 0, 0)) {
   # row.idx <- as.integer(t(matrix(1:n2, n, n)))
   row_idx <- rep(seq_len(n), each = n) + (seq_len(n) - 1L) * n
 
-  out <- A[row_idx, , drop = FALSE]
+  out <- a[row_idx, , drop = FALSE]
   out
 }
 
 # compute A %*% K_n without explicitly computing K
 # K_n = K_nn, so sqrt(ncol(A)) must be an integer!
 # = permuting the columns of A
-lav_matrix_commutation_post <- function(A = matrix(0, 0, 0)) { # nolint
-  m_a <- as.matrix(A)
+lav_mat_com_post <- function(a = matrix(0, 0, 0)) {
+  m_a <- as.matrix(a)
 
   # if (lav_use_lavaanC()) {
-  #   return(lavaanC::m_commutation_post(A))
+  #   return(lavaanC::m_commutation_post(a))
   # }
 
-  # number of columns of A
+  # number of columns of a
   n2 <- ncol(m_a)
 
   # K_nn only (n2 = m * n)
@@ -719,8 +719,8 @@ lav_matrix_commutation_post <- function(A = matrix(0, 0, 0)) { # nolint
 # compute K_n %*% A %*% K_n without explicitly computing K
 # K_n = K_nn, so sqrt(ncol(A)) must be an integer!
 # = permuting both the rows AND columns of A
-lav_matrix_commutation_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
-  m_a <- as.matrix(A)
+lav_mat_com_pre_post <- function(a = matrix(0, 0, 0)) {
+  m_a <- as.matrix(a)
   # if (lav_use_lavaanC()) {
   #   return(lavaanC::m_commutation_pre_post(A))
   # }
@@ -742,16 +742,16 @@ lav_matrix_commutation_pre_post <- function(A = matrix(0, 0, 0)) { # nolint
 
 # compute K_mn %*% A without explicitly computing K
 # = permuting the rows of A
-lav_matrix_commutation_mn_pre <- function(A, m = 1L, n = 1L) { # nolint
+lav_mat_com_mn_pre <- function(a, m = 1L, n = 1L) {
   # number of rows of A
-  mn <- NROW(A)
+  mn <- NROW(a)
   stopifnot(mn == m * n)
 
   # compute row indices
   # row.idx <- as.integer(t(matrix(1:mn, m, n)))
   row_idx <- rep(seq_len(m), each = n) + (seq_len(n) - 1L) * m
 
-  out <- A[row_idx, , drop = FALSE]
+  out <- a[row_idx, , drop = FALSE]
   out
 }
 
@@ -764,11 +764,11 @@ lav_matrix_commutation_mn_pre <- function(A, m = 1L, n = 1L) { # nolint
 # }
 
 # square root of a positive definite symmetric matrix
-lav_matrix_symmetric_sqrt <- function(S = matrix(0, 0, 0)) { # nolint
-  n <- NROW(S)
+lav_mat_sym_sqrt <- function(s = matrix(0, 0, 0)) {
+  n <- NROW(s)
 
   # eigen decomposition, assume symmetric matrix
-  s_eigen <- eigen(S, symmetric = TRUE)
+  s_eigen <- eigen(s, symmetric = TRUE)
   v <- s_eigen$vectors
   d <- s_eigen$values
 
@@ -796,8 +796,8 @@ lav_matrix_symmetric_sqrt <- function(S = matrix(0, 0, 0)) { # nolint
 # - note that A %*% solve(t(A) %*% A) %*% t(A) == tcrossprod(qr.Q(qr(A)))
 # - if we are using qr, we can as well use qr.Q to get the complement
 #
-lav_matrix_orthogonal_complement <- function(A = matrix(0, 0, 0)) { # nolint
-  qr_1 <- qr(A)
+lav_mat_ortho_complement <- function(a = matrix(0, 0, 0)) {
+  qr_1 <- qr(a)
   ran_k <- qr_1$rank
 
   # following Heinz Neudecker:
@@ -815,7 +815,7 @@ lav_matrix_orthogonal_complement <- function(A = matrix(0, 0, 0)) { # nolint
 # construct block diagonal matrix from a list of matrices
 # ... can contain multiple arguments, which will be coerced to a list
 #     or it can be a single list (of matrices)
-lav_matrix_bdiag <- function(...) {
+lav_mat_bdiag <- function(...) {
   if (nargs() == 0L) {
     return(matrix(0, 0, 0))
   }
@@ -867,7 +867,7 @@ lav_matrix_bdiag <- function(...) {
 
 # trace of a single square matrix, or the trace of a product of (compatible)
 # matrices resulting in a single square matrix
-lav_matrix_trace <- function(..., check = TRUE) {
+lav_mat_trace <- function(..., check = TRUE) {
   if (nargs() == 0L) {
     return(as.numeric(NA))
   }
@@ -890,7 +890,7 @@ lav_matrix_trace <- function(..., check = TRUE) {
       # check if square
       stopifnot(NROW(s) == NCOL(s))
     }
-    out <- sum(s[lav_matrix_diag_idx(n = NROW(s))])
+    out <- sum(s[lav_mat_diag_idx(n = NROW(s))])
   } else if (n_mat == 2L) {
     # dimension check is done by '*'
     out <- sum(mlist[[1]] * t(mlist[[2]]))
@@ -937,7 +937,7 @@ lav_matrix_trace <- function(..., check = TRUE) {
 
 # crossproduct, but handling NAs pairwise, if needed
 # otherwise, just call base::crossprod
-lav_matrix_crossprod <- function(a, m_b) {
+lav_mat_crossprod <- function(a, m_b) {
   # single argument?
   if (missing(m_b)) {
     if (!anyNA(a)) {
@@ -970,7 +970,7 @@ lav_matrix_crossprod <- function(a, m_b) {
 
 
 # reduced row echelon form of A
-lav_matrix_rref <- function(a, tol = sqrt(.Machine$double.eps)) {
+lav_mat_rref <- function(a, tol = sqrt(.Machine$double.eps)) {
   # MATLAB documentation says rref uses: tol = (max(size(A))*eps *norm(A,inf)
   if (missing(tol)) {
     a_norm <- max(rowSums(abs(a)))
@@ -1038,7 +1038,7 @@ lav_matrix_rref <- function(a, tol = sqrt(.Machine$double.eps)) {
 
 # inverse of a non-singular (not necessarily positive-definite) symmetric matrix
 # FIXME: error handling?
-lav_matrix_symmetric_inverse <- function(s, logdet = FALSE,
+lav_mat_sym_inverse <- function(s, logdet = FALSE,
                                          sinv_method = "eigen",
                                          zero_warn = FALSE) {
   # catch zero cols/rows (S is symmetric, so zero row iff zero col)
@@ -1145,7 +1145,7 @@ lav_matrix_symmetric_inverse <- function(s, logdet = FALSE,
 }
 
 # solve(A) %*% B, where A is symmetric, and B is vector of matrix
-lav_matrix_symmetric_solve_spd <- function(a, m_b, tol = 1e-10) {
+lav_mat_sym_solve_spd <- function(a, m_b, tol = 1e-10) {
   chol_a <- try(chol(a), silent = TRUE)
   if (!inherits(chol_a, "try-error")) {
     # Cholesky solve
@@ -1166,7 +1166,7 @@ lav_matrix_symmetric_solve_spd <- function(a, m_b, tol = 1e-10) {
 #
 # - only removal for now!
 #
-lav_matrix_symmetric_inverse_update <- function(s_inv, rm_idx = integer(0L), # nolint
+lav_mat_sym_inverse_update <- function(s_inv, rm_idx = integer(0L),
                                                 logdet = FALSE,
                                                 s_logdet = NULL) {
   ndel <- length(rm_idx)
@@ -1229,7 +1229,7 @@ lav_matrix_symmetric_inverse_update <- function(s_inv, rm_idx = integer(0L), # n
 # this approach was suggested to me by Wayne A. Fuller, personal communication,
 # 12 Nov 2020
 #
-lav_matrix_symmetric_diff_smallest_root <- function(m = NULL, p = NULL) { # nolint
+lav_mat_sym_diff_smallest_root <- function(m = NULL, p = NULL) {
   # check input (we will 'assume' they are square and symmetric)
   stopifnot(is.matrix(m), is.matrix(p))
 
@@ -1243,7 +1243,7 @@ lav_matrix_symmetric_diff_smallest_root <- function(m = NULL, p = NULL) { # noli
 
   # diagonal elements of P
   n_p <- nrow(p)
-  diag_p <- p[lav_matrix_diag_idx(n_p)]
+  diag_p <- p[lav_mat_diag_idx(n_p)]
 
   # force diagonal elements of P to be nonnegative (warn?)
   neg_idx <- which(diag_p < 0)
@@ -1291,7 +1291,7 @@ lav_matrix_symmetric_diff_smallest_root <- function(m = NULL, p = NULL) { # noli
     m_nn <- m[zero_idx, zero_idx, drop = FALSE]
 
     # create Mp.n
-    mp_n <- m_pp - m_pn %*% lav_matrix_symmetric_solve_spd(m_nn, m_np)
+    mp_n <- m_pp - m_pn %*% lav_mat_sym_solve_spd(m_nn, m_np)
 
     # extract positive part of P
     p_p <- p[-zero_idx, -zero_idx, drop = FALSE]
@@ -1319,7 +1319,7 @@ lav_matrix_symmetric_diff_smallest_root <- function(m = NULL, p = NULL) { # noli
 # force a symmetric matrix to be positive definite
 # simple textbook version (see Matrix::nearPD for a more sophisticated version)
 #
-lav_matrix_symmetric_force_pd <- function(s, tol = 1e-06) {
+lav_mat_sym_force_pd <- function(s, tol = 1e-06) {
   if (ncol(s) == 1L) {
     return(matrix(max(s[1, 1], tol), 1L, 1L))
   }
@@ -1342,26 +1342,26 @@ lav_matrix_symmetric_force_pd <- function(s, tol = 1e-06) {
 
 # compute sample covariance matrix, divided by 'N' (not N-1, as in cov)
 #
-# Mu is not supposed to be ybar, but close
-# if provided, we compute S as 1/N*crossprod(Y - Mu) instead of
-#                              1/N*crossprod(Y - ybar)
-lav_matrix_cov <- function(Y, Mu = NULL) {                  # nolint
-  n <- NROW(Y)
-  s1 <- stats::cov(Y) # uses a corrected two-pass algorithm
+# mu is not supposed to be ybar, but close
+# if provided, we compute S as 1/N*crossprod(y - mu) instead of
+#                              1/N*crossprod(y - ybar)
+lav_mat_cov <- function(y, mu = NULL) {
+  n <- NROW(y)
+  s1 <- stats::cov(y) # uses a corrected two-pass algorithm
   s <- s1 * (n - 1) / n
 
-  # Mu?
-  if (!is.null(Mu)) {
-    p <- NCOL(Y)
-    ybar <- base::.colMeans(Y, m = n, n = p)
-    s <- s + tcrossprod(ybar - Mu)
+  # mu?
+  if (!is.null(mu)) {
+    p <- NCOL(y)
+    ybar <- base::.colMeans(y, m = n, n = p)
+    s <- s + tcrossprod(ybar - mu)
   }
 
   s
 }
 
 # transform a matrix to match a given target mean/covariance
-lav_matrix_transform_mean_cov <- function(y,
+lav_mat_transform_mean_cov <- function(y,
                                           target_mean = numeric(NCOL(y)),
                                           target_cov = diag(NCOL(y))) {
   # coerce to matrix
@@ -1370,10 +1370,10 @@ lav_matrix_transform_mean_cov <- function(y,
   # convert to vector
   target_mean <- as.vector(target_mean)
 
-  s <- lav_matrix_cov(y)
-  s_inv <- lav_matrix_symmetric_inverse(s)
-  s_inv_sqrt <- lav_matrix_symmetric_sqrt(s_inv)
-  target_cov_sqrt <- lav_matrix_symmetric_sqrt(target_cov)
+  s <- lav_mat_cov(y)
+  s_inv <- lav_mat_sym_inverse(s)
+  s_inv_sqrt <- lav_mat_sym_sqrt(s_inv)
+  target_cov_sqrt <- lav_mat_sym_sqrt(target_cov)
 
   # transform cov
   x <- y %*% s_inv_sqrt %*% target_cov_sqrt
@@ -1387,7 +1387,7 @@ lav_matrix_transform_mean_cov <- function(y,
 
 # weighted column variances
 #
-# for each column in Y: var = sum(wt * (Y - w.mean(Y))^2) / N
+# for each column in y: var = sum(wt * (y - w.mean(y))^2) / N
 #
 # where N = sum(wt) - 1 (method = "unbiased") assuming wt are frequency weights
 #   or  N = sum(wt)     (method = "ML")
@@ -1398,7 +1398,7 @@ lav_matrix_transform_mean_cov <- function(y,
 # if we have missing values, we use only the observations and weights
 # that are NOT missing
 #
-lav_matrix_var_wt <- function(y, wt = NULL, method = c("unbiased", "ML")) {
+lav_mat_var_wt <- function(y, wt = NULL, method = c("unbiased", "ML")) {
   y <- unname(as.matrix.default(y))
   dim_1 <- dim(y)
 
@@ -1439,14 +1439,14 @@ lav_matrix_var_wt <- function(y, wt = NULL, method = c("unbiased", "ML")) {
 #
 # as A is typically sparse, we can stop if all elements in A^k are zero for,
 # say, k<=6
-lav_matrix_inverse_iminus <- function(a = NULL) {
+lav_mat_inverse_iminus <- function(a = NULL) {
   nr <- nrow(a)
   nc <- ncol(a)
   stopifnot(nr == nc)
 
   # create I + A
   ia <- a
-  diag_idx <- lav_matrix_diag_idx(nr)
+  diag_idx <- lav_mat_diag_idx(nr)
   ia[diag_idx] <- ia[diag_idx] + 1
 
   # initial approximation
@@ -1513,7 +1513,7 @@ lav_matrix_inverse_iminus <- function(a = NULL) {
 # - we allow for meanstructure TRUE/FALSE
 # - we allow for fixed.x = TRUE, if x.idx is not empty
 # - but NOT for conditional.x = TRUE (for now)
-lav_matrix_k_gammant_kt <- function(m_k, s, meanstructure = FALSE,
+lav_mat_k_gammant_kt <- function(m_k, s, meanstructure = FALSE,
                                     x_idx = integer(0L)) {
   # dimensions of S
   nvar <- nrow(s)
@@ -1576,7 +1576,7 @@ lav_matrix_k_gammant_kt <- function(m_k, s, meanstructure = FALSE,
     # expand vech row j of B2 into nvar x nvar_q block matrix V_mat
     v_mat <- matrix(0, nvar, nvar * q)
     for (j in seq_len(q)) {
-      m <- lav_matrix_vech_reverse(b2[j, ])
+      m <- lav_mat_vech_rev(b2[j, ])
       diag(m) <- diag(m) * 2
       v_mat[, (j - 1L) * nvar + seq_len(nvar)] <- m / 2
     }

--- a/R/lav_matrix_rotate.R
+++ b/R/lav_matrix_rotate.R
@@ -8,7 +8,7 @@
 #                     be a list
 
 # main function to rotate a single matrix 'A'
-lav_matrix_rotate <- function(a = NULL, # original matrix
+lav_mat_rotate <- function(a = NULL, # original matrix
                               orthogonal = FALSE, # default is oblique
                               method = "geomin", # default rot method
                               method_args = list(
@@ -83,7 +83,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
         nrow(init_rot), ncol(init_rot)))
     }
     # rotation matrix?
-    if (!lav_matrix_rotate_check(init_rot, orthogonal = orthogonal)) {
+    if (!lav_mat_rotate_check(init_rot, orthogonal = orthogonal)) {
       lav_msg_stop(gettext("init.ROT does not look like a rotation matrix"))
     }
   }
@@ -93,7 +93,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
     "cf-quartimax", "cf-varimax", "cf-equamax",
     "cf-parsimax", "cf-facparsim"
   )) {
-    method_fname <- "lav_matrix_rotate_cf"
+    method_fname <- "lav_mat_rotate_cf"
     method_args$cf_gamma <- switch(method,
       "cf-quartimax" = 0,
       "cf-varimax"   = 1 / p,
@@ -102,13 +102,13 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
       "cf-facparsim" = 1
     )
   } else if (method %in% c("bi-quartimin", "biquartimin")) {
-    method_fname <- "lav_matrix_rotate_biquartimin"
+    method_fname <- "lav_mat_rotate_biquartimin"
   } else if (method %in% c("bi-geomin", "bigeomin")) {
-    method_fname <- "lav_matrix_rotate_bigeomin"
+    method_fname <- "lav_mat_rotate_bigeomin"
   } else if (method == "target.strict") {
-    method_fname <- "lav_matrix_rotate_target"
+    method_fname <- "lav_mat_rotate_target"
   } else {
-    method_fname <- paste("lav_matrix_rotate_", method, sep = "")
+    method_fname <- paste("lav_mat_rotate_", method, sep = "")
   }
 
   # check if rotation method exists
@@ -144,10 +144,10 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
       lav_msg_stop(gettext("col(target_mask) != ncol(A)"))
     }
   }
-  # we keep this here, so lav_matrix_rotate() can be used independently
+  # we keep this here, so lav_mat_rotate() can be used independently
   if (method == "target.strict" && anyNA(target)) {
     method <- "pst"
-    method_fname <- "lav_matrix_rotate_pst"
+    method_fname <- "lav_mat_rotate_pst"
     target_mask <- matrix(1, nrow = nrow(target), ncol = ncol(target))
     target_mask[is.na(target)] <- 0
     method_args$target_mask <- target_mask
@@ -207,9 +207,9 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
   if (row_weights == "none") {
     weights <- rep(1.0, p)
   } else if (row_weights == "kaiser") {
-    weights <- lav_matrix_rotate_kaiser_weights(a)
+    weights <- lav_mat_rotate_kaiser_weights(a)
   } else if (row_weights == "cureton-mulaik") {
-    weights <- lav_matrix_rotate_cm_weights(a)
+    weights <- lav_mat_rotate_cm_weights(a)
   } else {
     lav_msg_stop(gettext("row_weights can be none, kaiser or cureton-mulaik"))
   }
@@ -222,8 +222,8 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
   if (rstarts > 0L) {
     rep_1 <- sapply(seq_len(rstarts), function(rep) {
       # random start (always orthogonal)
-      init_rot <- lav_matrix_rotate_gen(m = m, orthogonal = TRUE)
-      # init.ROT <- lav_matrix_rotate_gen(M = M, orthogonal = orthogonal)
+      init_rot <- lav_mat_rotate_gen(m = m, orthogonal = TRUE)
+      # init.ROT <- lav_mat_rotate_gen(M = M, orthogonal = orthogonal)
 
       if (lav_verbose()) {
         cat("\n")
@@ -233,7 +233,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
 
       # choose rotation algorithm
       if (algorithm == "gpa") {
-        rot <- lav_matrix_rotate_gpa(
+        rot <- lav_mat_rotate_gpa(
           a = a, orthogonal = orthogonal,
           init_rot = init_rot,
           method_fname = method_fname,
@@ -243,9 +243,9 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
         )
         info <- attr(rot, "info")
         attr(rot, "info") <- NULL
-        res <- c(info$method.value, lav_matrix_vec(rot))
+        res <- c(info$method.value, lav_mat_vec(rot))
       } else if (algorithm == "pairwise") {
-        rot <- lav_matrix_rotate_pairwise(
+        rot <- lav_mat_rotate_pairwise(
           a = a,
           orthogonal = orthogonal,
           init_rot = init_rot,
@@ -256,7 +256,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
         )
         info <- attr(rot, "info")
         attr(rot, "info") <- NULL
-        res <- c(info$method.value, lav_matrix_vec(rot))
+        res <- c(info$method.value, lav_mat_vec(rot))
       }
 
       if (lav_verbose()) {
@@ -282,7 +282,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
 
     # Gradient Projection Algorithm
     if (algorithm == "gpa") {
-      rot <- lav_matrix_rotate_gpa(
+      rot <- lav_mat_rotate_gpa(
         a = a, orthogonal = orthogonal,
         init_rot = init_rot,
         method_fname = method_fname,
@@ -291,7 +291,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
         max_iter = max_iter
       )
     } else if (algorithm == "pairwise") {
-      rot <- lav_matrix_rotate_pairwise(
+      rot <- lav_mat_rotate_pairwise(
         a = a,
         orthogonal = orthogonal,
         init_rot = init_rot,
@@ -331,7 +331,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
 
     # promax
     kappa <- method_args$promax_kappa
-    out <- lav_matrix_rotate_promax(
+    out <- lav_mat_rotate_promax(
       x = xx$loadings, m = kappa,
       varimax_rot = xx$rotmat
     )
@@ -421,7 +421,7 @@ lav_matrix_rotate <- function(a = NULL, # original matrix
 #   combined in a single function
 # - the default is oblique rotation
 #
-lav_matrix_rotate_gpa <- function(a = NULL, # original matrix
+lav_mat_rotate_gpa <- function(a = NULL, # original matrix
                                   orthogonal = FALSE, # default is oblique
                                   init_rot = NULL, # initial rotation
                                   method_fname = NULL, # criterion function
@@ -598,7 +598,7 @@ lav_matrix_rotate_gpa <- function(a = NULL, # original matrix
 # - repeat until the changes in the f() criterion are below tol
 #
 
-lav_matrix_rotate_pairwise <- function(a = NULL, # original matrix
+lav_mat_rotate_pairwise <- function(a = NULL, # original matrix
                                        orthogonal = FALSE,
                                        init_rot = NULL,
                                        method_fname = NULL, # crit function

--- a/R/lav_matrix_rotate_methods.R
+++ b/R/lav_matrix_rotate_methods.R
@@ -37,7 +37,7 @@
 # gamma = 1/P -> equamax
 # gamma = 1   -> varimax
 #
-lav_matrix_rotate_orthomax <- function(mm_lambda = NULL, orthomax_gamma = 1, # nolint
+lav_mat_rotate_orthomax <- function(mm_lambda = NULL, orthomax_gamma = 1,
                                        ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
   # center L2 column-wise
@@ -66,7 +66,7 @@ lav_matrix_rotate_orthomax <- function(mm_lambda = NULL, orthomax_gamma = 1, # n
 # the Crawford-Ferguson family is also equivalent to the oblimin family
 # if the latter is restricted to orthogonal rotation
 #
-lav_matrix_rotate_cf <- function(mm_lambda = NULL, cf_gamma = 0, ...,   # nolint
+lav_mat_rotate_cf <- function(mm_lambda = NULL, cf_gamma = 0, ...,
                                  grad = FALSE) {
   # check if gamma is between 0 and 1?
   n_row <- nrow(mm_lambda)
@@ -107,7 +107,7 @@ lav_matrix_rotate_cf <- function(mm_lambda = NULL, cf_gamma = 0, ...,   # nolint
 # gamma = 1   -> varimax
 # gamma = P/2 -> equamax
 #
-lav_matrix_rotate_oblimin <- function(mm_lambda = NULL, oblimin_gamma = 0, ..., # nolint
+lav_mat_rotate_oblimin <- function(mm_lambda = NULL, oblimin_gamma = 0, ...,
                                       grad = FALSE) {
   n_row <- nrow(mm_lambda)
   n_col <- ncol(mm_lambda)
@@ -137,7 +137,7 @@ lav_matrix_rotate_oblimin <- function(mm_lambda = NULL, oblimin_gamma = 0, ..., 
 # Carroll (1953); Saunders (1953) Neuhaus & Wrigley (1954); Ferguson (1954)
 # we use here the equivalent 'Ferguson, 1954' variant
 # (See Mulaik 2010, p. 303)
-lav_matrix_rotate_quartimax <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_quartimax <- function(mm_lambda = NULL, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
   out <- -1 * sum(l2 * l2) / 4
 
@@ -154,7 +154,7 @@ lav_matrix_rotate_quartimax <- function(mm_lambda = NULL, ..., grad = FALSE) { #
 #
 # special case of the Orthomax family (Harman, 1960), where gamma = 1
 # see Jennrich (2001, p. 296)
-lav_matrix_rotate_varimax <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_varimax <- function(mm_lambda = NULL, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
   # center L2 column-wise
   c_l2 <- t(t(l2) - colMeans(l2))
@@ -168,7 +168,7 @@ lav_matrix_rotate_varimax <- function(mm_lambda = NULL, ..., grad = FALSE) { # n
 }
 
 # quartimin criterion (part of Carroll's oblimin family
-lav_matrix_rotate_quartimin <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_quartimin <- function(mm_lambda = NULL, ..., grad = FALSE) {
   n_col <- ncol(mm_lambda)
   row1 <- matrix(1.0, n_col, n_col)
   diag(row1) <- 0.0
@@ -188,7 +188,7 @@ lav_matrix_rotate_quartimin <- function(mm_lambda = NULL, ..., grad = FALSE) { #
 # Browne's (2001) version of Yates (1984) geomin criterion
 #
 # we use the exp/log trick as in Bernaard & Jennrich (2005, p. 687)
-lav_matrix_rotate_geomin <- function(mm_lambda = NULL, geomin_epsilon = 0.01, # nolint
+lav_mat_rotate_geomin <- function(mm_lambda = NULL, geomin_epsilon = 0.01,
                                      ..., grad = FALSE) {
   n_col <- ncol(mm_lambda)
 
@@ -213,7 +213,7 @@ lav_matrix_rotate_geomin <- function(mm_lambda = NULL, geomin_epsilon = 0.01, # 
 
 # simple entropy
 # seems to only work for orthogonal rotation
-lav_matrix_rotate_entropy <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_entropy <- function(mm_lambda = NULL, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
 
   # handle zero elements -> replace by '1', so log(1) == 0
@@ -238,7 +238,7 @@ lav_matrix_rotate_entropy <- function(mm_lambda = NULL, ..., grad = FALSE) { # n
 #
 # works only ok with orthogonal rotation!
 
-lav_matrix_rotate_mccammon <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_mccammon <- function(mm_lambda = NULL, ..., grad = FALSE) {
   n_col <- ncol(mm_lambda)
   n_row <- nrow(mm_lambda)
   l2 <- mm_lambda * mm_lambda
@@ -292,7 +292,7 @@ lav_matrix_rotate_mccammon <- function(mm_lambda = NULL, ..., grad = FALSE) { # 
 #
 # Note: typo in Browne (2001), see last  paragraph of Bernaards and
 # Jennrich (2005) page 684
-lav_matrix_rotate_infomax <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_infomax <- function(mm_lambda = NULL, ..., grad = FALSE) {
   n_col <- ncol(mm_lambda)
   n_row <- nrow(mm_lambda)
   l2 <- mm_lambda * mm_lambda
@@ -338,7 +338,7 @@ lav_matrix_rotate_infomax <- function(mm_lambda = NULL, ..., grad = FALSE) { # n
 # Harman, 1976; Saunders, 1961
 #
 # for orthogonal rotation, oblimax is equivalent to quartimax
-lav_matrix_rotate_oblimax <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_oblimax <- function(mm_lambda = NULL, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
 
   # minimize version
@@ -356,11 +356,11 @@ lav_matrix_rotate_oblimax <- function(mm_lambda = NULL, ..., grad = FALSE) { # n
 # Bentler (1977)
 #
 #
-lav_matrix_rotate_bentler <- function(mm_lambda = NULL, ..., grad = FALSE) { # nolint
+lav_mat_rotate_bentler <- function(mm_lambda = NULL, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
 
   l2t_l2 <- crossprod(l2)
-  l2t_l2_inv <- lav_matrix_symmetric_inverse(s = l2t_l2, logdet = TRUE)
+  l2t_l2_inv <- lav_mat_sym_inverse(s = l2t_l2, logdet = TRUE)
   l2t_l2_logdet <- attr(l2t_l2_inv, "logdet")
 
   diag_1 <- diag(l2t_l2)
@@ -386,7 +386,7 @@ lav_matrix_rotate_bentler <- function(mm_lambda = NULL, ..., grad = FALSE) { # n
 #   (it removes the minor factors)
 # - tandem2 is used for final rotation
 #
-lav_matrix_rotate_tandem1 <- function(mm_lambda, ..., grad = FALSE) { # nolint
+lav_mat_rotate_tandem1 <- function(mm_lambda, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
   ll <- tcrossprod(mm_lambda)
   ll2 <- ll * ll
@@ -403,7 +403,7 @@ lav_matrix_rotate_tandem1 <- function(mm_lambda, ..., grad = FALSE) { # nolint
   out
 }
 
-lav_matrix_rotate_tandem2 <- function(mm_lambda, ..., grad = FALSE) { # nolint
+lav_mat_rotate_tandem2 <- function(mm_lambda, ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
   ll <- tcrossprod(mm_lambda)
   ll2 <- ll * ll
@@ -431,7 +431,7 @@ lav_matrix_rotate_tandem2 <- function(mm_lambda, ..., grad = FALSE) { # nolint
 # may be viewed as partially specified target rotation with
 # dynamically chosen weights
 #
-lav_matrix_rotate_simplimax <- function(mm_lambda = NULL, k = nrow(mm_lambda), # nolint
+lav_mat_rotate_simplimax <- function(mm_lambda = NULL, k = nrow(mm_lambda),
                                         ..., grad = FALSE) {
   l2 <- mm_lambda * mm_lambda
 
@@ -458,9 +458,9 @@ lav_matrix_rotate_simplimax <- function(mm_lambda = NULL, k = nrow(mm_lambda), #
 # mm_lambda is rotated toward a specified target matrix 'target'
 #
 # Note: 'target' must be fully specified; if there are any NAs
-#        use lav_matrix_rotate_pst() instead
+#        use lav_mat_rotate_pst() instead
 #
-lav_matrix_rotate_target <- function(mm_lambda = NULL, target = NULL,  # nolint
+lav_mat_rotate_target <- function(mm_lambda = NULL, target = NULL,
                                      ..., grad = FALSE) {
   # squared difference
   diff_1 <- mm_lambda - target
@@ -488,7 +488,7 @@ lav_matrix_rotate_target <- function(mm_lambda = NULL, target = NULL,  # nolint
 # if 'target' contains NAs, they should correspond to '0' values in the
 # target_mask matrix
 #
-lav_matrix_rotate_pst <- function(mm_lambda = NULL, target = NULL,            # nolint
+lav_mat_rotate_pst <- function(mm_lambda = NULL, target = NULL,
                                   target_mask = NULL, ..., grad = FALSE) { # nolint
   # mask target+mm_lambda
   target <- target_mask * target
@@ -516,7 +516,7 @@ lav_matrix_rotate_pst <- function(mm_lambda = NULL, target = NULL,            # 
 #
 # Jennrich & Bentler 2011
 #
-lav_matrix_rotate_biquartimin <- function(mm_lambda, ..., grad = FALSE) { # nolint
+lav_mat_rotate_biquartimin <- function(mm_lambda, ..., grad = FALSE) {
   # see Matlab code page 549
   stopifnot(ncol(mm_lambda) > 1L)
 
@@ -524,7 +524,7 @@ lav_matrix_rotate_biquartimin <- function(mm_lambda, ..., grad = FALSE) { # noli
   lambda_group <- mm_lambda[, -1, drop = FALSE]
 
   # apply quartimin on the 'group' part
-  out <- lav_matrix_rotate_quartimin(lambda_group, ..., grad = grad)
+  out <- lav_mat_rotate_quartimin(lambda_group, ..., grad = grad)
 
   if (grad) {
     tmp <- attr(out, "grad")
@@ -539,7 +539,7 @@ lav_matrix_rotate_biquartimin <- function(mm_lambda, ..., grad = FALSE) { # noli
 #
 # Jennrich & Bentler 2012
 #
-lav_matrix_rotate_bigeomin <- function(mm_lambda, geomin_epsilon = 0.01, ..., # nolint
+lav_mat_rotate_bigeomin <- function(mm_lambda, geomin_epsilon = 0.01, ...,
                                        grad = FALSE) {
   stopifnot(ncol(mm_lambda) > 1L)
 
@@ -547,7 +547,7 @@ lav_matrix_rotate_bigeomin <- function(mm_lambda, geomin_epsilon = 0.01, ..., # 
   lambda_group <- mm_lambda[, -1, drop = FALSE]
 
   # apply geomin on the 'group' part
-  out <- lav_matrix_rotate_geomin(lambda_group,
+  out <- lav_mat_rotate_geomin(lambda_group,
     geomin_epsilon = geomin_epsilon, ...,
     grad = grad
   )
@@ -561,7 +561,7 @@ lav_matrix_rotate_bigeomin <- function(mm_lambda, geomin_epsilon = 0.01, ..., # 
 }
 
 # multiple group rotation + agreement
-lav_matrix_rotate_mg_agreement <- function(lambda_list, method_fname = "geomin",
+lav_mat_rotate_mg_agreement <- function(lambda_list, method_fname = "geomin",
                                    method_args = list(),
                                    mg_agreement_method = "procrustes",
                                    w = 0.5, scale = TRUE) {
@@ -614,7 +614,7 @@ lav_matrix_rotate_mg_agreement <- function(lambda_list, method_fname = "geomin",
 }
 
 # gradient check
-ilav_matrix_rotate_grad_test <- function(crit = NULL, ...,
+ilav_mat_rotate_grad_test <- function(crit = NULL, ...,
                                          mm_lambda = NULL,
                                          n_row = 20L, n_col = 5L) {
   # test matrix
@@ -640,11 +640,11 @@ ilav_matrix_rotate_grad_test <- function(crit = NULL, ...,
   all.equal(gq1, gq2, tolerance = 1e-07)
 }
 
-ilav_matrix_rotate_grad_test_all <- function() {         # nolint
+ilav_mat_rotate_grad_test_all <- function() {
   # Orthomax family with various values for gamma
   for (gamma in seq(0, 1, 0.2)) {
-    check <- ilav_matrix_rotate_grad_test(
-      crit = lav_matrix_rotate_orthomax,
+    check <- ilav_mat_rotate_grad_test(
+      crit = lav_mat_rotate_orthomax,
       gamma = gamma
     )
     if (is.logical(check) && check) {
@@ -662,8 +662,8 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
 
   # Crawford-Ferguson with various values for gamma
   for (gamma in seq(0, 1, 0.2)) {
-    check <- ilav_matrix_rotate_grad_test(
-      crit = lav_matrix_rotate_cf,
+    check <- ilav_mat_rotate_grad_test(
+      crit = lav_mat_rotate_cf,
       gamma = gamma
     )
     if (is.logical(check) && check) {
@@ -681,8 +681,8 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
 
   # Oblimin family with various values for gamma
   for (gamma in seq(0, 1, 0.2)) {
-    check <- ilav_matrix_rotate_grad_test(
-      crit = lav_matrix_rotate_oblimin,
+    check <- ilav_mat_rotate_grad_test(
+      crit = lav_mat_rotate_oblimin,
       gamma = gamma
     )
     if (is.logical(check) && check) {
@@ -699,7 +699,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # quartimax
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_quartimax)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_quartimax)
   if (is.logical(check) && check) {
     cat("quartimax: OK\n")
   } else {
@@ -707,7 +707,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # varimax
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_varimax)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_varimax)
   if (is.logical(check) && check) {
     cat("varimax: OK\n")
   } else {
@@ -715,7 +715,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # quartimin
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_quartimin)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_quartimin)
   if (is.logical(check) && check) {
     cat("quartimin: OK\n")
   } else {
@@ -723,7 +723,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # geomin
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_geomin)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_geomin)
   if (is.logical(check) && check) {
     cat("geomin: OK\n")
   } else {
@@ -731,7 +731,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # simple entropy
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_entropy)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_entropy)
   if (is.logical(check) && check) {
     cat("entropy: OK\n")
   } else {
@@ -739,7 +739,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # McCammon entropy criterion
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_mccammon)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_mccammon)
   if (is.logical(check) && check) {
     cat("McCammon: OK\n")
   } else {
@@ -747,7 +747,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # infomax
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_infomax)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_infomax)
   if (is.logical(check) && check) {
     cat("infomax: OK\n")
   } else {
@@ -755,7 +755,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # oblimax
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_oblimax)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_oblimax)
   if (is.logical(check) && check) {
     cat("oblimax: OK\n")
   } else {
@@ -763,7 +763,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # bentler
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_bentler)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_bentler)
   if (is.logical(check) && check) {
     cat("bentler: OK\n")
   } else {
@@ -771,7 +771,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # simplimax
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_simplimax)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_simplimax)
   if (is.logical(check) && check) {
     cat("simplimax: OK\n")
   } else {
@@ -779,7 +779,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # tandem1
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_tandem1)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_tandem1)
   if (is.logical(check) && check) {
     cat("tandem1: OK\n")
   } else {
@@ -787,7 +787,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # tandem2
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_tandem2)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_tandem2)
   if (is.logical(check) && check) {
     cat("tandem2: OK\n")
   } else {
@@ -795,7 +795,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # bi-quartimin
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_biquartimin)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_biquartimin)
   if (is.logical(check) && check) {
     cat("biquartimin: OK\n")
   } else {
@@ -803,7 +803,7 @@ ilav_matrix_rotate_grad_test_all <- function() {         # nolint
   }
 
   # bi-quartimin
-  check <- ilav_matrix_rotate_grad_test(crit = lav_matrix_rotate_bigeomin)
+  check <- ilav_mat_rotate_grad_test(crit = lav_mat_rotate_bigeomin)
   if (is.logical(check) && check) {
     cat("bigeomin: OK\n")
   } else {

--- a/R/lav_matrix_rotate_mg.R
+++ b/R/lav_matrix_rotate_mg.R
@@ -5,7 +5,7 @@
 # - rstarts only affects the 'initial' rotation
 
 # main function to rotate a list of matrices 'Alist'
-lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
+lav_mat_rotate_mg <- function(a_list = NULL, # original matrices
                                  orthogonal = FALSE, # default is oblique
                                  method = "geomin", # default rot method
                                  method_args = list(
@@ -87,7 +87,7 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
         ))
       }
       # rotation matrix?
-      if (!lav_matrix_rotate_check(init_rot, orthogonal = orthogonal)) {
+      if (!lav_mat_rotate_check(init_rot, orthogonal = orthogonal)) {
         lav_msg_stop(gettext("init.ROT does not look like a rotation matrix"))
       }
     } # group
@@ -98,7 +98,7 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
     "cf-quartimax", "cf-varimax", "cf-equamax",
     "cf-parsimax", "cf-facparsim"
   )) {
-    method_fname <- "lav_matrix_rotate_cf"
+    method_fname <- "lav_mat_rotate_cf"
     method_args$cf_gamma <- switch(method,
       "cf-quartimax" = 0,
       "cf-varimax"   = 1 / p,
@@ -107,13 +107,13 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
       "cf-facparsim" = 1
     )
   } else if (method %in% c("bi-quartimin", "biquartimin")) {
-    method_fname <- "lav_matrix_rotate_biquartimin"
+    method_fname <- "lav_mat_rotate_biquartimin"
   } else if (method %in% c("bi-geomin", "bigeomin")) {
-    method_fname <- "lav_matrix_rotate_bigeomin"
+    method_fname <- "lav_mat_rotate_bigeomin"
   } else if (method == "target.strict") {
-    method_fname <- "lav_matrix_rotate_target"
+    method_fname <- "lav_mat_rotate_target"
   } else {
-    method_fname <- paste("lav_matrix_rotate_", method, sep = "")
+    method_fname <- paste("lav_mat_rotate_", method, sep = "")
   }
 
   # check if rotation method exists
@@ -149,10 +149,10 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
       lav_msg_stop(gettext("col(target_mask) != ncol(A)"))
     }
   }
-  # we keep this here, so lav_matrix_rotate() can be used independently
+  # we keep this here, so lav_mat_rotate() can be used independently
   if (method == "target.strict" && anyNA(target)) {
     method <- "pst"
-    method_fname <- "lav_matrix_rotate_pst"
+    method_fname <- "lav_mat_rotate_pst"
     target_mask <- matrix(1, nrow = nrow(target), ncol = ncol(target))
     target_mask[is.na(target)] <- 0
     method_args$target_mask <- target_mask
@@ -188,7 +188,7 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
     if (lav_verbose()) {
       cat("  group = ", g, "\n")
     }
-    res0 <- lav_matrix_rotate(
+    res0 <- lav_mat_rotate(
       a = a_list[[g]],
       orthogonal = orthogonal,
       method = method,
@@ -249,9 +249,9 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
   #   if (row_weights == "none") {
   #     weights <- rep(1.0, P)
   #   } else if (row_weights == "kaiser") {
-  #     weights <- lav_matrix_rotate_kaiser_weights(A)
+  #     weights <- lav_mat_rotate_kaiser_weights(A)
   #   } else if (row_weights == "cureton-mulaik") {
-  #     weights <- lav_matrix_rotate_cm_weights(A)
+  #     weights <- lav_mat_rotate_cm_weights(A)
   #   } else {
   #     lav_msg_stop(gettext("row_weights can be none,
   #                    kaiser or cureton-mulaik"))
@@ -265,8 +265,8 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
 #  if (rstarts > 0L) {
 #    REP <- lapply(seq_len(rstarts), function(rep) {
 #      # random start (always orthogonal)
-#      # init.ROT <- lav_matrix_rotate_gen(M = M, orthogonal = TRUE)
-#      # init.ROT <- lav_matrix_rotate_gen(M = M, orthogonal = orthogonal)
+#      # init.ROT <- lav_mat_rotate_gen(M = M, orthogonal = TRUE)
+#      # init.ROT <- lav_mat_rotate_gen(M = M, orthogonal = orthogonal)
 #
 #      if (lav_verbose()) {
 #        cat("\n")
@@ -274,7 +274,7 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
 #      }
 #
 #      # mg-pairwise + agreement
-#      rotList <- lav_matrix_rotate_pairwise_mg(
+#      rotList <- lav_mat_rotate_pairwise_mg(
 #        Alist = Alist,
 #        orthogonal = orthogonal,
 #        random.ROT = TRUE,
@@ -311,7 +311,7 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
     if (lav_verbose()) {
       cat("  mg-pairwise + agreement rotation:\n")
     }
-    rot_list <- lav_matrix_rotate_pairwise_mg(
+    rot_list <- lav_mat_rotate_pairwise_mg(
       a_list = a_list,
       orthogonal = orthogonal,
       random_rot = FALSE,
@@ -388,11 +388,11 @@ lav_matrix_rotate_mg <- function(a_list = NULL, # original matrices
 
 
 # pairwise rotation algorithm with direct line search
-# (see lav_matrix_rotate_pairwise()
+# (see lav_mat_rotate_pairwise()
 #
 # but adapted to handle multiple groups + an agreement criterion
 #
-lav_matrix_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
+lav_mat_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
                                           orthogonal = FALSE,
                                           random_rot = FALSE,
                                           method_fname = NULL, # crit function
@@ -416,7 +416,7 @@ lav_matrix_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
   # random initial rotation?
   if (random_rot) {
     for (g in seq_len(ngroups)) {
-      init_rot <- lav_matrix_rotate_gen(m = m, orthogonal = TRUE)
+      init_rot <- lav_mat_rotate_gen(m = m, orthogonal = TRUE)
       if (orthogonal) {
         lambda_list[[g]] <- a_list[[g]] %*% init_rot
       } else {
@@ -428,7 +428,7 @@ lav_matrix_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
 
   # using the current LAMBDA, evaluate the user-specified
   # rotation criterion; return Q (the criterion) only
-  q_current <- lav_matrix_rotate_mg_agreement(
+  q_current <- lav_mat_rotate_mg_agreement(
     lambda_list = lambda_list, method_fname = method_fname,
     method_args = method_args,
     mg_agreement_method = mg_agreement_method,
@@ -468,7 +468,7 @@ lav_matrix_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
     lambda_list[[g]] <- a %*% rot
 
     # evaluate criterion
-    q_1 <- lav_matrix_rotate_mg_agreement(
+    q_1 <- lav_mat_rotate_mg_agreement(
       lambda_list = lambda_list, method_fname = method_fname,
       method_args = method_args, mg_agreement_method = mg_agreement_method,
       w = mg_agreement_weight, scale = scale
@@ -495,7 +495,7 @@ lav_matrix_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
     lambda_list[[g]] <- a %*% rot
 
     # evaluate criterion
-    q_1 <- lav_matrix_rotate_mg_agreement(
+    q_1 <- lav_mat_rotate_mg_agreement(
       lambda_list = lambda_list, method_fname = method_fname,
       method_args = method_args, mg_agreement_method = mg_agreement_method,
       w = mg_agreement_weight, scale = scale
@@ -575,7 +575,7 @@ lav_matrix_rotate_pairwise_mg <- function(a_list = NULL, # original matrices
     } # ngroups
 
     # check for convergence
-    q_current <- lav_matrix_rotate_mg_agreement(
+    q_current <- lav_mat_rotate_mg_agreement(
       lambda_list = lambda_list, method_fname = method_fname,
       method_args = method_args, mg_agreement_method = mg_agreement_method,
       w = mg_agreement_weight, scale = scale

--- a/R/lav_matrix_rotate_utils.R
+++ b/R/lav_matrix_rotate_utils.R
@@ -11,7 +11,7 @@
 # with an Application to Condition Estimators. SIAM Journal on Numerical
 # Analysis, 17(3), 403-409. http://www.jstor.org/stable/2156882
 #
-lav_matrix_rotate_gen <- function(m = 10L, orthogonal = TRUE) {
+lav_mat_rotate_gen <- function(m = 10L, orthogonal = TRUE) {
   # catch M=1
   if (m == 1L) {
     return(matrix(1, 1, 1))
@@ -37,7 +37,7 @@ lav_matrix_rotate_gen <- function(m = 10L, orthogonal = TRUE) {
 
 # check if ROT is an orthogonal matrix if orthogonal = TRUE, or normal if
 # orthogonal = FALSE
-lav_matrix_rotate_check <- function(rot = NULL, orthogonal = TRUE,
+lav_mat_rotate_check <- function(rot = NULL, orthogonal = TRUE,
                                     tolerance = sqrt(.Machine$double.eps)) {
   # we assume ROT is a matrix
   m <- nrow(rot)
@@ -69,7 +69,7 @@ lav_matrix_rotate_check <- function(rot = NULL, orthogonal = TRUE,
 }
 
 # get weights vector needed to weight the rows using Kaiser normalization
-lav_matrix_rotate_kaiser_weights <- function(a = NULL) {    # nolint
+lav_mat_rotate_kaiser_weights <- function(a = NULL) {
   normalize <- 1 / sqrt(rowSums(a * a))
   idx_zero <- which(normalize == 0)
   # catch rows with all zero (thanks to Coen Bernaards for suggesting this)
@@ -83,7 +83,7 @@ lav_matrix_rotate_kaiser_weights <- function(a = NULL) {    # nolint
 #
 # Note: the 'final' weights are multiplied by the Kaiser weights (see CEFA)
 #
-lav_matrix_rotate_cm_weights <- function(a = NULL) {
+lav_mat_rotate_cm_weights <- function(a = NULL) {
   p <- nrow(a)
   m <- ncol(a)
 
@@ -110,7 +110,7 @@ lav_matrix_rotate_cm_weights <- function(a = NULL) {
 }
 
 # taken from the stats package, but skipping varimax (already done):
-lav_matrix_rotate_promax <- function(x, m = 4, varimax_rot = NULL) {
+lav_mat_rotate_promax <- function(x, m = 4, varimax_rot = NULL) {
   # this is based on promax() from factanal.R in /src/library/stats/R
 
   # 1. create 'ideal' pattern matrix

--- a/R/lav_model.R
+++ b/R/lav_model.R
@@ -13,13 +13,13 @@ lav_model <- function(lavpartable = NULL,                          # nolint
                       lavoptions = NULL,
                       th_idx = list()) {
   # handle bare-minimum partables
-  lavpartable <- lav_partable_complete(lavpartable)
-  lavpta <- lav_partable_attributes(lavpartable)
-  lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+  lavpartable <- lav_pt_complete(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
+  lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
 
   # global info from user model
-  nblocks <- lav_partable_nblocks(lavpartable)
-  ngroups <- lav_partable_ngroups(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
+  ngroups <- lav_pt_ngroups(lavpartable)
   meanstructure <- any(lavpartable$op == "~1")
   correlation <- lavoptions$correlation
   if (is.null(correlation)) {
@@ -42,7 +42,7 @@ lav_model <- function(lavpartable = NULL,                          # nolint
   group_w_free <- any(lavpartable$lhs == "group" & lavpartable$op == "%")
   multilevel <- FALSE
   if (!is.null(lavpartable$level)) {
-    nlevels <- lav_partable_nlevels(lavpartable)
+    nlevels <- lav_pt_nlevels(lavpartable)
     if (nlevels > 1L) {
       multilevel <- TRUE
     }
@@ -50,9 +50,9 @@ lav_model <- function(lavpartable = NULL,                          # nolint
     nlevels <- 1L
   }
 
-  nefa <- lav_partable_nefa(lavpartable)
+  nefa <- lav_pt_nefa(lavpartable)
   if (nefa > 0L) {
-    efa_values <- lav_partable_efa_values(lavpartable)
+    efa_values <- lav_pt_efa_values(lavpartable)
   }
 
   # check for simple equality constraints
@@ -66,7 +66,7 @@ lav_model <- function(lavpartable = NULL,                          # nolint
   }
 
   # handle variable definitions and (in)equality constraints
-  tmp_con <- lav_constraints_parse(
+  tmp_con <- lav_con_parse(
     partable = lavpartable,
     constraints = NULL
   )
@@ -148,14 +148,14 @@ lav_model <- function(lavpartable = NULL,                          # nolint
   # keep track of ov.names across blocks
   for (g in 1:nblocks) {
     # observed and latent variables for this block
-    ov_names <- lav_partable_vnames(lavpartable, "ov", block = g)
-    ov_names_nox <- lav_partable_vnames(lavpartable, "ov.nox", block = g)
-    ov_names_x <- lav_partable_vnames(lavpartable, "ov.x", block = g)
-    ov_num <- lav_partable_vnames(lavpartable, "ov.num", block = g)
+    ov_names <- lav_pt_vnames(lavpartable, "ov", block = g)
+    ov_names_nox <- lav_pt_vnames(lavpartable, "ov.nox", block = g)
+    ov_names_x <- lav_pt_vnames(lavpartable, "ov.x", block = g)
+    ov_num <- lav_pt_vnames(lavpartable, "ov.num", block = g)
     if (lavoptions$conditional.x) {
       if (nlevels > 1L) {
         if (ngroups == 1L) {
-          other_block_names <- lav_partable_vnames(lavpartable, "ov",
+          other_block_names <- lav_pt_vnames(lavpartable, "ov",
             block = seq_len(nblocks)[-g]
           )
         } else {
@@ -163,7 +163,7 @@ lav_model <- function(lavpartable = NULL,                          # nolint
           # which group is this?
           this_group <- ceiling(g / nlevels)
           blocks_within_group <- (this_group - 1L) * nlevels + seq_len(nlevels)
-          other_block_names <- lav_partable_vnames(lavpartable, "ov",
+          other_block_names <- lav_pt_vnames(lavpartable, "ov",
             block = blocks_within_group[-g]
           )
         }
@@ -195,7 +195,7 @@ lav_model <- function(lavpartable = NULL,                          # nolint
     nexo[g] <- length(ov_names_x)
 
     if (nefa > 0L) {
-      lv_names <- lav_partable_vnames(lavpartable, "lv", block = g)
+      lv_names <- lav_pt_vnames(lavpartable, "lv", block = g)
     }
 
     # model matrices for this block
@@ -389,7 +389,7 @@ lav_model <- function(lavpartable = NULL,                          # nolint
   }
 
   # which free parameters are observed variances?
-  ov_names <- lav_partable_vnames(lavpartable, "ov")
+  ov_names <- lav_pt_vnames(lavpartable, "ov")
   x_free_var_idx <- lavpartable$free[lavpartable$free &
     # !duplicated(lavpartable$free) &
     lavpartable$lhs %in% ov_names &
@@ -399,10 +399,10 @@ lav_model <- function(lavpartable = NULL,                          # nolint
   rv_lv <- rv_ov <- list()
   if (multilevel) {
     # store information about random slopes (if any)
-    lv_names <- lav_partable_vnames(lavpartable, "lv")
+    lv_names <- lav_pt_vnames(lavpartable, "lv")
     # we should also add split-y names (x) to lv.names
     # FIXME: make this work for multiple work multilevel
-    level_values <- lav_partable_level_values(lavpartable)
+    level_values <- lav_pt_level_values(lavpartable)
     ovx1 <- lav_object_vnames(lavpartable, "ov.x", level = level_values[1])
     ovx2 <- lav_object_vnames(lavpartable, "ov.x", level = level_values[2])
     ovx12 <- ovx2[ovx2 %in% ovx1]

--- a/R/lav_model_efa.R
+++ b/R/lav_model_efa.R
@@ -158,7 +158,7 @@ lav_model_efa_rotate_x <- function(x, lavmodel = NULL, lavoptions = NULL,
         if (lav_verbose(ropts$verbose))
           on.exit(lav_verbose(current_verbose), TRUE)
         # rotate this set
-        res <- lav_matrix_rotate(
+        res <- lav_mat_rotate(
           a = a,
           orthogonal = ropts$orthogonal,
           method = method,
@@ -340,7 +340,7 @@ lav_model_efa_rotate_x <- function(x, lavmodel = NULL, lavoptions = NULL,
       }
 
       # rotate this set
-      res <- lav_matrix_rotate_mg(
+      res <- lav_mat_rotate_mg(
         a_list = alist_1,
         orthogonal = ropts$orthogonal,
         method = method,
@@ -511,7 +511,7 @@ lav_model_efa_rotate_border_x <- function(x, lavmodel = NULL,
     )
 
     # setnames
-    set_names <- lav_partable_efa_values(lavpartable)
+    set_names <- lav_pt_efa_values(lavpartable)
 
     # for each set
     for (set in seq_len(lavmodel@nefa)) {
@@ -562,7 +562,7 @@ lav_model_efa_rotate_border_x <- function(x, lavmodel = NULL,
         "cf-quartimax", "cf-varimax", "cf-equamax",
         "cf-parsimax", "cf-facparsim"
       )) {
-        method_fname <- "lav_matrix_rotate_cf"
+        method_fname <- "lav_mat_rotate_cf"
         this_method_args$cf_gamma <- switch(method,
           "cf-quartimax" = 0,
           "cf-varimax"   = 1 / p,
@@ -571,9 +571,9 @@ lav_model_efa_rotate_border_x <- function(x, lavmodel = NULL,
           "cf-facparsim" = 1
         )
       } else if (method == "target.strict") {
-        method_fname <- "lav_matrix_rotate_target"
+        method_fname <- "lav_mat_rotate_target"
       } else {
-        method_fname <- paste("lav_matrix_rotate_", method, sep = "")
+        method_fname <- paste("lav_mat_rotate_", method, sep = "")
       }
 
       # check if rotation method exists
@@ -592,9 +592,9 @@ lav_model_efa_rotate_border_x <- function(x, lavmodel = NULL,
       if (ropts$row_weights == "none") {
         weights <- rep(1.0, p)
       } else if (ropts$row_weights == "kaiser") {
-        weights <- lav_matrix_rotate_kaiser_weights(a)
+        weights <- lav_mat_rotate_kaiser_weights(a)
       } else if (ropts$row_weights == "cureton-mulaik") {
-        weights <- lav_matrix_rotate_cm_weights(a)
+        weights <- lav_mat_rotate_cm_weights(a)
       } else {
         lav_msg_stop(gettextf("row_weights can be",
           lav_msg_view(c("none", "kaiser", "cureton-mulaik"), "or")))
@@ -618,12 +618,12 @@ lav_model_efa_rotate_border_x <- function(x, lavmodel = NULL,
         # or in other words, the non-diagonal elements of
         # Z - t(Z) are all zero
         tmp <- z - t(z)
-        this_res <- lav_matrix_vech(tmp, diagonal = FALSE)
+        this_res <- lav_mat_vech(tmp, diagonal = FALSE)
       } else {
         psi_z <- mm_psi * diag(z) # rescale rows only
         tmp <- z - psi_z
-        out1 <- lav_matrix_vech(tmp, diagonal = FALSE)
-        out2 <- lav_matrix_vechu(tmp, diagonal = FALSE)
+        out1 <- lav_mat_vech(tmp, diagonal = FALSE)
+        out2 <- lav_mat_vechu(tmp, diagonal = FALSE)
         this_res <- c(out1, out2)
       }
 

--- a/R/lav_model_estimate.R
+++ b/R/lav_model_estimate.R
@@ -10,7 +10,7 @@
 
 
 # model estimation
-lav_model_estimate <- function(lavmodel = NULL,
+lav_model_est <- function(lavmodel = NULL,
                                lavpartable = NULL, # for parscale = "stand"
                                lavh1 = NULL, # for multilevel + parsc
                                lavsamplestats = NULL,
@@ -19,7 +19,7 @@ lav_model_estimate <- function(lavmodel = NULL,
                                lavcache = list(),
                                start = "model",
                                do_fit = TRUE) {
-  lavpartable <- lav_partable_set_cache(lavpartable)
+  lavpartable <- lav_pt_set_cache(lavpartable)
   estimator <- lavoptions$estimator
   verbose <- lav_verbose()
   debug <- lav_debug()
@@ -72,7 +72,7 @@ lav_model_estimate <- function(lavmodel = NULL,
 
     # override? use random starting values instead? (new in 0.6-18)
   } else if (start == "random") {
-    start_1 <- lav_partable_random(
+    start_1 <- lav_pt_random(
       lavpartable = lavpartable,
       # needed if we still need to compute bounds:
       lavh1 = lavh1,
@@ -384,7 +384,7 @@ lav_model_estimate <- function(lavmodel = NULL,
     # update GLIST (change `state') and make a COPY!
     glist <- lav_model_x2glist(lavmodel, x = x)
 
-    dx <- lav_model_gradient(
+    dx <- lav_model_grad(
       lavmodel = lavmodel,
       glist = glist,
       lavsamplestats = lavsamplestats,
@@ -470,7 +470,7 @@ lav_model_estimate <- function(lavmodel = NULL,
   }
 
   gradient_function_numerical_complex <- function(x, verbose = FALSE, debug = FALSE) { # nolint
-    dx <- Re(lav_func_gradient_complex(
+    dx <- Re(lav_func_grad_complex(
       func = objective_function, x = x,
       h = sqrt(.Machine$double.eps)
     ))
@@ -992,7 +992,7 @@ lav_model_estimate <- function(lavmodel = NULL,
     }
 
     if (lavmodel@ceq.simple.only && nrow(lavmodel@ceq.simple.K) > 0L) {
-      ceq_jac_1 <- t(lav_matrix_orthogonal_complement(lavmodel@ceq.simple.K))
+      ceq_jac_1 <- t(lav_mat_ortho_complement(lavmodel@ceq.simple.K))
       ceq_lambda <- numeric(nrow(ceq_jac_1))
     } else {
       npar <- length(lavpartable$free[lavpartable$free > 0])

--- a/R/lav_model_find_iv.R
+++ b/R/lav_model_find_iv.R
@@ -27,7 +27,7 @@ lav_model_find_iv <- function(lavobject = NULL, lavmodel = NULL,
     lavmodel <- lavobject@Model
   } else {
     # get lavpta
-    lavpta <- lav_partable_attributes(lavpartable)
+    lavpta <- lav_pt_attributes(lavpartable)
   }
 
   # sanity checks
@@ -568,7 +568,7 @@ lav_model_find_iv_miivsem <- function(lavmodel = NULL, lavpta = NULL) {
     beta_orig[, colnames(tmp)] <- tmp
 
     # construct Phi
-    phi <- lav_matrix_bdiag(
+    phi <- lav_mat_bdiag(
       psi[lv_x_idx, lv_x_idx, drop = FALSE],
       theta,
       psi[-lv_x_idx, -lv_x_idx, drop = FALSE]
@@ -582,7 +582,7 @@ lav_model_find_iv_miivsem <- function(lavmodel = NULL, lavpta = NULL) {
 
     tmp <- crossprod(gamma)
     tmp[, ] <- 0
-    beta_1 <- lav_matrix_bdiag(beta, tmp)
+    beta_1 <- lav_mat_bdiag(beta, tmp)
     ii <- diag(nrow(beta_1))
     diag(tmp) <- 1
     gamma <- rbind(gamma, tmp)

--- a/R/lav_model_gradient.R
+++ b/R/lav_model_gradient.R
@@ -1,6 +1,6 @@
 # model gradient
 
-lav_model_gradient <- function(lavmodel = NULL,
+lav_model_grad <- function(lavmodel = NULL,
                                glist = NULL,
                                lavsamplestats = NULL,
                                lavdata = NULL,
@@ -266,7 +266,7 @@ lav_model_gradient <- function(lavmodel = NULL,
      # <- 0.5 * group.fx for ML/REML/NTRLS/catML), so dF/dphi has a 0.5
      # factor relative to the textbook ML loss.
     for (g in 1:lavmodel@nblocks) {
-      post_sigma_1 <- -0.5 * lav_matrix_duplication_pre(
+      post_sigma_1 <- -0.5 * lav_mat_dup_pre(
         matrix(omega[[g]], ncol = 1L))
       if (meanstructure) {
         post_mu <- -1 * as.numeric(omega_mu[[g]])
@@ -323,7 +323,7 @@ lav_model_gradient <- function(lavmodel = NULL,
             wls_v <- lavsamplestats@WLS.V[[g]] # for now
           } else {
             dls_a <- estimator_args$dls.a
-            gamma_nt <- lav_samplestats_gamma_nt(
+            gamma_nt <- lav_samp_gamma_nt(
               m_cov          = sigma_hat[[g]],
               m_mean         = mu_hat[[g]],
               x_idx          = lavsamplestats@x.idx[[g]],
@@ -333,7 +333,7 @@ lav_model_gradient <- function(lavmodel = NULL,
               slopestructure = lavmodel@conditional.x
             )
             w_dls <- (1 - dls_a) * lavsamplestats@NACOV[[g]] + dls_a * gamma_nt
-            wls_v <- lav_matrix_symmetric_inverse(w_dls)
+            wls_v <- lav_mat_sym_inverse(w_dls)
           }
           group_dx <- -1 * crossprod(
             delta[[g]],
@@ -341,7 +341,7 @@ lav_model_gradient <- function(lavmodel = NULL,
           )
         } else if (estimator == "NTRLS") {
           stopifnot(!conditional_x)
-          # WLS.V <- lav_samplestats_gamma_inverse_nt(
+          # WLS.V <- lav_samp_gamma_inverse_nt(
           #         m_icov = attr(Sigma.hat[[g]],"inv")[,,drop=FALSE],
           #         m_cov            = Sigma.hat[[g]][,,drop=FALSE],
           #         m_mean           = Mu.hat[[g]],
@@ -359,7 +359,7 @@ lav_model_gradient <- function(lavmodel = NULL,
           if (meanstructure) {
             mean_1 <- lavsamplestats@mean[[g]]
             mu <- mu_hat[[g]]
-            post_sigma_1 <- lav_matrix_duplication_pre(
+            post_sigma_1 <- lav_mat_dup_pre(
               matrix(
                 (sigma_inv %*% (s - sigma_1) %*% t(sigma_inv)) %*%
                   (diag(nvar) + (s - sigma_1) %*% sigma_inv) +
@@ -370,7 +370,7 @@ lav_model_gradient <- function(lavmodel = NULL,
             post_mu <- as.numeric(2 * sigma_inv %*% (mean_1 - mu))
             post <- c(post_mu, post_sigma_1)
           } else {
-            post <- lav_matrix_duplication_pre(
+            post <- lav_mat_dup_pre(
               matrix((sigma_inv %*% (s - sigma_1) %*% t(sigma_inv)) %*%
                 (diag(nvar) + (s - sigma_1) %*% sigma_inv), ncol = 1)
             )
@@ -443,39 +443,39 @@ lav_model_gradient <- function(lavmodel = NULL,
       ))
       est <- t(cbind(mu_g, pi_g))
       # obs.beta <- c(lavsamplestats@res.int[[g]],
-      #              lav_matrix_vec(lavsamplestats@res.slopes[[g]]))
-      # est.beta <- c(Mu.g,  lav_matrix_vec(PI.g))
+      #              lav_mat_vec(lavsamplestats@res.slopes[[g]]))
+      # est.beta <- c(Mu.g,  lav_mat_vec(PI.g))
       # beta.COV <- C3 %x% Sigma.inv
 
       # a <- t(obs.beta - est.beta)
       # b <- as.matrix(obs.beta - est.beta)
-      # K <- lav_matrix_commutation(m = nvar, n = nvar)
+      # K <- lav_mat_com(m = nvar, n = nvar)
       # AB <- (K %x% diag(NROW(C3)*NROW(C3))) %*%
-      #          (diag(nvar) %x% lav_matrix_vec(C3) %x% diag(nvar))
-      # K <- lav_matrix_commutation(m = nvar, n = NROW(C3))
+      #          (diag(nvar) %x% lav_mat_vec(C3) %x% diag(nvar))
+      # K <- lav_mat_com(m = nvar, n = NROW(C3))
       # AB <- ( diag(NROW(C3)) %x% K %x% diag(nvar) ) %*%
-      #        (lav_matrix_vec(C3) %x% diag( nvar * nvar) )
+      #        (lav_mat_vec(C3) %x% diag( nvar * nvar) )
 
       # POST.beta <- 2 *  beta.COV %*% (obs.beta - est.beta)
       d_beta <- c3 %*% (obs - est) %*% sigma_inv
       # NOTE: the vecr here, unlike lav_mvreg_dlogl_beta
       #       this is because DELTA has used vec(t(BETA)),
       #       instead of vec(BETA)
-      # POST.beta <- 2 * lav_matrix_vecr(d.BETA)
+      # POST.beta <- 2 * lav_mat_vecr(d.BETA)
       # NOT any longer, since 0.6-1!!!
-      post_beta <- 2 * lav_matrix_vec(d_beta)
+      post_beta <- 2 * lav_mat_vec(d_beta)
 
-      # POST.sigma1 <- lav_matrix_duplication_pre(
+      # POST.sigma1 <- lav_mat_dup_pre(
       #        (Sigma.inv %x% Sigma.inv)  %*% t(AB)  %*% (t(a) %x% b) )
 
       # Sigma
-      # POST.sigma2 <- lav_matrix_duplication_pre(
-      #                 matrix( lav_matrix_vec(
+      # POST.sigma2 <- lav_mat_dup_pre(
+      #                 matrix( lav_mat_vec(
       #          Sigma.inv %*% (S - Sigma) %*% t(Sigma.inv)), ncol = 1L))
       w_tilde <- s + t(obs - est) %*% c3 %*% (obs - est)
       d_sigma <- (sigma_inv - sigma_inv %*% w_tilde %*% sigma_inv)
-      d_vech_sigma <- as.numeric(lav_matrix_duplication_pre(
-        as.matrix(lav_matrix_vec(d_sigma))
+      d_vech_sigma <- as.numeric(lav_mat_dup_pre(
+        as.matrix(lav_mat_vec(d_sigma))
       ))
       post_sigma <- -1 * d_vech_sigma
 
@@ -510,7 +510,7 @@ lav_model_gradient <- function(lavmodel = NULL,
   # ML + conditional.x
   } else if (estimator == "ML" && lavdata@nlevels > 1L) {
     if (type != "free") {
-      lav_msg_fixme("type != free in lav_model_gradient for
+      lav_msg_fixme("type != free in lav_model_grad for
                     estimator ML for nlevels > 1")
     } else {
       delta <- lav_model_delta(lavmodel = lavmodel, glist = glist)
@@ -520,7 +520,7 @@ lav_model_gradient <- function(lavmodel = NULL,
     for (g in 1:lavmodel@ngroups) {
       if (!lavsamplestats@missing.flag) { # complete data
         if (lavmodel@conditional.x) {
-          dx_1 <- lav_mvreg_cluster_dlogl_2l_samplestats(
+          dx_1 <- lav_mvreg_cl_dlogl_2l_samp(
             ylp = lavsamplestats@YLp[[g]],
             lp = lavdata@Lp[[g]],
             res_sigma_w = sigma_hat[[(g - 1) * 2 + 1]],
@@ -532,7 +532,7 @@ lav_model_gradient <- function(lavmodel = NULL,
             sinv_method = "eigen"
           )
         } else {
-          dx_1 <- lav_mvnorm_cluster_dlogl_2l_samplestats(
+          dx_1 <- lav_mvn_cl_dlogl_2l_samp(
             ylp = lavsamplestats@YLp[[g]],
             lp = lavdata@Lp[[g]],
             mu_w = mu_hat[[(g - 1) * 2 + 1]],
@@ -548,7 +548,7 @@ lav_model_gradient <- function(lavmodel = NULL,
           lav_msg_stop(gettext("gradient for twolevel + conditional.x + fiml
                   is not ready; use optim.gradient = \"numerical\""))
         } else {
-          dx_1 <- lav_mvnorm_cluster_missing_dlogl_2l_samplestats(
+          dx_1 <- lav_mvn_cl_mi_dlogl_2l_samp(
             y1 = lavdata@X[[g]],
             y2 = lavsamplestats@YLp[[g]][[2]]$Y2,
             lp = lavdata@Lp[[g]],
@@ -582,7 +582,7 @@ lav_model_gradient <- function(lavmodel = NULL,
   } else if (estimator == "PML" || estimator == "FML" ||
     estimator == "MML") {
     if (type != "free") {
-      lav_msg_fixme("type != free in lav_model_gradient for estimator PML")
+      lav_msg_fixme("type != free in lav_model_grad for estimator PML")
     } else {
       delta <- lav_model_delta(lavmodel = lavmodel, glist = glist)
     }
@@ -650,7 +650,7 @@ lav_model_gradient <- function(lavmodel = NULL,
           as.numeric(t(d1) %*% delta[[g]]) / lavsamplestats@nobs[[g]]
       } else if (estimator == "MML") {
         group_dx <-
-          lav_model_gradient_mml(
+          lav_model_grad_mml(
             lavmodel = lavmodel,
             glist = glist,
             mm_theta = mm_theta[[g]],
@@ -718,7 +718,7 @@ lav_model_delta_numerical <- function(lavmodel = NULL, glist = NULL, g = 1L) {
   compute_moments <- function(x) {
     glist <- lav_model_x2glist(lavmodel = lavmodel, x = x, type = "free")
     sigma_hat <- lav_model_sigma(lavmodel = lavmodel, glist = glist)
-    s_vec <- lav_matrix_vech(sigma_hat[[g]])
+    s_vec <- lav_mat_vech(sigma_hat[[g]])
     if (lavmodel@meanstructure) {
       mu_hat <- lav_model_mu(lavmodel = lavmodel, glist = glist)
       out <- c(mu_hat[[g]], s_vec)
@@ -1009,7 +1009,7 @@ lav_model_omega <- function(sigma_hat = NULL, mu_hat = NULL,
         # FIXME: WHAT IS THE BEST THING TO DO HERE??
         # CURRENTLY: stop
         lav_msg_warn(gettext(
-          "lav_model_gradient: Sigma.hat is not positive definite\n"))
+          "lav_model_grad: Sigma.hat is not positive definite\n"))
         sigma_hat_inv <- MASS::ginv(sigma_hat[[g]])
       } else {
         sigma_hat_inv <- attr(sigma_hat[[g]], "inv")
@@ -1097,7 +1097,7 @@ lav_model_omega <- function(sigma_hat = NULL, mu_hat = NULL,
   omega
 }
 
-lav_model_gradient_dd <- function(lavmodel, g_list = NULL, group = 1L) {
+lav_model_grad_dd <- function(lavmodel, g_list = NULL, group = 1L) {
   if (is.null(g_list)) g_list <- lavmodel@GLIST
 
   #### FIX th + mu!!!!!
@@ -1135,10 +1135,10 @@ lav_model_gradient_dd <- function(lavmodel, g_list = NULL, group = 1L) {
   nfac <- ncol(m_list$lambda) - length(lv_dummy_idx)
 
   # dd$theta
-  theta_idx <- lav_matrix_diagh_idx(nvar)
+  theta_idx <- lav_mat_diagh_idx(nvar)
   dd$theta <- delta_theta[theta_idx, , drop = FALSE]
   if (length(ov_dummy_idx) > 0L) {
-    psi_idx <- lav_matrix_diagh_idx(ncol(m_list$psi))[lv_dummy_idx]
+    psi_idx <- lav_mat_diagh_idx(ncol(m_list$psi))[lv_dummy_idx]
     dd$theta[ov_dummy_idx, ] <- delta_psi[psi_idx, , drop = FALSE]
   }
   # num only? FIXME or just all of them?

--- a/R/lav_model_gradient_mml.R
+++ b/R/lav_model_gradient_mml.R
@@ -1,4 +1,4 @@
-lav_model_gradient_mml <- function(lavmodel = NULL,
+lav_model_grad_mml <- function(lavmodel = NULL,
                                    mm_theta = NULL,
                                    th = NULL,
                                    glist = NULL,
@@ -142,7 +142,7 @@ lav_model_gradient_mml <- function(lavmodel = NULL,
 
   # Delta
   ## DD <- lavcache[[group]]$DD
-  dd <- lav_model_gradient_dd(lavmodel, g_list = glist, group = group)
+  dd <- lav_model_grad_dd(lavmodel, g_list = glist, group = group)
 
   ## FIXME!!! do this analytically...
   x <- lav_model_get_parameters(lavmodel = lavmodel, GLIST = mlist)

--- a/R/lav_model_gradient_pml.R
+++ b/R/lav_model_gradient_pml.R
@@ -45,7 +45,7 @@ lav_pml_dploglik_dimplied <- function(
     diag(sigma_hat2) <- 1
   }
   cor_hat <- cov2cor(sigma_hat2) # to get correlations (rho!)
-  cors <- lav_matrix_vech(cor_hat, diagonal = FALSE)
+  cors <- lav_mat_vech(cor_hat, diagonal = FALSE)
 
   if (any(abs(cors) > 1)) {
     # what should we do now... force cov2cor?
@@ -147,7 +147,7 @@ lav_pml_dploglik_dimplied <- function(
     grad <- matrix(0, pstar, grad_size) # each pair is a row
   }
   pstar_1 <- matrix(0, nvar, nvar) # utility matrix, to get indices
-  pstar_1[lav_matrix_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
+  pstar_1[lav_mat_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
   # n <- length(x[, 1])
 
   for (j in seq_len(nvar - 1L)) {
@@ -178,7 +178,7 @@ lav_pml_dploglik_dimplied <- function(
             try optim.gradient = \"numerical\""))
         }
 
-        sc <- lav_mvnorm_scores_mu_vech_sigma(
+        sc <- lav_mvn_sc_mu_sigma(
           y = x[, c(i, j)],
           mu = mu_hat[c(i, j)], sigma_1 = sigma_hat[c(i, j), c(i, j)]
         )
@@ -189,7 +189,7 @@ lav_pml_dploglik_dimplied <- function(
             scores_1[, c(i, j)] <- scores_1[, c(i, j)] + sc[, c(1, 2)]
             # VAR1 + COV_12 + VAR2
             var_idx <- (nvar +
-              lav_matrix_vech_match_idx(nvar, idx = c(i, j)))
+              lav_mat_vech_match_idx(nvar, idx = c(i, j)))
             scores_1[, var_idx] <- scores_1[, var_idx] + sc[, c(3, 4, 5)]
           } else { # mixed ordered/continuous
             # MU
@@ -203,7 +203,7 @@ lav_pml_dploglik_dimplied <- function(
           if (all(ov_types == "numeric") && nexo == 0L) {
             mu_idx <- c(i, j)
             sigma_idx <- (nvar +
-              lav_matrix_vech_match_idx(nvar, idx = c(i, j)))
+              lav_mat_vech_match_idx(nvar, idx = c(i, j)))
             # MU1 + MU2
             grad[pstar_idx, mu_idx] <-
               colSums(sc[, c(1, 2)], na.rm = TRUE)
@@ -226,7 +226,7 @@ lav_pml_dploglik_dimplied <- function(
             try optim.gradient = \"numerical\""))
         }
 
-        sc_cor_uni <- lav_bvmix_cor_scores(
+        sc_cor_uni <- lav_bvmix_cor_sc(
           y1 = x[, i], y2 = x[, j],
           exo = NULL, wt = wt,
           evar_y1 = sigma_hat[i, i],
@@ -272,7 +272,7 @@ lav_pml_dploglik_dimplied <- function(
             try optim.gradient = \"numerical\""))
         }
 
-        sc_cor_uni <- lav_bvmix_cor_scores(
+        sc_cor_uni <- lav_bvmix_cor_sc(
           y1 = x[, j], y2 = x[, i],
           exo = NULL, wt = wt,
           evar_y1 = sigma_hat[j, j],
@@ -313,7 +313,7 @@ lav_pml_dploglik_dimplied <- function(
         # polychoric correlation
         if (nexo == 0L) {
           sc_cor_uni <-
-            lav_bvord_cor_scores(
+            lav_bvord_cor_sc(
               y1 = x[, i], y2 = x[, j],
               exo = NULL, wt = wt,
               rho = sigma_hat[i, j],
@@ -412,7 +412,7 @@ lav_pml_dploglik_dimplied <- function(
       uni_scores <- matrix(0, nrow(x), n_th)
       for (i in seq_len(nvar)) {
         th_idx_i <- which(th_idx == i)
-        der_y1 <- lav_pml_uni_scores(
+        der_y1 <- lav_pml_uni_sc(
           y1 = x[, i], th_y1 = th[th_idx == i],
           exo = NULL, sl_y1 = NULL,
           weights_casewise = lavcache$uniweights.casewise
@@ -424,7 +424,7 @@ lav_pml_dploglik_dimplied <- function(
       for (i in seq_len(nvar)) {
         th_idx_i <- which(th_idx == i)
         sl_idx_i <- n_th + seq(i, by = nvar, length.out = nexo)
-        der_y1 <- lav_pml_uni_scores(
+        der_y1 <- lav_pml_uni_sc(
           y1 = x[, i], th_y1 = th[th_idx == i],
           exo = exo, sl_y1 = pi0[i, ],
           weights_casewise = lavcache$uniweights.casewise

--- a/R/lav_model_h1_information.R
+++ b/R/lav_model_h1_information.R
@@ -24,7 +24,7 @@
 
 
 
-lav_model_h1_information <- function(lavobject = NULL,
+lav_model_h1_info <- function(lavobject = NULL,
                                      lavmodel = NULL,
                                      lavsamplestats = NULL,
                                      lavdata = NULL,
@@ -61,21 +61,21 @@ lav_model_h1_information <- function(lavobject = NULL,
 
   # compute information matrix
   if (information == "observed") {
-    i1 <- lav_model_h1_information_observed(
+    i1 <- lav_model_h1_info_observed(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
       lavcache = lavcache, lavoptions = lavoptions
     )
   } else if (information == "expected") {
-    i1 <- lav_model_h1_information_expected(
+    i1 <- lav_model_h1_info_expected(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
       lavcache = lavcache, lavoptions = lavoptions
     )
   } else if (information == "first.order") {
-    i1 <- lav_model_h1_information_firstorder(
+    i1 <- lav_model_h1_info_firstorder(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -88,7 +88,7 @@ lav_model_h1_information <- function(lavobject = NULL,
 }
 
 # fisher/expected information of H1
-lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
+lav_model_h1_info_expected <- function(lavobject = NULL,
                                               lavmodel = NULL,
                                               lavsamplestats = NULL,
                                               lavdata = NULL,
@@ -141,7 +141,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
       a1 <- vector("list", length = lavsamplestats@ngroups)
       for (g in seq_len(lavsamplestats@ngroups)) {
         dls_a <- lavmodel@estimator.args$dls.a
-        gamma_nt <- lav_samplestats_gamma_nt(
+        gamma_nt <- lav_samp_gamma_nt(
           m_cov          = lavimplied$cov[[g]],
           m_mean         = lavimplied$mean[[g]],
           x_idx          = lavsamplestats@x.idx[[g]],
@@ -151,7 +151,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
           slopestructure = lavmodel@conditional.x
         )
         w_dls <- (1 - dls_a) * lavsamplestats@NACOV[[g]] + dls_a * gamma_nt
-        a1[[g]] <- lav_matrix_symmetric_inverse(w_dls)
+        a1[[g]] <- lav_mat_sym_inverse(w_dls)
       }
     }
 
@@ -186,7 +186,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
 
         if (structured) {
           a1[[g]] <-
-            lav_mvnorm_missing_information_expected(
+            lav_mvn_mi_info_expected(
               y = lavdata@X[[g]],
               mp = lavdata@Mp[[g]],
               wt = wt,
@@ -197,7 +197,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
             )
         } else {
           a1[[g]] <-
-            lav_mvnorm_missing_information_expected(
+            lav_mvn_mi_info_expected(
               y = lavdata@X[[g]],
               mp = lavdata@Mp[[g]],
               wt = wt,
@@ -220,7 +220,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
           }
 
           if (structured) {
-            a1[[g]] <- lav_mvreg_information_expected(
+            a1[[g]] <- lav_mvreg_info_expected(
               sample_mean_x     = lavsamplestats@mean.x[[g]],
               sample_cov_x      = lavsamplestats@cov.x[[g]],
               sample_nobs       = lavsamplestats@nobs[[g]],
@@ -231,7 +231,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
               res_cov           = lavimplied$res.cov[[g]]
             )
           } else {
-            a1[[g]] <- lav_mvreg_information_expected(
+            a1[[g]] <- lav_mvreg_info_expected(
               sample_mean_x     = lavsamplestats@mean.x[[g]],
               sample_cov_x      = lavsamplestats@cov.x[[g]],
               sample_nobs       = lavsamplestats@nobs[[g]],
@@ -254,7 +254,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
           correlation_flag <- lavmodel@correlation
 
           if (structured) {
-            a1[[g]] <- lav_mvnorm_information_expected(
+            a1[[g]] <- lav_mvn_info_expected(
               sigma_1         = lavimplied$cov[[g]],
               # wt = WT, # not needed
               x_idx         = lavsamplestats@x.idx[[g]],
@@ -262,7 +262,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
               correlation   = correlation_flag
             )
           } else {
-            a1[[g]] <- lav_mvnorm_h1_information_expected(
+            a1[[g]] <- lav_mvn_h1_info_expected(
               sample_cov_inv = lavsamplestats@icov[[g]],
               # wt = WT, not needed
               x_idx          = lavsamplestats@x.idx[[g]],
@@ -277,7 +277,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
       if (lavmodel@group.w.free) {
         # unweight!! (as otherwise, we would 'weight' again)
         a <- exp(lavimplied$group.w[[g]]) / lavsamplestats@nobs[[g]]
-        a1[[g]] <- lav_matrix_bdiag(matrix(a, 1L, 1L), a1[[g]])
+        a1[[g]] <- lav_mat_bdiag(matrix(a, 1L, 1L), a1[[g]])
       }
     } # g
   # ML
@@ -305,7 +305,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
       sigma_b <- implied$cov[[(g - 1) * lavdata@nlevels + 2L]]
 
       # clustered data
-      a1[[g]] <- lav_mvnorm_cluster_information_expected(
+      a1[[g]] <- lav_mvn_cl_info_expected(
         lp           = lavdata@Lp[[g]],
         mu_w         = mu_w,
         sigma_w      = sigma_w,
@@ -320,7 +320,7 @@ lav_model_h1_information_expected <- function(lavobject = NULL, # nolint
   a1
 }
 
-lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
+lav_model_h1_info_observed <- function(lavobject = NULL,
                                               lavmodel = NULL,
                                               lavsamplestats = NULL,
                                               lavdata = NULL,
@@ -373,7 +373,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
       a1 <- vector("list", length = lavsamplestats@ngroups)
       for (g in seq_len(lavsamplestats@ngroups)) {
         dls_a <- lavmodel@estimator.args$dls.a
-        gamma_nt <- lav_samplestats_gamma_nt(
+        gamma_nt <- lav_samp_gamma_nt(
           m_cov          = lavimplied$cov[[g]],
           m_mean         = lavimplied$mean[[g]],
           x_idx          = lavsamplestats@x.idx[[g]],
@@ -383,7 +383,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
           slopestructure = lavmodel@conditional.x
         )
         w_dls <- (1 - dls_a) * lavsamplestats@NACOV[[g]] + dls_a * gamma_nt
-        a1[[g]] <- lav_matrix_symmetric_inverse(w_dls)
+        a1[[g]] <- lav_mat_sym_inverse(w_dls)
       }
     }
   # 2. DWLS/ULS diagonal @WLS.VD slot
@@ -481,7 +481,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
           }
 
           if (structured) {
-            a1[[g]] <- lav_mvnorm_information_observed_samplestats(
+            a1[[g]] <- lav_mvn_info_observed_samp(
               sample_mean   = lavsamplestats@mean[[g]],
               sample_cov    = lavsamplestats@cov[[g]],
               mu            = mean_1,
@@ -491,7 +491,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
               meanstructure = lavmodel@meanstructure
             )
           } else {
-            a1[[g]] <- lav_mvnorm_h1_information_observed_samplestats(
+            a1[[g]] <- lav_mvn_h1_info_observed_samp(
               sample_mean    = lavsamplestats@mean[[g]],
               sample_cov     = lavsamplestats@cov[[g]],
               sample_cov_inv = lavsamplestats@icov[[g]],
@@ -507,7 +507,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
       if (lavmodel@group.w.free) {
         # unweight!!
         a <- exp(lavimplied$group.w[[g]]) / lavsamplestats@nobs[[g]]
-        a1[[g]] <- lav_matrix_bdiag(matrix(a, 1, 1), a1[[g]])
+        a1[[g]] <- lav_mat_bdiag(matrix(a, 1, 1), a1[[g]])
       }
     } # g
   # ML
@@ -534,7 +534,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
       sigma_b <- implied$cov[[(g - 1) * lavdata@nlevels + 2L]]
 
       if (lavdata@missing == "ml") {
-          a1[[g]] <- lav_mvnorm_cluster_missing_information_observed(
+          a1[[g]] <- lav_mvn_cl_mi_info_observed(
             y1            = lavdata@X[[g]],
             y2            = lavsamplestats@YLp[[g]][[2]]$Y2,
             lp            = lavdata@Lp[[g]],
@@ -546,7 +546,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
             x_idx         = lavsamplestats@x.idx[[g]]
           )
       } else {
-        a1[[g]] <- lav_mvnorm_cluster_information_observed(
+        a1[[g]] <- lav_mvn_cl_info_observed(
           lp           = lavdata@Lp[[g]],
           ylp          = lavsamplestats@YLp[[g]],
           mu_w         = mu_w,
@@ -565,7 +565,7 @@ lav_model_h1_information_observed <- function(lavobject = NULL, # nolint
 # outer product of the case-wise scores (gradients)
 # HJ 18/10/2023: Adjust J matrix correctly using weights. Note: H matrix is
 # based on lav_model_hessian so no changes required.
-lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
+lav_model_h1_info_firstorder <- function(lavobject = NULL,
                                                 lavmodel = NULL,
                                                 lavsamplestats = NULL,
                                                 lavdata = NULL,
@@ -715,7 +715,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
 
       } else {
         if (is.null(wt)) {
-          b1[[g]] <- lav_matrix_crossprod(sc)
+          b1[[g]] <- lav_mat_crossprod(sc)
         } else {
           b1[[g]] <- crossprod(wt * sc)
         }
@@ -738,7 +738,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
         res_sigma_b <- implied$res.cov[[(g - 1) * lavdata@nlevels + 2L]]
         res_int_b <- implied$res.int[[(g - 1) * lavdata@nlevels + 2L]]
         res_pi_b <- implied$res.slopes[[(g - 1) * lavdata@nlevels + 2L]]
-        b1[[g]] <- lav_mvreg_cluster_information_firstorder(
+        b1[[g]] <- lav_mvreg_cl_info_firstorder(
           y1            = lavdata@X[[g]],
           ylp           = lavsamplestats@YLp[[g]],
           lp            = lavdata@Lp[[g]],
@@ -756,7 +756,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
         sigma_w <- implied$cov[[(g - 1) * lavdata@nlevels + 1L]]
         sigma_b <- implied$cov[[(g - 1) * lavdata@nlevels + 2L]]
     if (lavdata@missing == "ml") {
-          b1[[g]] <- lav_mvnorm_cluster_missing_information_firstorder(
+          b1[[g]] <- lav_mvn_cl_mi_info_firstorder(
             y1            = lavdata@X[[g]],
             y2            = lavsamplestats@YLp[[g]][[2]]$Y2,
             lp            = lavdata@Lp[[g]],
@@ -770,7 +770,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
           )
     } else {
       # no missing values
-          b1[[g]] <- lav_mvnorm_cluster_information_firstorder(
+          b1[[g]] <- lav_mvn_cl_info_firstorder(
             y1            = lavdata@X[[g]],
             ylp           = lavsamplestats@YLp[[g]],
             lp            = lavdata@Lp[[g]],
@@ -801,7 +801,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
           mean_1 <- lavh1$implied$mean[[g]]
         }
 
-        b1[[g]] <- lav_mvnorm_missing_information_firstorder(
+        b1[[g]] <- lav_mvn_mi_info_firstorder(
           y = lavdata@X[[g]],
           mp = lavdata@Mp[[g]], wt = wt,
           cluster_idx = cluster_idx,
@@ -821,7 +821,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
             res_slopes <- lavsamplestats@res.slopes[[g]]
           }
 
-          b1[[g]] <- lav_mvreg_information_firstorder(
+          b1[[g]] <- lav_mvreg_info_firstorder(
             y              = lavdata@X[[g]],
             exo            = lavdata@eXo[[g]],
             res_int        = res_int,
@@ -845,7 +845,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
           }
 
           if (structured) {
-            b1[[g]] <- lav_mvnorm_information_firstorder(
+            b1[[g]] <- lav_mvn_info_firstorder(
               y = lavdata@X[[g]],
               mu = mean_1, sigma_1 = lavimplied$cov[[g]],
               wt = wt,
@@ -854,7 +854,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
               meanstructure = lavmodel@meanstructure
             )
           } else {
-            b1[[g]] <- lav_mvnorm_h1_information_firstorder(
+            b1[[g]] <- lav_mvn_h1_info_firstorder(
               y = lavdata@X[[g]],
               sample_cov_inv = lavsamplestats@icov[[g]],
               gamma_1 = lavsamplestats@NACOV[[g]],
@@ -872,7 +872,7 @@ lav_model_h1_information_firstorder <- function(lavobject = NULL,     # nolint
     if (lavmodel@group.w.free) {
       # unweight!!
       a <- exp(lavimplied$group.w[[g]]) / lavsamplestats@nobs[[g]]
-      b1[[g]] <- lav_matrix_bdiag(matrix(a, 1, 1), b1[[g]])
+      b1[[g]] <- lav_mat_bdiag(matrix(a, 1, 1), b1[[g]])
     }
   } # g
 
@@ -936,21 +936,21 @@ lav_model_h1_acov <- function(lavobject = NULL,
 
   # compute information matrix
   if (information == "observed") {
-    i1 <- lav_model_h1_information_observed(
+    i1 <- lav_model_h1_info_observed(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
       lavcache = lavcache, lavoptions = lavoptions
     )
   } else if (information == "expected") {
-    i1 <- lav_model_h1_information_expected(
+    i1 <- lav_model_h1_info_expected(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
       lavcache = lavcache, lavoptions = lavoptions
     )
   } else if (information == "first.order") {
-    i1 <- lav_model_h1_information_firstorder(
+    i1 <- lav_model_h1_info_firstorder(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -959,7 +959,7 @@ lav_model_h1_acov <- function(lavobject = NULL,
   }
 
   if (lavoptions$se %in% c("robust.huber.white", "robust.sem")) {
-    j1 <- lav_model_h1_information_firstorder(
+    j1 <- lav_model_h1_info_firstorder(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -978,7 +978,7 @@ lav_model_h1_acov <- function(lavobject = NULL,
     }
 
     # invert information
-    i1_g_inv <- try(lav_matrix_symmetric_inverse(i1[[g]]), silent = TRUE)
+    i1_g_inv <- try(lav_mat_sym_inverse(i1[[g]]), silent = TRUE)
     if (inherits(i1_g_inv, "try-error")) {
       lav_msg_stop(gettext(
         "could not invert h1 information matrix in group"), g)

--- a/R/lav_model_h1_omega.R
+++ b/R/lav_model_h1_omega.R
@@ -60,21 +60,21 @@ lav_model_h1_omega <- function(lavobject = NULL,
 
   # compute A1 (per group)
   if (information == "observed") {
-    a1_1 <- lav_model_h1_information_observed(
+    a1_1 <- lav_model_h1_info_observed(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
       lavcache = lavcache, lavoptions = a1_options
     )
   } else if (information == "expected") {
-    a1_1 <- lav_model_h1_information_expected(
+    a1_1 <- lav_model_h1_info_expected(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
       lavcache = lavcache, lavoptions = a1_options
     )
   } else if (information == "first.order") { # not needed?
-    a1_1 <- lav_model_h1_information_firstorder(
+    a1_1 <- lav_model_h1_info_firstorder(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -83,7 +83,7 @@ lav_model_h1_omega <- function(lavobject = NULL,
   }
 
   # compute B1 (per group)
-  b1 <- lav_model_h1_information_firstorder(
+  b1 <- lav_model_h1_info_firstorder(
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats, lavdata = lavdata,
     lavimplied = lavimplied, lavh1 = lavh1,

--- a/R/lav_model_hessian.R
+++ b/R/lav_model_hessian.R
@@ -49,7 +49,7 @@ lav_model_hessian <- function(lavmodel = NULL,
     x_right2[j] <- x[j] + 2 * h_j
 
     g_left <-
-      lav_model_gradient(
+      lav_model_grad(
         lavmodel = lavmodel,
         glist = lav_model_x2glist(
           lavmodel =
@@ -64,7 +64,7 @@ lav_model_hessian <- function(lavmodel = NULL,
         ceq_simple = ceq_simple
       )
     g_left2 <-
-      lav_model_gradient(
+      lav_model_grad(
         lavmodel = lavmodel,
         glist = lav_model_x2glist(
           lavmodel =
@@ -80,7 +80,7 @@ lav_model_hessian <- function(lavmodel = NULL,
       )
 
     g_right <-
-      lav_model_gradient(
+      lav_model_grad(
         lavmodel = lavmodel,
         glist = lav_model_x2glist(
           lavmodel =
@@ -96,7 +96,7 @@ lav_model_hessian <- function(lavmodel = NULL,
       )
 
     g_right2 <-
-      lav_model_gradient(
+      lav_model_grad(
         lavmodel = lavmodel,
         glist = lav_model_x2glist(
           lavmodel =

--- a/R/lav_model_information.R
+++ b/R/lav_model_information.R
@@ -5,7 +5,7 @@
 # 2) by default, we ignore the constraints (we deal with this when we
 #    take the inverse later on)
 
-lav_model_information <- function(lavmodel = NULL,
+lav_model_info <- function(lavmodel = NULL,
                                   lavsamplestats = NULL,
                                   lavdata = NULL,
                                   lavimplied = NULL,
@@ -41,7 +41,7 @@ lav_model_information <- function(lavmodel = NULL,
     } else {
       group_weight <- TRUE
     }
-    m_e <- lav_model_information_observed(
+    m_e <- lav_model_info_observed(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -50,7 +50,7 @@ lav_model_information <- function(lavmodel = NULL,
       augmented = augmented, inverted = inverted, use_ginv = use_ginv
     )
   } else if (information == "expected") {
-    m_e <- lav_model_information_expected(
+    m_e <- lav_model_info_expected(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -58,7 +58,7 @@ lav_model_information <- function(lavmodel = NULL,
       augmented = augmented, inverted = inverted, use_ginv = use_ginv
     )
   } else if (information == "first.order") {
-    m_e <- lav_model_information_firstorder(
+    m_e <- lav_model_info_firstorder(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavimplied = lavimplied, lavh1 = lavh1,
@@ -77,7 +77,7 @@ lav_model_information <- function(lavmodel = NULL,
 # information = Delta' I1 Delta, where I1 is the unit information of
 # the saturated model (evaluated either at the structured or unstructured
 # estimates)
-lav_model_information_expected <- function(lavmodel = NULL,
+lav_model_info_expected <- function(lavmodel = NULL,
                                            lavsamplestats = NULL,
                                            lavdata = NULL,
                                            lavoptions = NULL,
@@ -101,7 +101,7 @@ lav_model_information_expected <- function(lavmodel = NULL,
 
   # 2. H1 information (single level)
   if (lavdata@nlevels == 1L) {
-    a1 <- lav_model_h1_information_expected(
+    a1 <- lav_model_h1_info_expected(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats,
       lavdata = lavdata,
@@ -138,7 +138,7 @@ lav_model_information_expected <- function(lavmodel = NULL,
       lp <- lavdata@Lp[[g]]
 
       info_g <-
-        lav_mvnorm_cluster_information_expected_delta(
+        lav_mvn_cl_info_expected_delta(
           lp = lp,
           delta = delta[[g]],
           mu_w = mu_w,
@@ -184,7 +184,7 @@ lav_model_information_expected <- function(lavmodel = NULL,
   # 5. augmented information?
   if (augmented) {
     information <-
-      lav_model_information_augment_invert(
+      lav_model_info_augment_invert(
         lavmodel = lavmodel,
         information = information,
         inverted = inverted,
@@ -202,7 +202,7 @@ lav_model_information_expected <- function(lavmodel = NULL,
 }
 
 # only for Mplus MLM
-lav_model_information_expected_mlm <- function(lavmodel = NULL,
+lav_model_info_expected_mlm <- function(lavmodel = NULL,
                                                lavsamplestats = NULL,
                                                m_delta = NULL,
                                                extra = FALSE,
@@ -223,7 +223,7 @@ lav_model_information_expected_mlm <- function(lavmodel = NULL,
     gw <- unlist(lav_model_gw(lavmodel = lavmodel))
   }
   for (g in 1:lavsamplestats@ngroups) {
-    a1[[g]] <- lav_mvnorm_h1_information_expected(
+    a1[[g]] <- lav_mvn_h1_info_expected(
       sample_cov     = lavsamplestats@cov[[g]],
       sample_cov_inv = lavsamplestats@icov[[g]],
       x_idx          = lavsamplestats@x.idx[[g]]
@@ -233,7 +233,7 @@ lav_model_information_expected_mlm <- function(lavmodel = NULL,
       # unweight!!
       a <- exp(gw[g]) / lavsamplestats@nobs[[g]]
       # a <- exp(gw[g]) * lavsamplestats@ntotal / lavsamplestats@nobs[[g]]
-      a1[[g]] <- lav_matrix_bdiag(matrix(a, 1, 1), a1[[g]])
+      a1[[g]] <- lav_mat_bdiag(matrix(a, 1, 1), a1[[g]])
     }
   }
 
@@ -256,7 +256,7 @@ lav_model_information_expected_mlm <- function(lavmodel = NULL,
   # augmented information?
   if (augmented) {
     information <-
-      lav_model_information_augment_invert(
+      lav_model_info_augment_invert(
         lavmodel = lavmodel,
         information = information,
         inverted = inverted,
@@ -273,7 +273,7 @@ lav_model_information_expected_mlm <- function(lavmodel = NULL,
 }
 
 
-lav_model_information_observed <- function(lavmodel = NULL,
+lav_model_info_observed <- function(lavmodel = NULL,
                                            lavsamplestats = NULL,
                                            lavdata = NULL,
                                            lavimplied = NULL,
@@ -349,7 +349,7 @@ lav_model_information_observed <- function(lavmodel = NULL,
 
     # 2. H1 information
 
-    a1 <- lav_model_h1_information_observed(
+    a1 <- lav_model_h1_info_observed(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats,
       lavdata = lavdata,
@@ -389,7 +389,7 @@ lav_model_information_observed <- function(lavmodel = NULL,
   # augmented information?
   if (augmented) {
     information <-
-      lav_model_information_augment_invert(
+      lav_model_info_augment_invert(
         lavmodel = lavmodel,
         information = information,
         inverted = inverted,
@@ -408,7 +408,7 @@ lav_model_information_observed <- function(lavmodel = NULL,
 # outer product of the case-wise scores (gradients)
 # HJ 18/10/23: Need to divide sum of crossproduct of individual log-likelihoods
 # by sum of weights rather than sample size.
-lav_model_information_firstorder <- function(lavmodel = NULL,           # nolint
+lav_model_info_firstorder <- function(lavmodel = NULL,
                                              lavsamplestats = NULL,
                                              lavdata = NULL,
                                              lavimplied = NULL,
@@ -436,7 +436,7 @@ lav_model_information_firstorder <- function(lavmodel = NULL,           # nolint
   delta <- lav_model_delta(lavmodel = lavmodel)
 
   # 2. H1 information
-  b1 <- lav_model_h1_information_firstorder(
+  b1 <- lav_model_h1_info_firstorder(
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats,
     lavdata = lavdata,
@@ -500,7 +500,7 @@ lav_model_information_firstorder <- function(lavmodel = NULL,           # nolint
   # augmented information?
   if (augmented) {
     information <-
-      lav_model_information_augment_invert(
+      lav_model_info_augment_invert(
         lavmodel = lavmodel,
         information = information,
         check_pd = check_pd,
@@ -526,7 +526,7 @@ lav_model_information_firstorder <- function(lavmodel = NULL,           # nolint
 # contains more parameters than the joint model; therefore, information
 # will be 'too small', and we need to remove some columns in H
 #
-lav_model_information_augment_invert <- function(lavmodel = NULL,   # nolint
+lav_model_info_augment_invert <- function(lavmodel = NULL,
                                                  information = NULL,
                                                  inverted = FALSE,
                                                  check_pd = FALSE,
@@ -564,7 +564,7 @@ lav_model_information_augment_invert <- function(lavmodel = NULL,   # nolint
       information <- e3
     }
   } else if (lavmodel@ceq.simple.only) {
-    h <- t(lav_matrix_orthogonal_complement(lavmodel@ceq.simple.K))
+    h <- t(lav_mat_ortho_complement(lavmodel@ceq.simple.K))
     if (length(rm_idx) > 0L) {
       h <- h[, -rm_idx, drop = FALSE]
     }

--- a/R/lav_model_loglik.R
+++ b/R/lav_model_loglik.R
@@ -82,7 +82,7 @@ lav_model_loglik <- function(lavdata = NULL,
             logl_group[g] <- as.numeric(NA)
           } else {
             logl_group[g] <-
-              lav_mvnorm_cluster_missing_loglik_samplestats_2l(
+              lav_mvn_cl_mi_loglik_samp_2l(
                 y1 = lavdata@X[[g]],
                 y2 = lavsamplestats@YLp[[g]][[2]]$Y2,
                 lp = lavdata@Lp[[g]],
@@ -97,7 +97,7 @@ lav_model_loglik <- function(lavdata = NULL,
           # complete case
           if (lavmodel@conditional.x) {
             logl_group[g] <-
-              lav_mvreg_cluster_loglik_samplestats_2l(
+              lav_mvreg_cl_loglik_samp_2l(
                 ylp          = lavsamplestats@YLp[[g]],
                 lp           = lavdata@Lp[[g]],
                 res_sigma_w  = res_sigma_w,
@@ -112,7 +112,7 @@ lav_model_loglik <- function(lavdata = NULL,
               )
           } else {
             logl_group[g] <-
-              lav_mvnorm_cluster_loglik_samplestats_2l(
+              lav_mvn_cl_loglik_samp_2l(
                 ylp          = lavsamplestats@YLp[[g]],
                 lp           = lavdata@Lp[[g]],
                 mu_w         = mu_w,
@@ -133,7 +133,7 @@ lav_model_loglik <- function(lavdata = NULL,
           x_mean <- lavh1$implied$mean[[g]][x_idx]
           x_cov <- lavh1$implied$cov[[g]][x_idx, x_idx, drop = FALSE]
         }
-        logl_group[g] <- lav_mvnorm_missing_loglik_samplestats(
+        logl_group[g] <- lav_mvn_mi_loglik_samp(
           yp     = lavsamplestats@missing[[g]],
           mu     = lavimplied$mean[[g]],
           sigma_1  = lavimplied$cov[[g]],
@@ -144,7 +144,7 @@ lav_model_loglik <- function(lavdata = NULL,
       } else { # single-level, complete data
         if (lavoptions$conditional.x) {
           # FIXME: use lavh1
-          logl_group[g] <- lav_mvreg_loglik_samplestats(
+          logl_group[g] <- lav_mvreg_loglik_samp(
             sample_res_int    = lavsamplestats@res.int[[g]],
             sample_res_slopes = lavsamplestats@res.slopes[[g]],
             sample_res_cov    = lavsamplestats@res.cov[[g]],
@@ -162,7 +162,7 @@ lav_model_loglik <- function(lavdata = NULL,
           } else {
             mu <- lavsamplestats@mean[[g]]
           }
-          logl_group[g] <- lav_mvnorm_loglik_samplestats(
+          logl_group[g] <- lav_mvn_loglik_samp(
             sample_mean = lavsamplestats@mean[[g]],
             sample_cov  = lavsamplestats@cov[[g]],
             sample_nobs = lavsamplestats@nobs[[g]],

--- a/R/lav_model_objective.R
+++ b/R/lav_model_objective.R
@@ -136,7 +136,7 @@ lav_model_objective <- function(lavmodel = NULL,
         }
         # check if h1 is defined (eg zero coverage)
         if (is.null(lavsamplestats@missing.h1[[g]]$h1)) {
-          #this.h1 <- lav_mvnorm_missing_loglik_samplestats(
+          #this.h1 <- lav_mvn_mi_loglik_samp(
           #  Yp = lavsamplestats@missing[[g]],
           #  Mu = Mu.hat[[g]], Sigma = Sigma.hat[[g]],
           #  log2pi = FALSE, minus.two = TRUE) / lavsamplestats@nobs[[g]]
@@ -230,7 +230,7 @@ lav_model_objective <- function(lavmodel = NULL,
           wls_v <- lavsamplestats@WLS.V[[g]]
         } else {
           dls_a <- estimator_args$dls.a
-          gamma_nt <- lav_samplestats_gamma_nt(
+          gamma_nt <- lav_samp_gamma_nt(
             m_cov          = sigma_hat[[g]],
             m_mean         = mu_hat[[g]],
             x_idx          = lavsamplestats@x.idx[[g]],
@@ -240,10 +240,10 @@ lav_model_objective <- function(lavmodel = NULL,
             slopestructure = lavmodel@conditional.x
           )
           w_dls <- (1 - dls_a) * lavsamplestats@NACOV[[g]] + dls_a * gamma_nt
-          wls_v <- lav_matrix_symmetric_inverse(w_dls)
+          wls_v <- lav_mat_sym_inverse(w_dls)
         }
       } else if (estimator == "NTRLS") {
-        # WLS.V <- lav_samplestats_gamma_inverse_nt(
+        # WLS.V <- lav_samp_gamma_inverse_nt(
         #             m_icov = attr(Sigma.hat[[g]],"inv")[,,drop=FALSE],
         #             m_cov            = Sigma.hat[[g]][,,drop=FALSE],
         #             m_mean           = Mu.hat[[g]],
@@ -252,7 +252,7 @@ lav_model_objective <- function(lavmodel = NULL,
         #             conditional_x  = conditional.x,
         #             meanstructure  = meanstructure,
         #             slopestructure = conditional.x)
-        wls_v <- lav_mvnorm_information_expected(
+        wls_v <- lav_mvn_info_expected(
           sigma_1 = sigma_hat[[g]],
           x_idx = lavsamplestats@x.idx[[g]],
           meanstructure = lavmodel@meanstructure

--- a/R/lav_model_properties.R
+++ b/R/lav_model_properties.R
@@ -11,7 +11,7 @@
 # note: there is no 'lavmodel' yet, because we call this in lav_model.R
 lav_model_properties <- function(glist, lavpartable = NULL,
                                  nmat = NULL, m_free_idx = NULL) {
-  lavpta <- lav_partable_attributes(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
   nblocks <- lavpta$nblocks
 
   # is the model a univariate/multivariate linear multiple regression

--- a/R/lav_model_utils.R
+++ b/R/lav_model_utils.R
@@ -164,7 +164,7 @@ lav_model_x2glist <- function(lavmodel = NULL, x = NULL,
     } else if (type == "full") {
       if (lavmodel@isSymmetric[mm]) {
         n <- ncol(glist[[mm]])
-        m_el_idx_1 <- lav_matrix_vech_idx(n)
+        m_el_idx_1 <- lav_mat_vech_idx(n)
       } else {
         m_el_idx_1 <- seq_along(glist[[mm]])
       }

--- a/R/lav_model_vcov.R
+++ b/R/lav_model_vcov.R
@@ -71,7 +71,7 @@ lav_model_nvcov_bootstrap <- function(lavmodel = NULL,
                    apply(coef_1, 2, mad, na.rm = TRUE))
   crit_ratio <- 5
   if (any(sd_mad_ratio > crit_ratio)) {
-    names_1 <- lav_partable_labels(lavpartable, type = "free")
+    names_1 <- lav_pt_labels(lavpartable, type = "free")
     params_w_outliers <- paste(names_1[sd_mad_ratio > crit_ratio],
                                collapse = " ")
     lav_msg_warn(gettextf(
@@ -113,7 +113,7 @@ lav_model_nvcov_robust_sem <- function(lavmodel = NULL,
     # - gamma is not identical to what is used for WLS; closer to EQS
     # - N/N-1 bug in G11 for NVarCov (but not test statistic)
     # - we divide by N-1! (just like EQS)
-    e_inv <- lav_model_information_expected_mlm(
+    e_inv <- lav_model_info_expected_mlm(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats,
       extra = TRUE,
@@ -122,7 +122,7 @@ lav_model_nvcov_robust_sem <- function(lavmodel = NULL,
       use_ginv = use_ginv
     )
   } else {
-    e_inv <- lav_model_information(
+    e_inv <- lav_model_info(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats,
       lavdata = lavdata,
@@ -231,7 +231,7 @@ lav_model_nvcov_robust_sandwich <- function(lavmodel = NULL,    # nolint
   #       B == outer product of case-wise scores
 
   # inverse observed/expected information matrix
-  e_inv <- lav_model_information(
+  e_inv <- lav_model_info(
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats,
     lavdata = lavdata,
@@ -261,7 +261,7 @@ lav_model_nvcov_robust_sandwich <- function(lavmodel = NULL,    # nolint
 
   # outer product of case-wise scores
   b0 <-
-    lav_model_information_firstorder(
+    lav_model_info_firstorder(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats,
       lavdata = lavdata,
@@ -342,7 +342,7 @@ lav_model_nvcov_two_stage <- function(lavmodel = NULL,
 
 
   # information matrix
-  e_inv <- lav_model_information(
+  e_inv <- lav_model_info(
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats,
     lavdata = lavdata,
@@ -402,7 +402,7 @@ lav_model_nvcov_two_stage <- function(lavmodel = NULL,
     if (lavoptions$se == "two.stage") {
       # this is Savalei & Bentler (2009)
       if (lavoptions$information[1] == "expected") {
-        info <- lav_mvnorm_missing_information_expected(
+        info <- lav_mvn_mi_info_expected(
           y = lavdata@X[[g]], mp = lavdata@Mp[[g]],
           wt = lavdata@weights[[g]],
           mu = mu, sigma_1 = sigma_1,
@@ -416,7 +416,7 @@ lav_model_nvcov_two_stage <- function(lavmodel = NULL,
           x_idx = lavsamplestats@x.idx[[g]]
         )
       }
-      gamma[[g]] <- lav_matrix_symmetric_inverse(info)
+      gamma[[g]] <- lav_mat_sym_inverse(info)
     } else { # we assume "robust.two.stage"
       # NACOV is here incomplete gamma
       # Savalei & Falk (2014)
@@ -426,7 +426,7 @@ lav_model_nvcov_two_stage <- function(lavmodel = NULL,
       } else {
         cluster_idx <- NULL
       }
-      gamma[[g]] <- lav_mvnorm_missing_h1_omega_sw(
+      gamma[[g]] <- lav_mvn_mi_h1_omega_sw(
         y = lavdata@X[[g]],
         mp = lavdata@Mp[[g]],
         yp = lavsamplestats@missing[[g]],
@@ -482,7 +482,7 @@ lav_model_vcov <- function(lavmodel = NULL,
   }
 
   if (se == "standard") {
-    nvar_cov <- lav_model_information(
+    nvar_cov <- lav_model_info(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats,
       lavdata = lavdata,
@@ -497,7 +497,7 @@ lav_model_vcov <- function(lavmodel = NULL,
     )
   } else if (se == "first.order") {
     nvar_cov <-
-      lav_model_information_firstorder(
+      lav_model_info_firstorder(
         lavmodel = lavmodel,
         lavsamplestats = lavsamplestats,
         lavdata = lavdata,

--- a/R/lav_model_wls.R
+++ b/R/lav_model_wls.R
@@ -24,9 +24,9 @@ lav_model_wls_est <- function(lavmodel = NULL, glist = NULL,
       if (lavmodel@conditional.x) {
         wls_est <- c(
           lavimplied$res.th[[g]],
-          lav_matrix_vec(lavimplied$res.slopes[[g]]),
+          lav_mat_vec(lavimplied$res.slopes[[g]]),
           diag(lavimplied$res.cov[[g]])[num_idx[[g]]],
-          lav_matrix_vech(lavimplied$res.cov[[g]],
+          lav_mat_vech(lavimplied$res.cov[[g]],
             diagonal = FALSE
           )
         )
@@ -34,7 +34,7 @@ lav_model_wls_est <- function(lavmodel = NULL, glist = NULL,
         wls_est <- c(
           lavimplied$th[[g]],
           diag(lavimplied$cov[[g]])[num_idx[[g]]],
-          lav_matrix_vech(lavimplied$cov[[g]],
+          lav_mat_vech(lavimplied$cov[[g]],
             diagonal = FALSE
           )
         )
@@ -52,20 +52,20 @@ lav_model_wls_est <- function(lavmodel = NULL, glist = NULL,
         # so we need vecr
         if (meanstructure) {
           wls_est <- c(
-            lav_matrix_vecr(
+            lav_mat_vecr(
               cbind(
                 lavimplied$res.int[[g]],
                 lavimplied$res.slopes[[g]]
               )
             ),
-            lav_matrix_vech(lavimplied$res.cov[[g]],
+            lav_mat_vech(lavimplied$res.cov[[g]],
               diagonal = diag_1
             )
           )
         } else {
           wls_est <- c(
-            lav_matrix_vecr(lavimplied$res.slopes[[g]]),
-            lav_matrix_vech(lavimplied$res.cov[[g]],
+            lav_mat_vecr(lavimplied$res.slopes[[g]]),
+            lav_mat_vech(lavimplied$res.cov[[g]],
               diagonal = diag_1
             )
           )
@@ -74,12 +74,12 @@ lav_model_wls_est <- function(lavmodel = NULL, glist = NULL,
         if (meanstructure) {
           wls_est <- c(
             lavimplied$mean[[g]],
-            lav_matrix_vech(lavimplied$cov[[g]],
+            lav_mat_vech(lavimplied$cov[[g]],
               diagonal = diag_1
             )
           )
         } else {
-          wls_est <- lav_matrix_vech(lavimplied$cov[[g]],
+          wls_est <- lav_mat_vech(lavimplied$cov[[g]],
             diagonal = diag_1
           )
         }
@@ -96,4 +96,4 @@ lav_model_wls_est <- function(lavmodel = NULL, glist = NULL,
   wls_est_1
 }
 
-# Note: lav_model_wls_v() is replaced by lav_model_h1_information() in 0.6-1
+# Note: lav_model_wls_v() is replaced by lav_model_h1_info() in 0.6-1

--- a/R/lav_modification.R
+++ b/R/lav_modification.R
@@ -53,8 +53,8 @@ modindices <- function(object,                         # nolint start
   if (object@Model@conditional.x) {
     strict_exo <- TRUE
   }
-  full <- lav_partable_full(
-    partable = lav_partable_set_cache(object@ParTable, object@pta),
+  full <- lav_pt_full(
+    partable = lav_pt_set_cache(object@ParTable, object@pta),
     free = TRUE, start = TRUE,
     strict_exo = strict_exo
   )
@@ -296,7 +296,7 @@ modindices <- function(object,                         # nolint start
   list_1$user <- NULL
 
   # remove block/group/level is only single block
-  if (lav_partable_nblocks(list_1) == 1L) {
+  if (lav_pt_nblocks(list_1) == 1L) {
     list_1$block <- NULL
     list_1$group <- NULL
     list_1$level <- NULL

--- a/R/lav_mplus_lavaan.R
+++ b/R/lav_mplus_lavaan.R
@@ -236,7 +236,7 @@ lav_mplus_cmd_fix_start <- function(cmd) {
   }
 }
 
-lav_mplus_cmd_constraints <- function(cmd) {
+lav_mplus_cmd_con <- function(cmd) {
   # Allow cmd to have newlines embedded. In this case, split on newlines, and
   #  loop over and parse each chunk
   # Dump leading and trailing newlines, which contain no information about
@@ -544,7 +544,7 @@ lav_mplus_cmd_wrap <- function(cmd, width = 90, exdent = 5) {
   unname(do.call(c, result))
 }
 
-lav_mplus_syntax_constraints <- function(syntax) {
+lav_mplus_syntax_con <- function(syntax) {
   # should probably pass in model syntax along with some tracking
   #  of which parameter labels are defined.
 
@@ -702,7 +702,7 @@ lav_mplus_syntax_model <- function(syntax) {
 
     # handle model constraint
     if ("model.constraint" %in% names(parsed_syntax)) {
-      con_syntax <- strsplit(lav_mplus_syntax_constraints(
+      con_syntax <- strsplit(lav_mplus_syntax_con(
                   parsed_syntax$model.constraint), "\n")[[1]]
     }
 
@@ -758,7 +758,7 @@ lav_mplus_syntax_model <- function(syntax) {
   for (cmd in syntax_split) {
     if (grepl("^\\s*#", cmd, perl = TRUE)) { # comment line
       lavaan_out <- c(lavaan_out, gsub("\n", "", cmd, fixed = TRUE))
-       # drop any newlines (otherwise done by lav_mplus_cmd_constraints)
+       # drop any newlines (otherwise done by lav_mplus_cmd_con)
     } else if (grepl("^\\s*$", cmd, perl = TRUE)) {
       # do nothing, just a space or blank line
     } else {
@@ -769,7 +769,7 @@ lav_mplus_syntax_model <- function(syntax) {
       cmd <- lav_mplus_cmd_fix_start(cmd)
 
       # parse any constraints here (avoid weird logic below)
-      cmd <- lav_mplus_cmd_constraints(cmd)
+      cmd <- lav_mplus_cmd_con(cmd)
 
       if ((op <- regexpr("\\s+(by|on|with|pwith)\\s+", cmd, ignore.case = TRUE,
        perl = TRUE))[1L] > 0) { # regressions, factors, covariances
@@ -846,7 +846,7 @@ lav_mplus_syntax_model <- function(syntax) {
         if (operator == "[") {
           # Tricky syntax shift (and corresponding kludge). For means, need to
           #    put constraint on RHS as pre-multiplier of 1 (e.g., x1 ~ 5*1).
-          # But lav_mplus_cmd_constraints returns constraints
+          # But lav_mplus_cmd_con returns constraints
           #     multiplied by parameters
           cmd <- sapply(means_scales_split, function(v) {
             # shift pre-multiplier
@@ -1048,7 +1048,7 @@ lav_mplus_lavaan <- function(inpfile, run = TRUE) {
   # handle model constraint
   if ("model.constraint" %in% names(sections)) {
     mplus_inp$model.constraint <-
-      lav_mplus_syntax_constraints(sections$model.constraint)
+      lav_mplus_syntax_con(sections$model.constraint)
     mplus_inp$model <-
       paste(mplus_inp$model, mplus_inp$model.constraint, sep = "\n")
   }

--- a/R/lav_muthen1984.R
+++ b/R/lav_muthen1984.R
@@ -56,7 +56,7 @@ muthen1984 <- function(data_1 = NULL,
     cat("\n")
   }
 
-  step1 <- lav_samplestats_step1(
+  step1 <- lav_samp_step1(
     y = data_1, wt = wt, ov_names = ov_names,
     ov_types = ov_types, ov_levels = ov_levels, ov_names_x = ov_names_x,
     exo = exo, scores_flag = wls_w, allow_empty_cell = allow_empty_cell,
@@ -100,7 +100,7 @@ muthen1984 <- function(data_1 = NULL,
   # stage two -- correlations
 
   if (lav_verbose()) cat("\n\nSTEP 2: covariances/correlations:\n")
-  cor_1 <- lav_samplestats_step2(
+  cor_1 <- lav_samp_step2(
     uni = fit, wt = wt, ov_names = ov_names,
     zero_add = zero_add,
     zero_keep_margins = zero_keep_margins,
@@ -134,7 +134,7 @@ muthen1984 <- function(data_1 = NULL,
   # stage three -- WLS.W
   sc_cor <- matrix(0, n, pstar)
   pstar_1 <- matrix(0, nvar, nvar)
-  pstar_1[lav_matrix_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
+  pstar_1[lav_mat_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
 
   a11_size <- NCOL(sc_th) + NCOL(sc_sl) + NCOL(sc_var)
 
@@ -167,7 +167,7 @@ muthen1984 <- function(data_1 = NULL,
         var_idx_j <- NCOL(sc_th) + match(j, num_idx)
       }
       if (ov_types[i] == "numeric" && ov_types[j] == "numeric") {
-        sc_cor_uni <- lav_bvreg_cor_scores(
+        sc_cor_uni <- lav_bvreg_cor_sc(
           rho = cor_1[i, j],
           fit_y1 = fit[[i]],
           fit_y2 = fit[[j]],
@@ -183,36 +183,36 @@ muthen1984 <- function(data_1 = NULL,
 
         # TH
         a21[pstar_idx, th_idx_i] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_mu_y1
           )
         a21[pstar_idx, th_idx_j] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_mu_y2
           )
         # SL
         if (nexo > 0L) {
           a21[pstar_idx, sl_idx_i] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y1
             )
           a21[pstar_idx, sl_idx_j] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y2
             )
         }
         # VAR
         a21[pstar_idx, var_idx_i] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_var_y1
           )
         a21[pstar_idx, var_idx_j] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_var_y2
           )
@@ -223,7 +223,7 @@ muthen1984 <- function(data_1 = NULL,
           (sqrt(var_1[i]) * cor_1[i, j]) / (2 * sqrt(var_1[j]))
         h22[pstar_idx, pstar_idx] <- sqrt(var_1[i]) * sqrt(var_1[j])
       } else if (ov_types[i] == "numeric" && ov_types[j] == "ordered") {
-        sc_cor_uni <- lav_bvmix_cor_scores(
+        sc_cor_uni <- lav_bvmix_cor_sc(
           rho = cor_1[i, j],
           fit_y1 = fit[[i]],
           fit_y2 = fit[[j]],
@@ -238,31 +238,31 @@ muthen1984 <- function(data_1 = NULL,
 
         # TH
         a21[pstar_idx, th_idx_i] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_mu_y1
           )
         a21[pstar_idx, th_idx_j] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_th_y2
           )
         # SL
         if (nexo > 0L) {
           a21[pstar_idx, sl_idx_i] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y1
             )
           a21[pstar_idx, sl_idx_j] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y2
             )
         }
         # VAR
         a21[pstar_idx, var_idx_i] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_var_y1
           )
@@ -270,7 +270,7 @@ muthen1984 <- function(data_1 = NULL,
         h21[pstar_idx, var_idx_i] <- cor_1[i, j] / (2 * sqrt(var_1[i]))
         h22[pstar_idx, pstar_idx] <- sqrt(var_1[i])
       } else if (ov_types[j] == "numeric" && ov_types[i] == "ordered") {
-        sc_cor_uni <- lav_bvmix_cor_scores(
+        sc_cor_uni <- lav_bvmix_cor_sc(
           rho = cor_1[i, j],
           fit_y1 = fit[[j]],
           fit_y2 = fit[[i]],
@@ -285,31 +285,31 @@ muthen1984 <- function(data_1 = NULL,
 
         # TH
         a21[pstar_idx, th_idx_j] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_mu_y1
           )
         a21[pstar_idx, th_idx_i] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_th_y2
           )
         # SL
         if (nexo > 0L) {
           a21[pstar_idx, sl_idx_j] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y1
             )
           a21[pstar_idx, sl_idx_i] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y2
             )
         }
         # VAR
         a21[pstar_idx, var_idx_j] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_var_y1
           )
@@ -318,7 +318,7 @@ muthen1984 <- function(data_1 = NULL,
         h22[pstar_idx, pstar_idx] <- sqrt(var_1[j])
       } else if (ov_types[i] == "ordered" && ov_types[j] == "ordered") {
         # polychoric correlation
-        sc_cor_uni <- lav_bvord_cor_scores(
+        sc_cor_uni <- lav_bvord_cor_sc(
           rho = cor_1[i, j],
           fit_y1 = fit[[i]],
           fit_y2 = fit[[j]],
@@ -333,24 +333,24 @@ muthen1984 <- function(data_1 = NULL,
 
         # TH
         a21[pstar_idx, th_idx_i] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_th_y1
           )
         a21[pstar_idx, th_idx_j] <-
-          lav_matrix_crossprod(
+          lav_mat_crossprod(
             sc_cor[, pstar_idx],
             sc_cor_uni$dx_th_y2
           )
         # SL
         if (nexo > 0L) {
           a21[pstar_idx, sl_idx_i] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y1
             )
           a21[pstar_idx, sl_idx_j] <-
-            lav_matrix_crossprod(
+            lav_mat_crossprod(
               sc_cor[, pstar_idx],
               sc_cor_uni$dx_sl_y2
             )
@@ -370,14 +370,14 @@ muthen1984 <- function(data_1 = NULL,
   # stage three
 
   sc <- cbind(sc_th, sc_sl, sc_var, sc_cor)
-  inner <- lav_matrix_crossprod(sc)
+  inner <- lav_mat_crossprod(sc)
 
   # A11
   # new approach (2 June 2012): A11 is just a 'sparse' version of
   # (the left upper block of) INNER
   a11 <- matrix(0, a11_size, a11_size)
   if (!is.null(wt)) {
-    inner2 <- lav_matrix_crossprod(sc / wt, sc)
+    inner2 <- lav_mat_crossprod(sc / wt, sc)
   } else {
     inner2 <- inner
   }

--- a/R/lav_mvnorm.R
+++ b/R/lav_mvnorm.R
@@ -27,7 +27,7 @@
 #                 (only for catml; not for correlation = TRUE!)
 
 # 0. densities
-lav_mvnorm_dmvnorm <- function(y = NULL,
+lav_mvn_dmvnorm <- function(y = NULL,
                                wt = NULL,
                                mu = NULL,
                                sigma_1 = NULL,
@@ -39,9 +39,9 @@ lav_mvnorm_dmvnorm <- function(y = NULL,
                                log = TRUE) {
   if (is.matrix(y)) {
     if (is.null(mu) && is.null(sigma_1) && is.null(sigma_inv)) {
-      out <- lav_mvnorm_loglik_data_z(y = y, casewise = TRUE)
+      out <- lav_mvn_loglik_data_z(y = y, casewise = TRUE)
     } else {
-      out <- lav_mvnorm_loglik_data(
+      out <- lav_mvn_loglik_data(
         y = y, mu = mu, sigma_1 = sigma_1,
         casewise = TRUE,
         sinv_method = sinv_method
@@ -58,7 +58,7 @@ lav_mvnorm_dmvnorm <- function(y = NULL,
       out <- -(p * log_2pi + dist_1) / 2
     } else {
       if (is.null(sigma_inv)) {
-        sigma_inv <- lav_matrix_symmetric_inverse(
+        sigma_inv <- lav_mat_sym_inverse(
           s = sigma_1,
           logdet = TRUE, sinv_method = sinv_method
         )
@@ -103,7 +103,7 @@ lav_mvnorm_dmvnorm <- function(y = NULL,
       sigma_x <- sigma_1[x_idx, x_idx, drop = FALSE]
     }
 
-    logl_x <- lav_mvnorm_dmvnorm(
+    logl_x <- lav_mvn_dmvnorm(
       y = x, wt = wt, mu = mu_x, sigma_1 = sigma_x,
       sigma_inv = NULL,
       sinv_method = sinv_method,
@@ -125,7 +125,7 @@ lav_mvnorm_dmvnorm <- function(y = NULL,
 
 # 1a: input is raw data
 # (note casewise = TRUE same as: dmvnorm(Y, mean, sigma, log = TRUE))
-lav_mvnorm_loglik_data <- function(y = NULL,
+lav_mvn_loglik_data <- function(y = NULL,
                                    wt = NULL,
                                    mu = NULL,
                                    sigma_1 = NULL,
@@ -134,7 +134,7 @@ lav_mvnorm_loglik_data <- function(y = NULL,
                                    x_cov = NULL,
                                    casewise = FALSE,
                                    sinv_method = "eigen") {
-  # Y must be a matrix (use lav_mvnorm_dmvnorm() for non-matrix input)
+  # Y must be a matrix (use lav_mvn_dmvnorm() for non-matrix input)
   stopifnot(is.matrix(y))
 
   if (!is.null(wt)) {
@@ -157,7 +157,7 @@ lav_mvnorm_loglik_data <- function(y = NULL,
       dist_1 <- rowSums((yc %*% ic_s)^2)
       logdet <- -2 * sum(log(diag(ic_s)))
     } else {
-      sigma_inv <- lav_matrix_symmetric_inverse(
+      sigma_inv <- lav_mat_sym_inverse(
         s = sigma_1, logdet = TRUE,
         sinv_method = sinv_method
       )
@@ -175,7 +175,7 @@ lav_mvnorm_loglik_data <- function(y = NULL,
     }
   } else {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = TRUE,
       sinv_method = sinv_method
     )
@@ -185,9 +185,9 @@ lav_mvnorm_loglik_data <- function(y = NULL,
       sample_cov <- out$cov
     } else {
       sample_mean <- base::.colMeans(y, m = n, n = p)
-      sample_cov <- lav_matrix_cov(y)
+      sample_cov <- lav_mat_cov(y)
     }
-    loglik <- lav_mvnorm_loglik_samplestats(
+    loglik <- lav_mvn_loglik_samp(
       sample_mean = sample_mean,
       sample_cov = sample_cov,
       sample_nobs = n,
@@ -206,7 +206,7 @@ lav_mvnorm_loglik_data <- function(y = NULL,
     if (is.null(x_cov)) {
       sigma_x <- sigma_1[x_idx, x_idx, drop = FALSE]
     }
-    loglik_x <- lav_mvnorm_loglik_data(
+    loglik_x <- lav_mvn_loglik_data(
       y = y[, x_idx, drop = FALSE],
       wt = wt, mu = mu_x, sigma_1 = sigma_x,
       x_idx = integer(0L), casewise = casewise,
@@ -222,7 +222,7 @@ lav_mvnorm_loglik_data <- function(y = NULL,
 
 
 # 1b: input are sample statistics (mean, cov, N) only
-lav_mvnorm_loglik_samplestats <- function(sample_mean = NULL,
+lav_mvn_loglik_samp <- function(sample_mean = NULL,
                                           sample_cov = NULL,
                                           sample_nobs = NULL,
                                           mu = NULL,
@@ -239,7 +239,7 @@ lav_mvnorm_loglik_samplestats <- function(sample_mean = NULL,
   log_2pi <- log(2 * pi)
 
   if (is.null(sigma_inv)) {
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = TRUE,
       sinv_method = sinv_method
     )
@@ -274,7 +274,7 @@ lav_mvnorm_loglik_samplestats <- function(sample_mean = NULL,
     sample_mean_x <- sample_mean[x_idx]
     sample_cov_x <- sample_cov[x_idx, x_idx, drop = FALSE]
     loglik_x <-
-      lav_mvnorm_loglik_samplestats(
+      lav_mvn_loglik_samp(
         sample_mean = sample_mean_x,
         sample_cov = sample_cov_x,
         sample_nobs = sample_nobs,
@@ -290,7 +290,7 @@ lav_mvnorm_loglik_samplestats <- function(sample_mean = NULL,
 }
 
 # 1c special case: Mu = 0, Sigma = I
-lav_mvnorm_loglik_data_z <- function(y = NULL,
+lav_mvn_loglik_data_z <- function(y = NULL,
                                      wt = NULL,
                                      casewise = FALSE) {
   if (!is.null(wt)) {
@@ -315,7 +315,7 @@ lav_mvnorm_loglik_data_z <- function(y = NULL,
       sample_cov <- out$cov
     } else {
       sample_mean <- base::.colMeans(y, m = n, n = p)
-      sample_cov <- lav_matrix_cov(y)
+      sample_cov <- lav_mat_cov(y)
     }
 
     dist1 <- sum(diag(sample_cov))
@@ -334,7 +334,7 @@ lav_mvnorm_loglik_data_z <- function(y = NULL,
 # 2. Derivatives
 
 # 2a: derivative logl with respect to mu
-lav_mvnorm_dlogl_dmu <- function(y = NULL,
+lav_mvn_dlogl_dmu <- function(y = NULL,
                                  wt = NULL,
                                  mu = NULL,
                                  sigma_1 = NULL,
@@ -345,7 +345,7 @@ lav_mvnorm_dlogl_dmu <- function(y = NULL,
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -371,7 +371,7 @@ lav_mvnorm_dlogl_dmu <- function(y = NULL,
 }
 
 # 2b: derivative logl with respect to Sigma (full matrix, ignoring symmetry)
-lav_mvnorm_dlogl_dsigma <- function(y = NULL,
+lav_mvn_dlogl_dsigma <- function(y = NULL,
                                     wt = NULL,
                                     mu = NULL,
                                     sigma_1 = NULL,
@@ -388,7 +388,7 @@ lav_mvnorm_dlogl_dsigma <- function(y = NULL,
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -404,7 +404,7 @@ lav_mvnorm_dlogl_dsigma <- function(y = NULL,
     # subtract 'Mu' from Y
     # Yc <- t( t(Y) - Mu )
     # W.tilde <- crossprod(Yc) / N
-    w_tilde <- lav_matrix_cov(y, Mu = mu)
+    w_tilde <- lav_mat_cov(y, mu = mu)
   }
 
   # derivative
@@ -419,7 +419,7 @@ lav_mvnorm_dlogl_dsigma <- function(y = NULL,
 }
 
 # 2c: derivative logl with respect to vech(Sigma)
-lav_mvnorm_dlogl_dvechsigma <- function(y = NULL,
+lav_mvn_dlogl_dvechsigma <- function(y = NULL,
                                         wt = NULL,
                                         mu = NULL,
                                         sigma_1 = NULL,
@@ -436,7 +436,7 @@ lav_mvnorm_dlogl_dvechsigma <- function(y = NULL,
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -449,7 +449,7 @@ lav_mvnorm_dlogl_dvechsigma <- function(y = NULL,
     my <- out$center
     w_tilde <- sy + tcrossprod(my - mu)
   } else {
-    w_tilde <- lav_matrix_cov(y, Mu = mu)
+    w_tilde <- lav_mat_cov(y, mu = mu)
   }
 
   # derivative (avoiding kronecker product)
@@ -461,15 +461,15 @@ lav_mvnorm_dlogl_dvechsigma <- function(y = NULL,
   }
 
   # vech
-  dvech_sigma <- as.numeric(lav_matrix_duplication_pre(
-      as.matrix(lav_matrix_vec(d_sigma))
+  dvech_sigma <- as.numeric(lav_mat_dup_pre(
+      as.matrix(lav_mat_vec(d_sigma))
   ))
 
   dvech_sigma
 }
 
 # 2d: : derivative logl with respect to Mu and vech(Sigma)
-lav_mvnorm_dlogl_dmu_dvechsigma <- function(m_y = NULL,   # nolint
+lav_mvn_dlogl_dmu_dvechsigma <- function(m_y = NULL,
                                             wt = NULL,
                                             m_mu = NULL,
                                             m_sigma = NULL,
@@ -486,7 +486,7 @@ lav_mvnorm_dlogl_dmu_dvechsigma <- function(m_y = NULL,   # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = m_sigma, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -503,7 +503,7 @@ lav_mvnorm_dlogl_dmu_dvechsigma <- function(m_y = NULL,   # nolint
     m_w_tilde <- m_sy + tcrossprod(m_my - m_mu)
     dmu <- as.numeric(sigma_inv %*% colSums(m_yc * wt))
   } else {
-    m_w_tilde <- lav_matrix_cov(m_y, Mu = m_mu)
+    m_w_tilde <- lav_mat_cov(m_y, mu = m_mu)
     dmu <- as.numeric(sigma_inv %*% colSums(m_yc))
   }
 
@@ -517,8 +517,8 @@ lav_mvnorm_dlogl_dmu_dvechsigma <- function(m_y = NULL,   # nolint
   }
 
   # vech
-  dvech_sigma <- as.numeric(lav_matrix_duplication_pre(
-    as.matrix(lav_matrix_vec(m_dsigma))
+  dvech_sigma <- as.numeric(lav_mat_dup_pre(
+    as.matrix(lav_mat_vec(m_dsigma))
   ))
 
   c(dmu, dvech_sigma)
@@ -527,7 +527,7 @@ lav_mvnorm_dlogl_dmu_dvechsigma <- function(m_y = NULL,   # nolint
 # 3. Casewise scores
 
 # 3a: casewise scores with respect to mu
-lav_mvnorm_scores_mu <- function(y = NULL,
+lav_mvn_sc_mu <- function(y = NULL,
                                  wt = NULL,
                                  mu = NULL,
                                  x_idx = integer(0L),
@@ -538,7 +538,7 @@ lav_mvnorm_scores_mu <- function(y = NULL,
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -564,7 +564,7 @@ lav_mvnorm_scores_mu <- function(y = NULL,
 }
 
 # 3b: casewise scores with respect to vech(Sigma)
-lav_mvnorm_scores_vech_sigma <- function(y = NULL,
+lav_mvn_sc_sigma <- function(y = NULL,
                                          wt = NULL,
                                          mu = NULL,
                                          sigma_1 = NULL,
@@ -576,14 +576,14 @@ lav_mvnorm_scores_vech_sigma <- function(y = NULL,
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # vech(Sigma.inv)
-  isigma <- lav_matrix_vech(sigma_inv)
+  isigma <- lav_mat_vech(sigma_inv)
 
   # subtract Mu
   yc <- t(t(y) - mu)
@@ -592,19 +592,19 @@ lav_mvnorm_scores_vech_sigma <- function(y = NULL,
   yc <- yc %*% sigma_inv
 
   # tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(p)
-  idx2 <- lav_matrix_vech_row_idx(p)
+  idx1 <- lav_mat_vech_col_idx(p)
+  idx2 <- lav_mat_vech_row_idx(p)
   z <- yc[, idx1] * yc[, idx2]
 
   # subtract isigma from each row
   sc <- t(t(z) - isigma)
 
   # adjust for vech
-  sc[, lav_matrix_diagh_idx(p)] <- sc[, lav_matrix_diagh_idx(p)] / 2
+  sc[, lav_mat_diagh_idx(p)] <- sc[, lav_mat_diagh_idx(p)] / 2
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    sc[, lav_matrix_vech_which_idx(n = p, idx = x_idx)] <- 0
+    sc[, lav_mat_vech_which_idx(n = p, idx = x_idx)] <- 0
   }
 
   # weights
@@ -616,7 +616,7 @@ lav_mvnorm_scores_vech_sigma <- function(y = NULL,
 }
 
 # 3c: casewise scores with respect to mu + vech(Sigma)
-lav_mvnorm_scores_mu_vech_sigma <- function(y = NULL, # nolint
+lav_mvn_sc_mu_sigma <- function(y = NULL,
                                             wt = NULL,
                                             mu = NULL,
                                             sigma_1 = NULL,
@@ -628,14 +628,14 @@ lav_mvnorm_scores_mu_vech_sigma <- function(y = NULL, # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # vech(Sigma.inv)
-  isigma <- lav_matrix_vech(sigma_inv)
+  isigma <- lav_mat_vech(sigma_inv)
 
   # subtract Mu
   yc <- t(t(y) - mu)
@@ -644,20 +644,20 @@ lav_mvnorm_scores_mu_vech_sigma <- function(y = NULL, # nolint
   yc <- yc %*% sigma_inv
 
   # tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(p)
-  idx2 <- lav_matrix_vech_row_idx(p)
+  idx1 <- lav_mat_vech_col_idx(p)
+  idx2 <- lav_mat_vech_row_idx(p)
   z <- yc[, idx1] * yc[, idx2]
 
   # subtract isigma from each row
   sc <- t(t(z) - isigma)
 
-  # adjust for lav_matrix_duplication_pre (not vech!)
-  sc[, lav_matrix_diagh_idx(p)] <- sc[, lav_matrix_diagh_idx(p)] / 2
+  # adjust for lav_mat_dup_pre (not vech!)
+  sc[, lav_mat_diagh_idx(p)] <- sc[, lav_mat_diagh_idx(p)] / 2
 
   # fixed.x?
   if (length(x_idx) > 0L) {
     yc[, x_idx] <- 0
-    sc[, lav_matrix_vech_which_idx(n = p, idx = x_idx)] <- 0
+    sc[, lav_mat_vech_which_idx(n = p, idx = x_idx)] <- 0
   }
 
   out <- cbind(yc, sc)
@@ -674,7 +674,7 @@ lav_mvnorm_scores_mu_vech_sigma <- function(y = NULL, # nolint
 # 4. hessian of logl
 
 # 4a: hessian logl Mu and vech(Sigma) from raw data
-lav_mvnorm_logl_hessian_data <- function(y = NULL,
+lav_mvn_logl_hessian_data <- function(y = NULL,
                                          wt = NULL,
                                          mu = NULL,
                                          sigma_1 = NULL,
@@ -689,7 +689,7 @@ lav_mvnorm_logl_hessian_data <- function(y = NULL,
   }
 
   # observed information
-  observed <- lav_mvnorm_information_observed_data(
+  observed <- lav_mvn_info_observed_data(
     y = y, wt = wt, mu = mu,
     sigma_1 = sigma_1, x_idx = x_idx,
     sinv_method = sinv_method, sigma_inv = sigma_inv,
@@ -713,7 +713,7 @@ lav_mvnorm_logl_hessian_samplestats <- # nolint
     n <- sample_nobs
 
     # observed information
-    observed <- lav_mvnorm_information_observed_samplestats(
+    observed <- lav_mvn_info_observed_samp(
       sample_mean = sample_mean, sample_cov = sample_cov,
       mu = mu, sigma_1 = sigma_1,
       x_idx = x_idx, sinv_method = sinv_method, sigma_inv = sigma_inv,
@@ -726,7 +726,7 @@ lav_mvnorm_logl_hessian_samplestats <- # nolint
 # 5) Information h0
 
 # 5a: unit expected information h0 Mu and vech(Sigma)
-lav_mvnorm_information_expected <- function(y = NULL, # unused! # nolint
+lav_mvn_info_expected <- function(y = NULL, # unused!
                                             wt = NULL, # unused!
                                             mu = NULL, # unused!
                                             sigma_1 = NULL,
@@ -737,7 +737,7 @@ lav_mvnorm_information_expected <- function(y = NULL, # unused! # nolint
                       correlation = FALSE) {
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -752,15 +752,15 @@ lav_mvnorm_information_expected <- function(y = NULL, # unused! # nolint
   #   }
   # } else {
     if (correlation) {
-      i22 <- 0.5 * lav_matrix_duplication_cor_pre_post(sigma_inv %x% sigma_inv)
+      i22 <- 0.5 * lav_mat_dup_cor_pre_post(sigma_inv %x% sigma_inv)
     } else {
-      i22 <- 0.5 * lav_matrix_duplication_pre_post(sigma_inv %x% sigma_inv)
+      i22 <- 0.5 * lav_mat_dup_pre_post(sigma_inv %x% sigma_inv)
     }
   # }
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    pstar_x <- lav_matrix_vech_which_idx(
+    pstar_x <- lav_mat_vech_which_idx(
       n = NCOL(sigma_inv), idx = x_idx
     )
     i22[pstar_x, ] <- 0
@@ -774,7 +774,7 @@ lav_mvnorm_information_expected <- function(y = NULL, # unused! # nolint
       i11[x_idx, ] <- 0
       i11[, x_idx] <- 0
     }
-    out <- lav_matrix_bdiag(i11, i22)
+    out <- lav_mat_bdiag(i11, i22)
   } else {
     out <- i22
   }
@@ -783,7 +783,7 @@ lav_mvnorm_information_expected <- function(y = NULL, # unused! # nolint
 }
 
 # 5b: unit observed information h0
-lav_mvnorm_information_observed_data <- function(y = NULL, # nolint
+lav_mvn_info_observed_data <- function(y = NULL,
                                                  wt = NULL,
                                                  mu = NULL,
                                                  sigma_1 = NULL,
@@ -800,10 +800,10 @@ lav_mvnorm_information_observed_data <- function(y = NULL, # nolint
     n <- NROW(y)
     # sample statistics
     sample_mean <- colMeans(y)
-    sample_cov <- lav_matrix_cov(y)
+    sample_cov <- lav_mat_cov(y)
   }
 
-  lav_mvnorm_information_observed_samplestats(
+  lav_mvn_info_observed_samp(
     sample_mean = sample_mean,
     sample_cov = sample_cov, mu = mu, sigma_1 = sigma_1,
     x_idx = x_idx, sinv_method = sinv_method, sigma_inv = sigma_inv,
@@ -812,7 +812,7 @@ lav_mvnorm_information_observed_data <- function(y = NULL, # nolint
 }
 
 # 5b-bis: observed information h0 from sample statistics
-lav_mvnorm_information_observed_samplestats <- function( # nolint
+lav_mvn_info_observed_samp <- function(
     sample_mean = NULL,
     sample_cov = NULL,
     mu = NULL,
@@ -827,7 +827,7 @@ lav_mvnorm_information_observed_samplestats <- function( # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -837,7 +837,7 @@ lav_mvnorm_information_observed_samplestats <- function( # nolint
 
   if (meanstructure) {
     i11 <- sigma_inv
-    i21 <- lav_matrix_duplication_pre((sigma_inv %*%
+    i21 <- lav_mat_dup_pre((sigma_inv %*%
       (sample_mean - mu)) %x% sigma_inv)
     i12 <- t(i21)
   }
@@ -846,7 +846,7 @@ lav_mvnorm_information_observed_samplestats <- function( # nolint
   # if (lav_use_lavaanC()) {
   #   I22 <- lavaanC::m_kronecker_dup_pre_post(Sigma.inv, AAA, 0.5)
   # } else {
-    i22 <- (1 / 2) * lav_matrix_duplication_pre_post(sigma_inv %x% aaa)
+    i22 <- (1 / 2) * lav_mat_dup_pre_post(sigma_inv %x% aaa)
   # }
 
   if (meanstructure) {
@@ -860,7 +860,7 @@ lav_mvnorm_information_observed_samplestats <- function( # nolint
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    not_x <- lav_matrix_vech_which_idx(
+    not_x <- lav_mat_vech_which_idx(
       n = NCOL(sigma_inv), idx = x_idx,
       add_idx_at_start = meanstructure
     )
@@ -872,7 +872,7 @@ lav_mvnorm_information_observed_samplestats <- function( # nolint
 }
 
 # 5c: unit first-order information h0
-lav_mvnorm_information_firstorder <- function(y = NULL,    # nolint
+lav_mvn_info_firstorder <- function(y = NULL,
                                               wt = NULL,
                                               cluster_idx = NULL,
                                               mu = NULL,
@@ -888,14 +888,14 @@ lav_mvnorm_information_firstorder <- function(y = NULL,    # nolint
   }
 
   if (meanstructure) {
-    sc <- lav_mvnorm_scores_mu_vech_sigma(
+    sc <- lav_mvn_sc_mu_sigma(
       y = y, wt = wt,
       mu = mu, sigma_1 = sigma_1, x_idx = x_idx,
       sinv_method = sinv_method, sigma_inv = sigma_inv
     )
   } else {
     # the caller should use Mu = sample.mean
-    sc <- lav_mvnorm_scores_vech_sigma(
+    sc <- lav_mvn_sc_sigma(
       y = y, wt = wt,
       mu = mu, sigma_1 = sigma_1,
       sinv_method = sinv_method, sigma_inv = sigma_inv
@@ -925,10 +925,10 @@ lav_mvnorm_information_firstorder <- function(y = NULL,    # nolint
 
 # 6a: inverted unit expected information h0 Mu and vech(Sigma)
 #
-#     Note: this is the same as lav_samplestats_gamma_nt()
+#     Note: this is the same as lav_samp_gamma_nt()
 #           but where COV=Sigma and MEAN=Mu
 #
-lav_mvnorm_inverted_information_expected <- function(y = NULL, # unused! # nolint
+lav_mvn_inv_info_expected <- function(y = NULL, # unused!
                                                      wt = NULL, # unused!
                                                      mu = NULL, # unused!
                                                      sigma_1 = NULL,
@@ -953,14 +953,14 @@ lav_mvnorm_inverted_information_expected <- function(y = NULL, # unused! # nolin
     #   SS <- lavaanC::m_kronecker_dup_ginv_pre_post(Sigma, multiplicator = 2.0)
     #   RR <- lavaanC::m_kronecker_dup_ginv_pre_post(R, multiplicator = 2.0)
     # } else {
-      ss <- 2 * lav_matrix_duplication_ginv_pre_post(sigma_1 %x% sigma_1)
-      rr <- 2 * lav_matrix_duplication_ginv_pre_post(r %x% r)
+      ss <- 2 * lav_mat_dup_ginv_pre_post(sigma_1 %x% sigma_1)
+      rr <- 2 * lav_mat_dup_ginv_pre_post(r %x% r)
     # }
     i22 <- ss - rr
 
     if (meanstructure) {
       i11 <- ybar_x_aug
-      out <- lav_matrix_bdiag(i11, i22)
+      out <- lav_mat_bdiag(i11, i22)
     } else {
       out <- i22
     }
@@ -969,11 +969,11 @@ lav_mvnorm_inverted_information_expected <- function(y = NULL, # unused! # nolin
     #   I22 <-
     #      lavaanC::m_kronecker_dup_ginv_pre_post(Sigma, multiplicator = 2.0)
     # } else {
-      i22 <- 2 * lav_matrix_duplication_ginv_pre_post(sigma_1 %x% sigma_1)
+      i22 <- 2 * lav_mat_dup_ginv_pre_post(sigma_1 %x% sigma_1)
     # }
     if (meanstructure) {
       i11 <- sigma_1
-      out <- lav_matrix_bdiag(i11, i22)
+      out <- lav_mat_bdiag(i11, i22)
     } else {
       out <- i22
     }

--- a/R/lav_mvnorm_cluster.R
+++ b/R/lav_mvnorm_cluster.R
@@ -16,7 +16,7 @@
 # - mu.w: y within  part
 # - mu.b: y between part
 # - mu.z: level-2 variables only
-lav_mvnorm_cluster_implied22l <- function(lp = NULL,
+lav_mvn_cl_implied22l <- function(lp = NULL,
                                           implied = NULL,
                                           mu_w = NULL,
                                           mu_b = NULL,
@@ -100,7 +100,7 @@ lav_mvnorm_cluster_implied22l <- function(lp = NULL,
   )
 }
 
-lav_mvnorm_cluster_2l2implied <- function(lp,
+lav_mvn_cl_2l2implied <- function(lp,
                                           sigma_w = NULL,
                                           sigma_b = NULL,
                                           sigma_zz = NULL,
@@ -189,7 +189,7 @@ lav_mvnorm_cluster_2l2implied <- function(lp,
 
 # Mu.W, Mu.B, Sigma.W, Sigma.B are the model-implied statistics
 # (not yet reordered)
-lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
+lav_mvn_cl_loglik_samp_2l <- function(ylp = NULL,
                                                      lp = NULL,
                                                      mu_w = NULL,
                                                      sigma_w = NULL,
@@ -199,7 +199,7 @@ lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
                                                      log2pi = FALSE,
                                                      minus_two = TRUE) {
   # map implied to 2l matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp, mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
   )
@@ -230,7 +230,7 @@ lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
   mean_d <- ylp[[2]]$mean.d
 
   # common parts:
-  sigma_w_inv <- lav_matrix_symmetric_inverse(
+  sigma_w_inv <- lav_mat_sym_inverse(
     s = sigma_w_1,
     logdet = TRUE, sinv_method = sinv_method
   )
@@ -238,7 +238,7 @@ lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
   attr(sigma_w_inv, "logdet") <- NULL
 
   if (length(between_idx) > 0L) {
-    sigma_zz_inv <- lav_matrix_symmetric_inverse(
+    sigma_zz_inv <- lav_mat_sym_inverse(
       s = sigma_zz,
       logdet = TRUE, sinv_method = sinv_method
     )
@@ -274,7 +274,7 @@ lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
 
     # construct sigma.j
     sigma_j <- (nj * sigma_b_z) + sigma_w_1
-    sigma_j_inv <- lav_matrix_symmetric_inverse(
+    sigma_j_inv <- lav_mat_sym_inverse(
       s = sigma_j,
       logdet = TRUE, sinv_method = sinv_method
     )
@@ -286,8 +286,8 @@ lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
       # stop, and return NA right away
       # return(as.numeric(NA))
       # FORCE?
-      # sigma.j <- lav_matrix_symmetric_force_pd(sigma.j)
-      # sigma.j.inv <- lav_matrix_symmetric_inverse(s = sigma.j,
+      # sigma.j <- lav_mat_sym_force_pd(sigma.j)
+      # sigma.j.inv <- lav_mat_sym_inverse(s = sigma.j,
       #           logdet = TRUE, sinv_method = Sinv.method)
       # sigma.j.logdet <- attr(sigma.j.inv, "logdet")
       # attr(sigma.j.inv, "logdet") <- NULL
@@ -350,7 +350,7 @@ lav_mvnorm_cluster_loglik_samplestats_2l <- function(ylp = NULL, # nolint
 
 
 # first derivative -2*logl wrt Mu.W, Mu.B, Sigma.W, Sigma.B
-lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
+lav_mvn_cl_dlogl_2l_samp <- function(ylp = NULL,
                                                     lp = NULL,
                                                     mu_w = NULL,
                                                     sigma_w = NULL,
@@ -359,7 +359,7 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
                                                     return_list = FALSE,
                                                     sinv_method = "eigen") {
   # map implied to 2l matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp, mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
   )
@@ -391,25 +391,25 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
   mean_d <- ylp[[2]]$mean.d
 
   # common parts:
-  sigma_w_inv <- lav_matrix_symmetric_inverse(
+  sigma_w_inv <- lav_mat_sym_inverse(
     s = sigma_w_1,
     logdet = FALSE, sinv_method = sinv_method
   )
 
   # both level-1 and level-2
   g_muy <- matrix(0, ncluster_sizes, length(mu_y))
-  g_sigma_w_1 <- matrix(0, ncluster_sizes, length(lav_matrix_vech(sigma_w_1)))
-  g_sigma_b_1 <- matrix(0, ncluster_sizes, length(lav_matrix_vech(sigma_b_1)))
+  g_sigma_w_1 <- matrix(0, ncluster_sizes, length(lav_mat_vech(sigma_w_1)))
+  g_sigma_b_1 <- matrix(0, ncluster_sizes, length(lav_mat_vech(sigma_b_1)))
 
   if (length(between_idx) > 0L) {
     g_muz <- matrix(0, ncluster_sizes, length(mu_z))
     g_sigma_zz_1 <- matrix(
       0, ncluster_sizes,
-      length(lav_matrix_vech(sigma_zz))
+      length(lav_mat_vech(sigma_zz))
     )
-    g_sigma_yz_1 <- matrix(0, ncluster_sizes, length(lav_matrix_vec(sigma_yz)))
+    g_sigma_yz_1 <- matrix(0, ncluster_sizes, length(lav_mat_vec(sigma_yz)))
 
-    sigma_zz_inv <- lav_matrix_symmetric_inverse(
+    sigma_zz_inv <- lav_mat_sym_inverse(
       s = sigma_zz,
       logdet = FALSE, sinv_method = sinv_method
     )
@@ -437,7 +437,7 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b_z) + sigma_w_1
-      sigma_j_inv <- lav_matrix_symmetric_inverse(
+      sigma_j_inv <- lav_mat_sym_inverse(
         s = sigma_j,
         logdet = FALSE, sinv_method = sinv_method
       )
@@ -469,13 +469,13 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
       g_sigma_w <- sigma_j_inv - j_yzj
       tmp <- g_sigma_w * 2
       diag(tmp) <- diag(g_sigma_w)
-      g_sigma_w_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_w_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * (sigma_j_inv - j_yzj)
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZZ
       g_sigma_zz <- (sigma_zz_inv + nj * sigma_zz_inv %*% (
@@ -485,7 +485,7 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
 
       tmp <- g_sigma_zz * 2
       diag(tmp) <- diag(g_sigma_zz)
-      g_sigma_zz_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_zz_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZY
       g_sigma_yz <- 2 * nj * (
@@ -493,19 +493,19 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
           (sigma_yz_zi %*% y2yc_zz - sigma_yz - y2yc_yz)
           + j_yzj %*% sigma_yz) %*% sigma_zz_inv)
 
-      g_sigma_yz_1[clz, ] <- lav_matrix_vec(g_sigma_yz)
+      g_sigma_yz_1[clz, ] <- lav_mat_vec(g_sigma_yz)
     }
 
     # level-1
     d_mu_y <- colSums(g_muy * cluster_size_ns)
-    d_sigma_w1 <- lav_matrix_vech_reverse(colSums(g_sigma_w_1 *
+    d_sigma_w1 <- lav_mat_vech_rev(colSums(g_sigma_w_1 *
       cluster_size_ns))
-    d_sigma_b <- lav_matrix_vech_reverse(colSums(g_sigma_b_1 *
+    d_sigma_b <- lav_mat_vech_rev(colSums(g_sigma_b_1 *
       cluster_size_ns))
 
     # level-2
     d_mu_z <- colSums(g_muz * cluster_size_ns)
-    d_sigma_zz <- lav_matrix_vech_reverse(colSums(g_sigma_zz_1 *
+    d_sigma_zz <- lav_mat_vech_rev(colSums(g_sigma_zz_1 *
       cluster_size_ns))
     d_sigma_yz <- matrix(
       colSums(g_sigma_yz_1 * cluster_size_ns),
@@ -526,7 +526,7 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b_1) + sigma_w_1
-      sigma_j_inv <- lav_matrix_symmetric_inverse(
+      sigma_j_inv <- lav_mat_sym_inverse(
         s = sigma_j,
         logdet = FALSE, sinv_method = sinv_method
       )
@@ -540,20 +540,20 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
       g_sigma_w <- sigma_j_inv - j_yyj
       tmp <- g_sigma_w * 2
       diag(tmp) <- diag(g_sigma_w)
-      g_sigma_w_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_w_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * (sigma_j_inv - j_yyj)
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[clz, ] <- lav_mat_vech(tmp)
     }
 
     # level-1
     d_mu_y <- colSums(g_muy * cluster_size_ns)
-    d_sigma_w1 <- lav_matrix_vech_reverse(colSums(g_sigma_w_1 *
+    d_sigma_w1 <- lav_mat_vech_rev(colSums(g_sigma_w_1 *
       cluster_size_ns))
-    d_sigma_b <- lav_matrix_vech_reverse(colSums(g_sigma_b_1 *
+    d_sigma_b <- lav_mat_vech_rev(colSums(g_sigma_b_1 *
       cluster_size_ns))
     # level-2
     d_mu_z <- numeric(0L)
@@ -571,7 +571,7 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
   d_sigma_w <- d_sigma_w1 + d_sigma_w2
 
   # rearrange
-  dout <- lav_mvnorm_cluster_2l2implied(
+  dout <- lav_mvn_cl_2l2implied(
     lp = lp,
     sigma_w = d_sigma_w, sigma_b = d_sigma_b,
     sigma_yz = d_sigma_yz, sigma_zz = d_sigma_zz,
@@ -582,8 +582,8 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
     out <- dout
   } else {
     out <- c(
-      dout$Mu.W, lav_matrix_vech(dout$Sigma.W),
-      dout$Mu.B, lav_matrix_vech(dout$Sigma.B)
+      dout$Mu.W, lav_mat_vech(dout$Sigma.W),
+      dout$Mu.B, lav_mat_vech(dout$Sigma.B)
     )
   }
 
@@ -591,7 +591,7 @@ lav_mvnorm_cluster_dlogl_2l_samplestats <- function(ylp = NULL, # nolint
 }
 
 # cluster-wise scores -2*logl wrt Mu.W, Mu.B, Sigma.W, Sigma.B
-lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
+lav_mvn_cl_sc_2l <- function(y1 = NULL,
                                          ylp = NULL,
                                          lp = NULL,
                                          mu_w = NULL,
@@ -600,7 +600,7 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
                                          sigma_b = NULL,
                                          sinv_method = "eigen") {
   # map implied to 2l matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp, mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
   )
@@ -638,21 +638,21 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
   y2_cm <- t(t(y2) - mu_b_1)
 
   # common parts:
-  sigma_w_inv <- lav_matrix_symmetric_inverse(
+  sigma_w_inv <- lav_mat_sym_inverse(
     s = sigma_w_1,
     logdet = FALSE, sinv_method = sinv_method
   )
 
   # both level-1 and level-2
   g_muy <- matrix(0, nclusters, length(mu_y))
-  g_sigma_w_1 <- matrix(0, nclusters, length(lav_matrix_vech(sigma_w_1)))
-  g_sigma_b_1 <- matrix(0, nclusters, length(lav_matrix_vech(sigma_b_1)))
+  g_sigma_w_1 <- matrix(0, nclusters, length(lav_mat_vech(sigma_w_1)))
+  g_sigma_b_1 <- matrix(0, nclusters, length(lav_mat_vech(sigma_b_1)))
   g_muz <- matrix(0, nclusters, length(mu_z))
-  g_sigma_zz_1 <- matrix(0, nclusters, length(lav_matrix_vech(sigma_zz)))
-  g_sigma_yz_1 <- matrix(0, nclusters, length(lav_matrix_vec(sigma_yz)))
+  g_sigma_zz_1 <- matrix(0, nclusters, length(lav_mat_vech(sigma_zz)))
+  g_sigma_yz_1 <- matrix(0, nclusters, length(lav_mat_vec(sigma_yz)))
 
   if (length(between_idx) > 0L) {
-    sigma_zz_inv <- lav_matrix_symmetric_inverse(
+    sigma_zz_inv <- lav_mat_sym_inverse(
       s = sigma_zz,
       logdet = FALSE, sinv_method = sinv_method
     )
@@ -687,7 +687,7 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b_z) + sigma_w_1
-      sigma_j_inv <- lav_matrix_symmetric_inverse(
+      sigma_j_inv <- lav_mat_sym_inverse(
         s = sigma_j,
         logdet = FALSE, sinv_method = sinv_method
       )
@@ -722,14 +722,14 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
 
       tmp <- g_sigma_w * 2
       diag(tmp) <- diag(g_sigma_w)
-      g_sigma_w_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_w_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * (sigma_j_inv - j_yzj)
 
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[cl, ] <- lav_mat_vech(tmp)
 
 
       # SIGMA.ZZ
@@ -740,7 +740,7 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
 
       tmp <- g_sigma_zz * 2
       diag(tmp) <- diag(g_sigma_zz)
-      g_sigma_zz_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_zz_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZY
       g_sigma_yz <- 2 * nj * (
@@ -748,7 +748,7 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
           (sigma_yz_zi %*% y2yc_zz - sigma_yz - y2yc_yz)
           + j_yzj %*% sigma_yz) %*% sigma_zz_inv)
 
-      g_sigma_yz_1[cl, ] <- lav_matrix_vec(g_sigma_yz)
+      g_sigma_yz_1[cl, ] <- lav_mat_vec(g_sigma_yz)
     }
   # between.idx
   } else { # no level-2 variables
@@ -766,7 +766,7 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b_1) + sigma_w_1
-      sigma_j_inv <- lav_matrix_symmetric_inverse(
+      sigma_j_inv <- lav_mat_sym_inverse(
         s = sigma_j,
         logdet = FALSE, sinv_method = sinv_method
       )
@@ -782,13 +782,13 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
         + sigma_j_inv - j_yyj)
       tmp <- g_sigma_w * 2
       diag(tmp) <- diag(g_sigma_w)
-      g_sigma_w_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_w_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * (sigma_j_inv - j_yyj)
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[cl, ] <- lav_mat_vech(tmp)
     }
   }
 
@@ -816,41 +816,41 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
   # Sigma.B
   if (length(between_idx) > 0L) {
     p_tilde_star <- p_tilde * (p_tilde + 1) / 2
-    b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
+    b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
 
     sigma_b_tilde <- matrix(0, nclusters, p_tilde_star)
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_b_1
 
-    col_idx <- lav_matrix_vec(b_tilde[ov_idx[[1]], between_idx,
+    col_idx <- lav_mat_vec(b_tilde[ov_idx[[1]], between_idx,
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_yz_1
 
-    col_idx <- lav_matrix_vech(b_tilde[between_idx, between_idx,
+    col_idx <- lav_mat_vech(b_tilde[between_idx, between_idx,
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_zz_1
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
       drop = FALSE
     ])
     sigma_b <- sigma_b_tilde[, col_idx, drop = FALSE]
   } else {
     p_tilde_star <- p_tilde * (p_tilde + 1) / 2
-    b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
+    b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
 
     sigma_b_tilde <- matrix(0, nclusters, p_tilde_star)
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_b_1
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
       drop = FALSE
     ])
     sigma_b <- sigma_b_tilde[, col_idx, drop = FALSE]
@@ -864,7 +864,7 @@ lav_mvnorm_cluster_scores_2l <- function(y1 = NULL,
 
 
 # first-order information: outer crossprod of scores per cluster
-lav_mvnorm_cluster_information_firstorder <- function(y1 = NULL,  # nolint
+lav_mvn_cl_info_firstorder <- function(y1 = NULL,
                                                       ylp = NULL,
                                                       lp = NULL,
                                                       mu_w = NULL,
@@ -876,7 +876,7 @@ lav_mvnorm_cluster_information_firstorder <- function(y1 = NULL,  # nolint
                                                       sinv_method = "eigen") {
   # n <- NROW(y1)
 
-  scores <- lav_mvnorm_cluster_scores_2l(
+  scores <- lav_mvn_cl_sc_2l(
     y1 = y1,
     ylp = ylp,
     lp = lp,
@@ -906,7 +906,7 @@ lav_mvnorm_cluster_information_firstorder <- function(y1 = NULL,  # nolint
     if (length(x_idx_w) > 0L) {
       xw_idx <- c(
         x_idx_w,
-        nw + lav_matrix_vech_which_idx(n = nw, idx = x_idx_w)
+        nw + lav_mat_vech_which_idx(n = nw, idx = x_idx_w)
       )
     } else {
       xw_idx <- integer(0L)
@@ -915,7 +915,7 @@ lav_mvnorm_cluster_information_firstorder <- function(y1 = NULL,  # nolint
     if (length(x_idx_b) > 0L) {
       xb_idx <- c(
         x_idx_b,
-        nb + lav_matrix_vech_which_idx(n = nb, idx = x_idx_b)
+        nb + lav_mat_vech_which_idx(n = nb, idx = x_idx_b)
       )
     } else {
       xb_idx <- integer(0L)
@@ -933,7 +933,7 @@ lav_mvnorm_cluster_information_firstorder <- function(y1 = NULL,  # nolint
 # expected information 'h1' model
 # order: mu.w within, vech(sigma.w) within, mu.b between, vech(sigma.b) between
 # mu.w rows/cols that are splitted within/between are forced to zero
-lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
+lav_mvn_cl_info_expected <- function(lp = NULL,
                                                     mu_w = NULL,
                                                     sigma_w = NULL,
                                                     mu_b = NULL,
@@ -941,7 +941,7 @@ lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
                                                     x_idx = integer(0L),
                                                     sinv_method = "eigen") {
   # translate to internal matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp,
     mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
@@ -960,9 +960,9 @@ lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
   p_tilde <- length(unique(c(ov_idx[[1]], ov_idx[[2]])))
   p_tilde_star <- p_tilde * (p_tilde + 1) / 2
   npar <- p_tilde + p_tilde_star
-  b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
-  w_idx <- lav_matrix_vech(b_tilde[ov_idx[[1]], ov_idx[[1]], drop = FALSE])
-  b_idx <- lav_matrix_vech(b_tilde[ov_idx[[2]], ov_idx[[2]], drop = FALSE])
+  b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
+  w_idx <- lav_mat_vech(b_tilde[ov_idx[[1]], ov_idx[[1]], drop = FALSE])
+  b_idx <- lav_mat_vech(b_tilde[ov_idx[[2]], ov_idx[[2]], drop = FALSE])
 
   delta_w_tilde <- matrix(0, npar, npar)
   delta_b_tilde <- matrix(0, npar, npar)
@@ -1015,15 +1015,15 @@ lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
     #     lavaanC::m_kronecker_dup_pre_post(omega.j.inv, multiplicator = 0.5)
     # } else {
       i22_j <- 0.5 *
-        lav_matrix_duplication_pre_post(omega_j_inv %x% omega_j_inv)
+        lav_mat_dup_pre_post(omega_j_inv %x% omega_j_inv)
     # }
-    i_j <- lav_matrix_bdiag(i11_j, i22_j)
+    i_j <- lav_mat_bdiag(i11_j, i22_j)
     info_j <- t(delta_j) %*% i_j %*% delta_j
 
     information_j <- information_j + n_s[clz] * info_j
   }
 
-  sigma_w_inv <- lav_matrix_symmetric_inverse(
+  sigma_w_inv <- lav_mat_sym_inverse(
     s = sigma_w, logdet = FALSE,
     sinv_method = sinv_method
   )
@@ -1037,9 +1037,9 @@ lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
   #                                                    multiplicator = 0.5)
   # } else {
     i22_w <- 0.5 *
-      lav_matrix_duplication_pre_post(sigma_w_inv_tilde %x% sigma_w_inv_tilde)
+      lav_mat_dup_pre_post(sigma_w_inv_tilde %x% sigma_w_inv_tilde)
   # }
-  i_w <- lav_matrix_bdiag(i11_w, i22_w)
+  i_w <- lav_mat_bdiag(i11_w, i22_w)
   information_w <- (nobs - nclusters) *
     (t(delta_w_tilde) %*% i_w %*% delta_w_tilde)
 
@@ -1054,7 +1054,7 @@ lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
   if (length(x_idx) > 0L) {
     xw_idx <- c(
       x_idx,
-      p_tilde + lav_matrix_vech_which_idx(n = p_tilde, idx = x_idx)
+      p_tilde + lav_mat_vech_which_idx(n = p_tilde, idx = x_idx)
     )
     xb_idx <- npar + xw_idx
     all_idx <- c(xw_idx, xb_idx)
@@ -1078,7 +1078,7 @@ lav_mvnorm_cluster_information_expected <- function(lp = NULL,  # nolint
 
 # expected information -- delta
 # for non-saturated models only
-lav_mvnorm_cluster_information_expected_delta <- function(lp = NULL, # nolint
+lav_mvn_cl_info_expected_delta <- function(lp = NULL,
                                                       delta = NULL,
                                                       mu_w = NULL,
                                                       sigma_w = NULL,
@@ -1086,7 +1086,7 @@ lav_mvnorm_cluster_information_expected_delta <- function(lp = NULL, # nolint
                                                       sigma_b = NULL,
                                                       sinv_method = "eigen") {
   # translate to internal matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp,
     mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
@@ -1128,9 +1128,9 @@ lav_mvnorm_cluster_information_expected_delta <- function(lp = NULL, # nolint
   delta_w_tilde_mu[lp$both.idx[[2]], ] <- 0
 
 
-  b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
-  w_idx <- lav_matrix_vech(b_tilde[ov_idx[[1]], ov_idx[[1]], drop = FALSE])
-  b_idx <- lav_matrix_vech(b_tilde[ov_idx[[2]], ov_idx[[2]], drop = FALSE])
+  b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
+  w_idx <- lav_mat_vech(b_tilde[ov_idx[[1]], ov_idx[[1]], drop = FALSE])
+  b_idx <- lav_mat_vech(b_tilde[ov_idx[[2]], ov_idx[[2]], drop = FALSE])
   delta_w_tilde_sigma[w_idx, ] <- delta_w[-(1:nw), ]
   delta_b_tilde_sigma[b_idx, ] <- delta_b[-(1:nb), ]
 
@@ -1175,16 +1175,16 @@ lav_mvnorm_cluster_information_expected_delta <- function(lp = NULL, # nolint
     #      lavaanC::m_kronecker_dup_pre_post(omega.j.inv, multiplicator = 0.5)
     # } else {
       i22_j <- 0.5 *
-             lav_matrix_duplication_pre_post(omega_j_inv %x% omega_j_inv)
+             lav_mat_dup_pre_post(omega_j_inv %x% omega_j_inv)
     # }
-    i_j <- lav_matrix_bdiag(i11_j, i22_j)
+    i_j <- lav_mat_bdiag(i11_j, i22_j)
     info_j <- t(delta_j) %*% i_j %*% delta_j
 
     information_j <- information_j + n_s[clz] * info_j
   }
 
 
-  sigma_w_inv <- lav_matrix_symmetric_inverse(
+  sigma_w_inv <- lav_mat_sym_inverse(
     s = sigma_w_1, logdet = FALSE,
     sinv_method = sinv_method
   )
@@ -1193,9 +1193,9 @@ lav_mvnorm_cluster_information_expected_delta <- function(lp = NULL, # nolint
   #   I22.w <- lavaanC::m_kronecker_dup_pre_post(Sigma.W.inv,
   #                                                       multiplicator = 0.5)
   # } else {
-    i22_w <- 0.5 * lav_matrix_duplication_pre_post(sigma_w_inv %x% sigma_w_inv)
+    i22_w <- 0.5 * lav_mat_dup_pre_post(sigma_w_inv %x% sigma_w_inv)
   # }
-  i_w <- lav_matrix_bdiag(i11_w, i22_w)
+  i_w <- lav_mat_bdiag(i11_w, i22_w)
 
   # force zero for means both.idx in within part
   # changed in 0.6-5
@@ -1217,7 +1217,7 @@ lav_mvnorm_cluster_information_expected_delta <- function(lp = NULL, # nolint
 # mu.w rows/cols that are splitted within/between are forced to zero
 #
 # numerical approximation (for now)
-lav_mvnorm_cluster_information_observed <- function(lp = NULL,     # nolint
+lav_mvn_cl_info_observed <- function(lp = NULL,
                                                     ylp = NULL,
                                                     mu_w = NULL,
                                                     sigma_w = NULL,
@@ -1247,11 +1247,11 @@ lav_mvnorm_cluster_information_observed <- function(lp = NULL,     # nolint
     mu_w_tilde2[lp$both.idx[[2]]] <- mu_w_tilde[lp$both.idx[[2]]]
     mu_w2 <- mu_w_tilde2[ov_idx[[1]]]
 
-    sigma_w2 <- lav_matrix_vech_reverse(x[nw + 1:nw_star])
+    sigma_w2 <- lav_mat_vech_rev(x[nw + 1:nw_star])
     mu_b2 <- x[nw + nw_star + 1:nb]
-    sigma_b2 <- lav_matrix_vech_reverse(x[nw + nw_star + nb + 1:nb_star])
+    sigma_b2 <- lav_mat_vech_rev(x[nw + nw_star + nb + 1:nb_star])
 
-    dx <- lav_mvnorm_cluster_dlogl_2l_samplestats(
+    dx <- lav_mvn_cl_dlogl_2l_samp(
       ylp = ylp,
       lp = lp, mu_w = mu_w2, sigma_w = sigma_w2,
       mu_b = mu_b2, sigma_b = sigma_b2,
@@ -1265,8 +1265,8 @@ lav_mvnorm_cluster_information_observed <- function(lp = NULL,     # nolint
 
   # start.x
   start_x <- c(
-    as.vector(mu_w), lav_matrix_vech(sigma_w),
-    as.vector(mu_b), lav_matrix_vech(sigma_b)
+    as.vector(mu_w), lav_mat_vech(sigma_w),
+    as.vector(mu_b), lav_mat_vech(sigma_b)
   )
 
   # total information
@@ -1281,7 +1281,7 @@ lav_mvnorm_cluster_information_observed <- function(lp = NULL,     # nolint
     if (length(x_idx_w) > 0L) {
       xw_idx <- c(
         x_idx_w,
-        nw + lav_matrix_vech_which_idx(n = nw, idx = x_idx_w)
+        nw + lav_mat_vech_which_idx(n = nw, idx = x_idx_w)
       )
     } else {
       xw_idx <- integer(0L)
@@ -1290,7 +1290,7 @@ lav_mvnorm_cluster_information_observed <- function(lp = NULL,     # nolint
     if (length(x_idx_b) > 0L) {
       xb_idx <- c(
         x_idx_b,
-        nb + lav_matrix_vech_which_idx(n = nb, idx = x_idx_b)
+        nb + lav_mat_vech_which_idx(n = nb, idx = x_idx_b)
       )
     } else {
       xb_idx <- integer(0L)
@@ -1310,7 +1310,7 @@ lav_mvnorm_cluster_information_observed <- function(lp = NULL,     # nolint
 #
 # per cluster-SIZE
 #
-lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
+lav_mvn_cl_em_sat <- function(ylp = NULL,
                                       lp = NULL,
                                       tol = 1e-04,
                                       max_iter = 5000,
@@ -1343,7 +1343,7 @@ lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
   # }
 
   # report initial fx
-  fx <- lav_mvnorm_cluster_loglik_samplestats_2l(
+  fx <- lav_mvn_cl_loglik_samp_2l(
     ylp = ylp, lp = lp,
     mu_w = mu_w_1, sigma_w = sigma_w_1,
     mu_b = mu_b_1, sigma_b = sigma_b_1,
@@ -1360,7 +1360,7 @@ lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
   }
 
   # translate to internal matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp,
     mu_w = mu_w_1, sigma_w = sigma_w_1, mu_b = mu_b_1, sigma_b = sigma_b_1
   )
@@ -1387,7 +1387,7 @@ lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
   fx_old <- fx
   for (i in 1:max_iter) {
     # E-step
-    estep <- lav_mvnorm_cluster_em_estepb( # Y1 = Y1,
+    estep <- lav_mvn_cl_em_estepb( # Y1 = Y1,
       ylp = ylp,
       lp = lp,
       sigma_w = sigma_w,
@@ -1406,7 +1406,7 @@ lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
     mu_w <- estep$mu.w
     mu_b <- estep$mu.b
 
-    implied2 <- lav_mvnorm_cluster_2l2implied(
+    implied2 <- lav_mvn_cl_2l2implied(
       lp = lp,
       sigma_w = estep$sigma.w, sigma_b = estep$sigma.b,
       sigma_zz = sigma_zz, sigma_yz = estep$sigma.yz,
@@ -1424,7 +1424,7 @@ lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
       diag(sigma_w_1)[zero_var] <- diag(sigma_w)[zero_var] <- min_variance
     }
 
-    fx <- lav_mvnorm_cluster_loglik_samplestats_2l(
+    fx <- lav_mvn_cl_loglik_samp_2l(
       ylp = ylp,
       lp = lp, mu_w = implied2$Mu.W, sigma_w = sigma_w_1,
       mu_b = implied2$Mu.B, sigma_b = implied2$Sigma.B,
@@ -1482,7 +1482,7 @@ lav_mvnorm_cluster_em_sat <- function(ylp = NULL,
 
 
 # based on lav_mvnorm_cluster_em_estep
-lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
+lav_mvn_cl_em_h0 <- function(lavsamplestats = NULL,
                                      lavdata = NULL,
                                      lavimplied = NULL,
                                      lavpartable = NULL,
@@ -1517,7 +1517,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
   # TODO: what if current 'starting' parameters imply a non-pd sigma.b?
 
   # report initial fx
-  fx <- lav_mvnorm_cluster_loglik_samplestats_2l(
+  fx <- lav_mvn_cl_loglik_samp_2l(
     ylp = ylp, lp = lp,
     mu_w = lavimplied$mean[[1]], sigma_w = lavimplied$cov[[1]],
     mu_b = lavimplied$mean[[2]], sigma_b = lavimplied$cov[[2]],
@@ -1534,7 +1534,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
   }
 
   # translate to internal matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp,
     mu_w = lavimplied$mean[[1]], sigma_w = lavimplied$cov[[1]],
     mu_b = lavimplied$mean[[2]], sigma_b = lavimplied$cov[[2]]
@@ -1563,7 +1563,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
   # rel <- numeric(max_iter)
   for (i in 1:max_iter) {
     # E-step
-    estep <- lav_mvnorm_cluster_em_estepb(
+    estep <- lav_mvn_cl_em_estepb(
       ylp = ylp,
       lp = lp,
       sigma_w = sigma_w,
@@ -1576,7 +1576,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
     )
 
     # back to model-implied dimensions
-    implied <- lav_mvnorm_cluster_2l2implied(
+    implied <- lav_mvn_cl_2l2implied(
       lp = lp,
       sigma_w = estep$sigma.w, sigma_b = estep$sigma.b,
       sigma_zz = sigma_zz, sigma_yz = estep$sigma.yz,
@@ -1632,7 +1632,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
     # end of M-step
 
     implied2 <- local_fit@implied
-    fx <- lav_mvnorm_cluster_loglik_samplestats_2l(
+    fx <- lav_mvn_cl_loglik_samp_2l(
       ylp = ylp,
       lp = lp, mu_w = implied2$mean[[1]], sigma_w = implied2$cov[[1]],
       mu_b = implied2$mean[[2]], sigma_b = implied2$cov[[2]],
@@ -1644,7 +1644,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
 
     # derivatives
     lavmodel <- lav_model_set_parameters(lavmodel, x = local_fit@optim$x)
-    dx <- lav_model_gradient(lavmodel,
+    dx <- lav_model_grad(lavmodel,
       lavdata = lavdata,
       lavsamplestats = lavsamplestats
     )
@@ -1687,7 +1687,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
     }
 
     # translate to internal matrices
-    out <- lav_mvnorm_cluster_implied22l(
+    out <- lav_mvn_cl_implied22l(
       lp = lp,
       mu_w = implied2$mean[[1]], sigma_w = implied2$cov[[1]],
       mu_b = implied2$mean[[2]], sigma_b = implied2$cov[[2]]
@@ -1730,7 +1730,7 @@ lav_mvnorm_cluster_em_h0 <- function(lavsamplestats = NULL,
 
 # get the random effects (here: expected values for cluster means)
 # and optionally a standard error
-lav_mvnorm_cluster_em_estep_ranef <- function(ylp = NULL, # nolint
+lav_mvn_cl_em_estep_ranef <- function(ylp = NULL,
                                               lp = NULL,
                                               sigma_w = NULL,
                                               sigma_b = NULL,
@@ -1818,7 +1818,7 @@ lav_mvnorm_cluster_em_estep_ranef <- function(ylp = NULL, # nolint
 }
 
 # per cluster
-lav_mvnorm_cluster_em_estep <- function( # Y1           = NULL,
+lav_mvn_cl_em_estep <- function( # Y1           = NULL,
                                         ylp = NULL,
                                         lp = NULL,
                                         sigma_w = NULL,
@@ -1943,7 +1943,7 @@ lav_mvnorm_cluster_em_estep <- function( # Y1           = NULL,
 }
 
 # per cluster SIZE
-lav_mvnorm_cluster_em_estepb <- function( # Y1           = NULL, # not used!
+lav_mvn_cl_em_estepb <- function( # Y1           = NULL, # not used!
                                          ylp = NULL,
                                          lp = NULL,
                                          sigma_w = NULL,

--- a/R/lav_mvnorm_cluster_missing.R
+++ b/R/lav_mvnorm_cluster_missing.R
@@ -6,7 +6,7 @@
 
 
 # Mu.W, Mu.B, Sigma.W, Sigma.B are the model-implied statistics
-lav_mvnorm_cluster_missing_loglik_samplestats_2l <- function(y1 = NULL, # nolint
+lav_mvn_cl_mi_loglik_samp_2l <- function(y1 = NULL,
                                                          y2 = NULL,
                                                          lp = NULL,
                                                          mp = NULL,
@@ -19,7 +19,7 @@ lav_mvnorm_cluster_missing_loglik_samplestats_2l <- function(y1 = NULL, # nolint
                                                          loglik_x = 0,
                                                          minus_two = TRUE) {
   # map implied to 2l matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp, mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
   )
@@ -113,7 +113,7 @@ lav_mvnorm_cluster_missing_loglik_samplestats_2l <- function(y1 = NULL, # nolint
 
       if (length(z_na_idx) > 0L) {
         # zp <- sigma_zz[-z_na_idx, -z_na_idx, drop = FALSE]
-        zp_inv <- lav_matrix_symmetric_inverse_update(
+        zp_inv <- lav_mat_sym_inverse_update(
           s_inv = sigma_zz_inv, rm_idx = z_na_idx,
           logdet = TRUE, s_logdet = sigma_zz_logdet
         )
@@ -160,7 +160,7 @@ lav_mvnorm_cluster_missing_loglik_samplestats_2l <- function(y1 = NULL, # nolint
     if (length(na_idx) > 0L) {
       #MPi[Mp$case.idx[[p]]] <- p
       # wp <- sigma_w_1[-na_idx, -na_idx, drop = FALSE]
-      wp_inv <- lav_matrix_symmetric_inverse_update(
+      wp_inv <- lav_mat_sym_inverse_update(
         s_inv = sigma_w_inv, rm_idx = na_idx,
         logdet = TRUE, s_logdet = sigma_w_logdet
       )
@@ -194,7 +194,7 @@ lav_mvnorm_cluster_missing_loglik_samplestats_2l <- function(y1 = NULL, # nolint
   ) # only both part is needed
 
   # per cluster
-  both_diag_idx <- lav_matrix_diag_idx(length(both_idx))
+  both_diag_idx <- lav_mat_diag_idx(length(both_idx))
   for (j in seq_len(nclusters)) {
     # we only need the 'both.idx' part of A.j, sigma.b.z, p.j, g.j ,...
     a_j <- alist_1[[j]]
@@ -251,7 +251,7 @@ lav_mvnorm_cluster_missing_loglik_samplestats_2l <- function(y1 = NULL, # nolint
 }
 
 # Mu.W, Mu.B, Sigma.W, Sigma.B are the model-implied statistics
-lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
+lav_mvn_cl_mi_dlogl_2l_samp <- function(
     y1 = NULL,
     y2 = NULL,
     lp = NULL,
@@ -263,7 +263,7 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
     sinv_method = "eigen",
     return_list = FALSE) {
   # map implied to 2l matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp, mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
   )
@@ -342,7 +342,7 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
 
       if (length(z_na_idx) > 0L) {
         # zp <- sigma_zz[-z_na_idx, -z_na_idx, drop = FALSE]
-        zp_inv <- lav_matrix_symmetric_inverse_update(
+        zp_inv <- lav_mat_sym_inverse_update(
           s_inv = sigma_zz_inv, rm_idx = z_na_idx,
           logdet = FALSE
         )
@@ -384,7 +384,7 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
 
     if (length(na_idx) > 0L) {
       mpi[mp$case.idx[[p]]] <- p
-      wp_inv <- lav_matrix_symmetric_inverse_update(
+      wp_inv <- lav_mat_sym_inverse_update(
         s_inv = sigma_w_inv, rm_idx = na_idx,
         logdet = FALSE
       )
@@ -415,7 +415,7 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
   )
 
   # per cluster
-  both_diag_idx <- lav_matrix_diag_idx(length(both_idx))
+  both_diag_idx <- lav_mat_diag_idx(length(both_idx))
   for (j in seq_len(nclusters)) {
     a_j_full <- alist_1[[j]]
     a_j <- a_j_full[both_idx, both_idx, drop = FALSE]
@@ -589,7 +589,7 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
   } # j
 
   # rearrange
-  dout <- lav_mvnorm_cluster_2l2implied(
+  dout <- lav_mvn_cl_2l2implied(
     lp = lp,
     sigma_w = dx_sigma_w, sigma_b = dx_sigma_b,
     sigma_yz = dx_sigma_yz, sigma_zz = dx_sigma_zz,
@@ -600,8 +600,8 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
     out <- dout
   } else {
     out <- c(
-      dout$Mu.W, lav_matrix_vech(dout$Sigma.W),
-      dout$Mu.B, lav_matrix_vech(dout$Sigma.B)
+      dout$Mu.W, lav_mat_vech(dout$Sigma.W),
+      dout$Mu.B, lav_mat_vech(dout$Sigma.B)
     )
   }
 
@@ -609,7 +609,7 @@ lav_mvnorm_cluster_missing_dlogl_2l_samplestats <- function( # nolint
 }
 
 # cluster-wise scores -2*logl wrt Mu.W, Mu.B, Sigma.W, Sigma.B
-lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
+lav_mvn_cl_mi_sc_2l <- function(
     y1 = NULL,
     y2 = NULL,
     lp = NULL,
@@ -620,7 +620,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
     sigma_b = NULL,
     sinv_method = "eigen") {
   # map implied to 2l matrices
-  out <- lav_mvnorm_cluster_implied22l(
+  out <- lav_mvn_cl_implied22l(
     lp = lp, mu_w = mu_w, mu_b = mu_b,
     sigma_w = sigma_w, sigma_b = sigma_b
   )
@@ -672,11 +672,11 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
 
   # both level-1 and level-2
   g_muy <- matrix(0, nclusters, length(mu_y))
-  g_sigma_w <- matrix(0, nclusters, length(lav_matrix_vech(sigma_w_1)))
-  g_sigma_b <- matrix(0, nclusters, length(lav_matrix_vech(out$sigma.b)))
+  g_sigma_w <- matrix(0, nclusters, length(lav_mat_vech(sigma_w_1)))
+  g_sigma_b <- matrix(0, nclusters, length(lav_mat_vech(out$sigma.b)))
   g_muz <- matrix(0, nclusters, length(mu_z))
-  g_sigma_zz <- matrix(0, nclusters, length(lav_matrix_vech(sigma_zz)))
-  g_sigma_yz <- matrix(0, nclusters, length(lav_matrix_vec(out$sigma.yz)))
+  g_sigma_zz <- matrix(0, nclusters, length(lav_mat_vech(sigma_zz)))
+  g_sigma_yz <- matrix(0, nclusters, length(lav_mat_vec(out$sigma.yz)))
 
   # Z per missing pattern
   if (nz > 0L) {
@@ -699,7 +699,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
 
       if (length(z_na_idx) > 0L) {
         # zp <- sigma_zz[-z_na_idx, -z_na_idx, drop = FALSE]
-        zp_inv <- lav_matrix_symmetric_inverse_update(
+        zp_inv <- lav_mat_sym_inverse_update(
           s_inv = sigma_zz_inv, rm_idx = z_na_idx,
           logdet = FALSE
         )
@@ -741,7 +741,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
 
     if (length(na_idx) > 0L) {
       mpi[mp$case.idx[[p]]] <- p
-      wp_inv <- lav_matrix_symmetric_inverse_update(
+      wp_inv <- lav_mat_sym_inverse_update(
         s_inv = sigma_w_inv, rm_idx = na_idx,
         logdet = FALSE
       )
@@ -773,7 +773,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
   )
 
   # per cluster
-  both_diag_idx <- lav_matrix_diag_idx(length(both_idx))
+  both_diag_idx <- lav_mat_diag_idx(length(both_idx))
   for (j in seq_len(nclusters)) {
     a_j_full <- alist_1[[j]]
     a_j <- a_j_full[both_idx, both_idx, drop = FALSE]
@@ -836,7 +836,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
       # symmetry correction
       zz <- 2 * tmp
       diag(zz) <- diag(tmp)
-      g_sigma_zz[j, ] <- lav_matrix_vech(zz)
+      g_sigma_zz[j, ] <- lav_mat_vech(zz)
 
       ###############
       # dx.sigma.yz #
@@ -852,7 +852,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
       tmp <- t0 + t1 + t2 + t3 + t4
       tmp2 <- matrix(0, nrow(out$sigma.yz), ncol(out$sigma.yz))
       tmp2[both_idx, ] <- tmp
-      g_sigma_yz[j, ] <- lav_matrix_vec(tmp2)
+      g_sigma_yz[j, ] <- lav_mat_vec(tmp2)
 
       ##############
       # dx.sigma.b #
@@ -864,7 +864,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
       diag(zz) <- diag(tmp)
       zz2 <- matrix(0, nrow(out$sigma.b), ncol(out$sigma.b))
       zz2[both_idx, both_idx] <- zz
-      g_sigma_b[j, ] <- lav_matrix_vech(zz2)
+      g_sigma_b[j, ] <- lav_mat_vech(zz2)
       # dx.sigma.b[both.idx, both.idx] <-
       #  dx.sigma.b[both.idx, both.idx, drop = FALSE] + ZZ
 
@@ -886,7 +886,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
       diag(zz) <- diag(tmp)
       zz2 <- matrix(0, nrow(out$sigma.b), ncol(out$sigma.b))
       zz2[both_idx, both_idx] <- zz
-      g_sigma_b[j, ] <- lav_matrix_vech(zz2)
+      g_sigma_b[j, ] <- lav_mat_vech(zz2)
       # dx.sigma.b[both.idx, both.idx] <-
       #  dx.sigma.b[both.idx, both.idx, drop = FALSE] + ZZ
 
@@ -939,7 +939,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
     # symmetry correction
     zz <- 2 * tmp
     diag(zz) <- diag(tmp)
-    g_sigma_w[j, ] <- lav_matrix_vech(zz)
+    g_sigma_w[j, ] <- lav_mat_vech(zz)
     # dx.sigma.w <- dx.sigma.w + ZZ
 
     ###########
@@ -982,41 +982,41 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
   # Sigma.B
   if (length(between_idx) > 0L) {
     p_tilde_star <- p_tilde * (p_tilde + 1) / 2
-    b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
+    b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
 
     sigma_b_tilde <- matrix(0, nclusters, p_tilde_star)
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_b
 
-    col_idx <- lav_matrix_vec(b_tilde[ov_idx[[1]], between_idx,
+    col_idx <- lav_mat_vec(b_tilde[ov_idx[[1]], between_idx,
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_yz
 
-    col_idx <- lav_matrix_vech(b_tilde[between_idx, between_idx,
+    col_idx <- lav_mat_vech(b_tilde[between_idx, between_idx,
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_zz
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
       drop = FALSE
     ])
     sigma_b <- sigma_b_tilde[, col_idx, drop = FALSE]
   } else {
     p_tilde_star <- p_tilde * (p_tilde + 1) / 2
-    b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
+    b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
 
     sigma_b_tilde <- matrix(0, nclusters, p_tilde_star)
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[1]], ov_idx[[1]],
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_b
 
-    col_idx <- lav_matrix_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
+    col_idx <- lav_mat_vech(b_tilde[ov_idx[[2]], ov_idx[[2]],
       drop = FALSE
     ])
     sigma_b <- sigma_b_tilde[, col_idx, drop = FALSE]
@@ -1029,7 +1029,7 @@ lav_mvnorm_cluster_missing_scores_2l <- function(             # nolint
 }
 
 # first-order information: outer crossprod of scores per cluster
-lav_mvnorm_cluster_missing_information_firstorder <- function( # nolint
+lav_mvn_cl_mi_info_firstorder <- function(
     y1 = NULL,
     y2 = NULL,
     lp = NULL,
@@ -1042,7 +1042,7 @@ lav_mvnorm_cluster_missing_information_firstorder <- function( # nolint
     divide_by_two = FALSE,
     sinv_method = "eigen") {
 
-  scores <- lav_mvnorm_cluster_missing_scores_2l(
+  scores <- lav_mvn_cl_mi_sc_2l(
     y1 = y1,
     y2 = y2,
     lp = lp,
@@ -1074,7 +1074,7 @@ lav_mvnorm_cluster_missing_information_firstorder <- function( # nolint
     if (length(x_idx_w) > 0L) {
       xw_idx <- c(
         x_idx_w,
-        nw + lav_matrix_vech_which_idx(n = nw, idx = x_idx_w)
+        nw + lav_mat_vech_which_idx(n = nw, idx = x_idx_w)
       )
     } else {
       xw_idx <- integer(0L)
@@ -1083,7 +1083,7 @@ lav_mvnorm_cluster_missing_information_firstorder <- function( # nolint
     if (length(x_idx_b) > 0L) {
       xb_idx <- c(
         x_idx_b,
-        nb + lav_matrix_vech_which_idx(n = nb, idx = x_idx_b)
+        nb + lav_mat_vech_which_idx(n = nb, idx = x_idx_b)
       )
     } else {
       xb_idx <- integer(0L)
@@ -1103,7 +1103,7 @@ lav_mvnorm_cluster_missing_information_firstorder <- function( # nolint
 # mu.w rows/cols that are splitted within/between are forced to zero
 #
 # numerical approximation (for now)
-lav_mvnorm_cluster_missing_information_observed <- function( # nolint
+lav_mvn_cl_mi_info_observed <- function(
     y1 = NULL,
     y2 = NULL,
     lp = NULL,
@@ -1136,11 +1136,11 @@ lav_mvnorm_cluster_missing_information_observed <- function( # nolint
     mu_w_tilde2[lp$both.idx[[2]]] <- mu_w_tilde[lp$both.idx[[2]]]
     mu_w2 <- mu_w_tilde2[ov_idx[[1]]]
 
-    sigma_w2 <- lav_matrix_vech_reverse(x[nw + 1:nw_star])
+    sigma_w2 <- lav_mat_vech_rev(x[nw + 1:nw_star])
     mu_b2 <- x[nw + nw_star + 1:nb]
-    sigma_b2 <- lav_matrix_vech_reverse(x[nw + nw_star + nb + 1:nb_star])
+    sigma_b2 <- lav_mat_vech_rev(x[nw + nw_star + nb + 1:nb_star])
 
-    dx <- lav_mvnorm_cluster_missing_dlogl_2l_samplestats(
+    dx <- lav_mvn_cl_mi_dlogl_2l_samp(
       y1 = y1, y2 = y2, lp = lp, mp = mp,
       mu_w = mu_w2, sigma_w = sigma_w2,
       mu_b = mu_b2, sigma_b = sigma_b2,
@@ -1154,8 +1154,8 @@ lav_mvnorm_cluster_missing_information_observed <- function( # nolint
 
   # start.x
   start_x <- c(
-    as.vector(mu_w), lav_matrix_vech(sigma_w),
-    as.vector(mu_b), lav_matrix_vech(sigma_b)
+    as.vector(mu_w), lav_mat_vech(sigma_w),
+    as.vector(mu_b), lav_mat_vech(sigma_b)
   )
 
   # total information
@@ -1171,7 +1171,7 @@ lav_mvnorm_cluster_missing_information_observed <- function( # nolint
     if (length(x_idx_w) > 0L) {
       xw_idx <- c(
         x_idx_w,
-        nw + lav_matrix_vech_which_idx(n = nw, idx = x_idx_w)
+        nw + lav_mat_vech_which_idx(n = nw, idx = x_idx_w)
       )
     } else {
       xw_idx <- integer(0L)
@@ -1180,7 +1180,7 @@ lav_mvnorm_cluster_missing_information_observed <- function( # nolint
     if (length(x_idx_b) > 0L) {
       xb_idx <- c(
         x_idx_b,
-        nb + lav_matrix_vech_which_idx(n = nb, idx = x_idx_b)
+        nb + lav_mat_vech_which_idx(n = nb, idx = x_idx_b)
       )
     } else {
       xb_idx <- integer(0L)

--- a/R/lav_mvnorm_h1.R
+++ b/R/lav_mvnorm_h1.R
@@ -27,7 +27,7 @@
 # 1. log-likelihood h1
 
 # 1a: input is raw data
-lav_mvnorm_h1_loglik_data <- function(
+lav_mvn_h1_loglik_data <- function(
     y = NULL,
     x_idx = integer(0L),
     casewise = FALSE,
@@ -48,7 +48,7 @@ lav_mvnorm_h1_loglik_data <- function(
     sample_cov <- out$cov
   } else {
     sample_mean <- base::.colMeans(y, m = n, n = p)
-    sample_cov <- lav_matrix_cov(y)
+    sample_cov <- lav_mat_cov(y)
   }
 
   if (casewise) {
@@ -62,7 +62,7 @@ lav_mvnorm_h1_loglik_data <- function(
       dist_1 <- rowSums((yc %*% ic_s)^2)
       logdet <- -2 * sum(log(diag(ic_s)))
     } else {
-      sample_cov_inv <- lav_matrix_symmetric_inverse(
+      sample_cov_inv <- lav_mat_sym_inverse(
         s = sample_cov,
         logdet = TRUE, sinv_method = sinv_method
       )
@@ -80,14 +80,14 @@ lav_mvnorm_h1_loglik_data <- function(
     }
   } else {
     # invert sample_cov
-    sample_cov_inv <- lav_matrix_symmetric_inverse(
+    sample_cov_inv <- lav_mat_sym_inverse(
       s = sample_cov,
       logdet = TRUE, sinv_method = sinv_method
     )
     logdet <- attr(sample_cov_inv, "logdet")
 
     loglik <-
-      lav_mvnorm_h1_loglik_samplestats(
+      lav_mvn_h1_loglik_samp(
         sample_cov_logdet = logdet,
         sample_nvar = p,
         sample_nobs = n
@@ -96,7 +96,7 @@ lav_mvnorm_h1_loglik_data <- function(
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    loglik_x <- lav_mvnorm_h1_loglik_data(
+    loglik_x <- lav_mvn_h1_loglik_data(
       y = y[, x_idx, drop = FALSE],
       wt = wt, x_idx = integer(0L),
       casewise = casewise,
@@ -112,7 +112,7 @@ lav_mvnorm_h1_loglik_data <- function(
 
 
 # 1b: input are sample statistics only (logdet, N and P)
-lav_mvnorm_h1_loglik_samplestats <- function( # nolint
+lav_mvn_h1_loglik_samp <- function(
     sample_cov_logdet = NULL,
     sample_nvar = NULL,
     sample_nobs = NULL,
@@ -135,7 +135,7 @@ lav_mvnorm_h1_loglik_samplestats <- function( # nolint
 
   # all we need is the logdet
   if (is.null(sample_cov_logdet)) {
-    sample_cov_inv <- lav_matrix_symmetric_inverse(
+    sample_cov_inv <- lav_mat_sym_inverse(
       s = sample_cov,
       logdet = TRUE, sinv_method = sinv_method
     )
@@ -161,7 +161,7 @@ lav_mvnorm_h1_loglik_samplestats <- function( # nolint
     }
 
     loglik_x <-
-      lav_mvnorm_h1_loglik_samplestats(
+      lav_mvn_h1_loglik_samp(
         sample_cov = sample_cov_x,
         sample_nobs = sample_nobs,
         x_idx = integer(0L),
@@ -178,7 +178,7 @@ lav_mvnorm_h1_loglik_samplestats <- function( # nolint
 # 4. hessian of logl (around MLEs of Mu and Sigma)
 
 # 4a: hessian logl Mu and vech(Sigma) from raw data
-lav_mvnorm_h1_logl_hessian_data <- function(   # nolint
+lav_mvn_h1_logl_hessian_data <- function(
     y = NULL,
     wt = NULL,
     x_idx = integer(0L),
@@ -193,7 +193,7 @@ lav_mvnorm_h1_logl_hessian_data <- function(   # nolint
   }
 
   # observed information
-  observed <- lav_mvnorm_h1_information_observed_data(
+  observed <- lav_mvn_h1_info_observed_data(
     y = y, wt = wt,
     x_idx = x_idx,
     sinv_method = sinv_method,
@@ -205,7 +205,7 @@ lav_mvnorm_h1_logl_hessian_data <- function(   # nolint
 }
 
 # 4b: hessian Mu and vech(Sigma) from samplestats
-lav_mvnorm_h1_logl_hessian_samplestats <- function( # nolint
+lav_mvn_h1_logl_hessian_samp <- function(
     sample_mean = NULL, # unused!
     sample_cov = NULL,
     sample_nobs = NULL,
@@ -217,7 +217,7 @@ lav_mvnorm_h1_logl_hessian_samplestats <- function( # nolint
   n <- sample_nobs
 
   # observed information
-  observed <- lav_mvnorm_h1_information_observed_samplestats(
+  observed <- lav_mvn_h1_info_observed_samp(
     sample_mean = sample_mean, sample_cov = sample_cov,
     x_idx = x_idx,
     sinv_method = sinv_method, sample_cov_inv = sample_cov_inv,
@@ -232,7 +232,7 @@ lav_mvnorm_h1_logl_hessian_samplestats <- function( # nolint
 # 5) Information h1 (note: expected == observed if data is complete!)
 
 # 5a: unit expected information h1
-lav_mvnorm_h1_information_expected <- function( # nolint
+lav_mvn_h1_info_expected <- function(
     y = NULL,
     wt = NULL,
     sample_cov = NULL,
@@ -246,7 +246,7 @@ lav_mvnorm_h1_information_expected <- function( # nolint
     if (is.null(sample_cov)) {
       if (is.null(wt)) {
         sample_mean <- base::.colMeans(y, m = NROW(y), n = NCOL(y))
-        sample_cov <- lav_matrix_cov(y)
+        sample_cov <- lav_mat_cov(y)
       } else {
         out <- stats::cov.wt(y, wt = wt, method = "ML")
         sample_cov <- out$cov
@@ -254,7 +254,7 @@ lav_mvnorm_h1_information_expected <- function( # nolint
     }
 
     # invert sample_cov
-    sample_cov_inv <- lav_matrix_symmetric_inverse(
+    sample_cov_inv <- lav_mat_sym_inverse(
       s = sample_cov,
       logdet = FALSE, sinv_method = sinv_method
     )
@@ -266,7 +266,7 @@ lav_mvnorm_h1_information_expected <- function( # nolint
     #   i22 <- lavaanC::m_kronecker_dup_cor_pre_post(sample.cov.inv,
     #                                                multiplicator = 0.5)
     # } else {
-      i22 <- 0.5 * lav_matrix_duplication_cor_pre_post(sample_cov_inv %x%
+      i22 <- 0.5 * lav_mat_dup_cor_pre_post(sample_cov_inv %x%
                                                      sample_cov_inv)
     # }
   } else {
@@ -274,14 +274,14 @@ lav_mvnorm_h1_information_expected <- function( # nolint
     #   i22 <- lavaanC::m_kronecker_dup_pre_post(sample.cov.inv,
     #                                            multiplicator = 0.5)
     # } else {
-      i22 <- 0.5 * lav_matrix_duplication_pre_post(sample_cov_inv %x%
+      i22 <- 0.5 * lav_mat_dup_pre_post(sample_cov_inv %x%
                                                    sample_cov_inv)
     # }
   }
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    pstar_x <- lav_matrix_vech_which_idx(
+    pstar_x <- lav_mat_vech_which_idx(
       n = NCOL(sample_cov_inv), idx = x_idx
     )
     i22[pstar_x, ] <- 0
@@ -294,7 +294,7 @@ lav_mvnorm_h1_information_expected <- function( # nolint
       i11[x_idx, ] <- 0
       i11[, x_idx] <- 0
     }
-    out <- lav_matrix_bdiag(i11, i22)
+    out <- lav_mat_bdiag(i11, i22)
   } else {
     out <- i22
   }
@@ -303,7 +303,7 @@ lav_mvnorm_h1_information_expected <- function( # nolint
 }
 
 # 5b: unit observed information h1
-lav_mvnorm_h1_information_observed_data <- function( # nolint
+lav_mvn_h1_info_observed_data <- function(
     y = NULL,
     wt = NULL,
     x_idx = integer(0L),
@@ -311,7 +311,7 @@ lav_mvnorm_h1_information_observed_data <- function( # nolint
     sample_cov_inv = NULL,
     meanstructure = TRUE) {
 
-  lav_mvnorm_h1_information_expected(
+  lav_mvn_h1_info_expected(
     y = y, sinv_method = sinv_method,
     wt = wt, x_idx = x_idx,
     sample_cov_inv = sample_cov_inv,
@@ -320,7 +320,7 @@ lav_mvnorm_h1_information_observed_data <- function( # nolint
 }
 
 # 5b-bis: observed information h1 from sample statistics
-lav_mvnorm_h1_information_observed_samplestats <- function( # nolint
+lav_mvn_h1_info_observed_samp <- function(
     sample_mean = NULL, # unused!
     sample_cov = NULL,
     x_idx = integer(0L),
@@ -330,7 +330,7 @@ lav_mvnorm_h1_information_observed_samplestats <- function( # nolint
 
   if (is.null(sample_cov_inv)) {
     # invert sample_cov
-    sample_cov_inv <- lav_matrix_symmetric_inverse(
+    sample_cov_inv <- lav_mat_sym_inverse(
       s = sample_cov,
       logdet = FALSE, sinv_method = sinv_method
     )
@@ -347,13 +347,13 @@ lav_mvnorm_h1_information_observed_samplestats <- function( # nolint
   #   i22 <- lavaanC::m_kronecker_dup_pre_post(sample.cov.inv,
   #                                            multiplicator = 0.5)
   # } else {
-    i22 <- 0.5 * lav_matrix_duplication_pre_post(sample_cov_inv %x%
+    i22 <- 0.5 * lav_mat_dup_pre_post(sample_cov_inv %x%
     sample_cov_inv)
   # }
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    pstar_x <- lav_matrix_vech_which_idx(
+    pstar_x <- lav_mat_vech_which_idx(
       n = NCOL(sample_cov_inv), idx = x_idx
     )
     i22[pstar_x, ] <- 0
@@ -361,7 +361,7 @@ lav_mvnorm_h1_information_observed_samplestats <- function( # nolint
   }
 
   if (meanstructure) {
-    out <- lav_matrix_bdiag(i11, i22)
+    out <- lav_mat_bdiag(i11, i22)
   } else {
     out <- i22
   }
@@ -372,7 +372,7 @@ lav_mvnorm_h1_information_observed_samplestats <- function( # nolint
 # 5c: unit first-order information h1
 #     note: first order information h1 == A1 %*% Gamma %*% A1
 #           (where A1 = obs/exp information h1)
-lav_mvnorm_h1_information_firstorder <- function( # nolint
+lav_mvn_h1_info_firstorder <- function(
     y = NULL,
     wt = NULL,
     sample_cov = NULL,
@@ -385,7 +385,7 @@ lav_mvnorm_h1_information_firstorder <- function( # nolint
 
   if (!is.null(wt)) {
     out <- stats::cov.wt(y, wt = wt, method = "ML")
-    res <- lav_mvnorm_information_firstorder(
+    res <- lav_mvn_info_firstorder(
       y = y, wt = wt,
       cluster_idx = cluster_idx,
       mu = out$center, sigma_1 = out$cov, x_idx = x_idx,
@@ -399,16 +399,16 @@ lav_mvnorm_h1_information_firstorder <- function( # nolint
     # invert sample_cov
     if (is.null(sample_cov)) {
       sample_mean <- base::.colMeans(y, m = NROW(y), n = NCOL(y))
-      sample_cov <- lav_matrix_cov(y)
+      sample_cov <- lav_mat_cov(y)
     }
-    sample_cov_inv <- lav_matrix_symmetric_inverse(
+    sample_cov_inv <- lav_mat_sym_inverse(
       s = sample_cov,
       logdet = FALSE, sinv_method = sinv_method
     )
   }
 
   # question: is there any benefit computing Gamma/A1 instead of just
-  # calling lav_mvnorm_information_firstorder()?
+  # calling lav_mvn_info_firstorder()?
   # answer (2014): probably not; it is just reassuring that the expression
   # J = A1 %*% gamma_1 %*% A1 seems to hold
 
@@ -416,13 +416,13 @@ lav_mvnorm_h1_information_firstorder <- function( # nolint
   # FIXME: what about the 'unbiased = TRUE' option?
   if (is.null(gamma_1)) {
     if (length(x_idx) > 0L) {
-      gamma_1 <- lav_samplestats_gamma(y,
+      gamma_1 <- lav_samp_gamma(y,
         x_idx = x_idx, fixed_x = TRUE,
         cluster_idx = cluster_idx,
         meanstructure = meanstructure
       )
     } else {
-      gamma_1 <- lav_samplestats_gamma(y,
+      gamma_1 <- lav_samp_gamma(y,
         meanstructure = meanstructure,
         cluster_idx = cluster_idx
       )
@@ -434,16 +434,16 @@ lav_mvnorm_h1_information_firstorder <- function( # nolint
     # invert sample_cov
     if (is.null(sample_cov)) {
       sample_mean <- base::.colMeans(y, m = NROW(y), n = NCOL(y))
-      sample_cov <- lav_matrix_cov(y)
+      sample_cov <- lav_mat_cov(y)
     }
-    sample_cov_inv <- lav_matrix_symmetric_inverse(
+    sample_cov_inv <- lav_mat_sym_inverse(
       s = sample_cov,
       logdet = FALSE, sinv_method = sinv_method
     )
   }
 
   # A1
-  a1 <- lav_mvnorm_h1_information_expected(
+  a1 <- lav_mvn_h1_info_expected(
     y = y, sinv_method = sinv_method,
     sample_cov_inv = sample_cov_inv,
     x_idx = x_idx,
@@ -459,7 +459,7 @@ lav_mvnorm_h1_information_firstorder <- function( # nolint
 #    6b: (unit) inverted observed information (A1.inv = gamma_nt)
 
 lav_mvnorm_h1_inverted_information_expected <-              # nolint
-lav_mvnorm_h1_inverted_information_observed <- function(    # nolint
+lav_mvn_h1_inv_info_observed <- function(
   y = NULL,
   wt = NULL,
   sample_cov = NULL,
@@ -469,7 +469,7 @@ lav_mvnorm_h1_inverted_information_observed <- function(    # nolint
   if (is.null(sample_cov)) {
     if (is.null(wt)) {
       sample_mean <- base::.colMeans(y, m = NROW(y), n = NCOL(y))
-      sample_cov <- lav_matrix_cov(y)
+      sample_cov <- lav_mat_cov(y)
     } else {
       out <- stats::cov.wt(y, wt = wt, method = "ML")
       sample_cov <- out$cov
@@ -477,7 +477,7 @@ lav_mvnorm_h1_inverted_information_observed <- function(    # nolint
   }
 
   if (length(x_idx) > 0L) {
-    gamma_nt <- lav_samplestats_gamma_nt(
+    gamma_nt <- lav_samp_gamma_nt(
       m_y = y, wt = wt, x_idx = x_idx,
       m_cov = sample_cov,
       meanstructure = TRUE,
@@ -489,9 +489,9 @@ lav_mvnorm_h1_inverted_information_observed <- function(    # nolint
     #   i22 <- lavaanC::m_kronecker_dup_ginv_pre_post(sample_cov,
     #                                                 multiplicator = 2.0)
     # } else {
-      i22 <- 2 * lav_matrix_duplication_ginv_pre_post(sample_cov %x% sample_cov)
+      i22 <- 2 * lav_mat_dup_ginv_pre_post(sample_cov %x% sample_cov)
     # }
-    gamma_nt <- lav_matrix_bdiag(i11, i22)
+    gamma_nt <- lav_mat_bdiag(i11, i22)
   }
 
   gamma_nt
@@ -500,7 +500,7 @@ lav_mvnorm_h1_inverted_information_observed <- function(    # nolint
 #    6c: (unit) inverted first-order information (B1.inv) (not used?)
 #        J1.inv = gamma_nt %*% solve(Gamma) %*%  gamma_nt
 #
-lav_mvnorm_h1_inverted_information_firstorder <- function( # nolint
+lav_mvn_h1_inv_info_firstorder <- function(
     y = NULL,
     wt = NULL,
     sample_cov = NULL,
@@ -509,7 +509,7 @@ lav_mvnorm_h1_inverted_information_firstorder <- function( # nolint
     sample_cov_inv = NULL,
     gamma_1 = NULL) {
 
-  # lav_samplestats_gamma() has no wt argument (yet)
+  # lav_samp_gamma() has no wt argument (yet)
   if (!is.null(wt)) {
     lav_msg_stop(gettext("function not supported if wt is not NULL"))
   }
@@ -518,12 +518,12 @@ lav_mvnorm_h1_inverted_information_firstorder <- function( # nolint
   # what about the 'unbiased = TRUE' option?
   if (is.null(gamma_1)) {
     if (length(x_idx) > 0L) {
-      gamma_1 <- lav_samplestats_gamma(y,
+      gamma_1 <- lav_samp_gamma(y,
         x_idx = x_idx, fixed_x = TRUE,
         meanstructure = TRUE
       )
     } else {
-      gamma_1 <- lav_samplestats_gamma(y, meanstructure = TRUE)
+      gamma_1 <- lav_samp_gamma(y, meanstructure = TRUE)
     }
   }
 
@@ -549,8 +549,8 @@ lav_mvnorm_h1_inverted_information_firstorder <- function( # nolint
 
 #    7a: 1/N * gamma_nt
 #    7b: 1/N * gamma_nt
-lav_mvnorm_h1_acov_expected <-
-lav_mvnorm_h1_acov_observed <- function(
+lav_mvn_h1_acov_expected <-
+lav_mvn_h1_acov_observed <- function(
     y = NULL,
     wt = NULL,
     sample_cov = NULL,
@@ -574,7 +574,7 @@ lav_mvnorm_h1_acov_observed <- function(
 }
 
 #    7c: 1/N * (gamma_nt * Gamma^{-1} * gamma_nt)
-lav_mvnorm_h1_acov_firstorder <- function(
+lav_mvn_h1_acov_firstorder <- function(
     y = NULL,
     wt = NULL,
     sample_cov = NULL,
@@ -589,7 +589,7 @@ lav_mvnorm_h1_acov_firstorder <- function(
     n <- NROW(y)
   }
 
-  j1_inv <- lav_mvnorm_h1_inverted_information_firstorder(
+  j1_inv <- lav_mvn_h1_inv_info_firstorder(
     y = y, wt = wt,
     sample_cov = sample_cov,
     x_idx = x_idx, sinv_method = sinv_method,
@@ -600,14 +600,14 @@ lav_mvnorm_h1_acov_firstorder <- function(
 }
 
 #    7d: 1/N * Gamma (sandwich)
-lav_mvnorm_h1_acov_sandwich <- function(
+lav_mvn_h1_acov_sandwich <- function(
     y = NULL,
     wt = NULL,
     sample_cov = NULL,
     x_idx = integer(0L),
     gamma_1 = NULL) {
 
-  # lav_samplestats_gamma() has no wt argument (yet)
+  # lav_samp_gamma() has no wt argument (yet)
   if (!is.null(wt)) {
     lav_msg_stop(gettext("function not supported if wt is not NULL"))
   }
@@ -621,12 +621,12 @@ lav_mvnorm_h1_acov_sandwich <- function(
   # Gamma
   if (is.null(gamma_1)) {
     if (length(x_idx) > 0L) {
-      gamma_1 <- lav_samplestats_gamma(y,
+      gamma_1 <- lav_samp_gamma(y,
         x_idx = x_idx, fixed_x = TRUE,
         meanstructure = TRUE
       )
     } else {
-      gamma_1 <- lav_samplestats_gamma(y, meanstructure = TRUE)
+      gamma_1 <- lav_samp_gamma(y, meanstructure = TRUE)
     }
   }
 

--- a/R/lav_mvnorm_missing.R
+++ b/R/lav_mvnorm_missing.R
@@ -9,7 +9,7 @@
 #    5a: (unit)    expected information
 #    5b: (unit)    observed information
 #    5c: (unit) first.order information
-#    5d: lav_mvnorm_missing_information_both (both observed + first.order)
+#    5d: lav_mvn_mi_info_both (both observed + first.order)
 
 # 6) inverted information h0 mu + vech(Sigma)
 #    6a: /
@@ -39,7 +39,7 @@
 #                    2) truly case per case    (pattern = FALSE)
 #    depending on the sample size, missing patterns, etc... one can be
 #    (much) faster than the other
-lav_mvnorm_missing_loglik_data <- function(y = NULL,
+lav_mvn_mi_loglik_data <- function(y = NULL,
                                            mu = NULL,
                                            wt = NULL,
                                            sigma_1 = NULL,
@@ -50,13 +50,13 @@ lav_mvnorm_missing_loglik_data <- function(y = NULL,
                                            log2pi = TRUE,
                                            minus_two = FALSE) {
   if (pattern) {
-    llik <- lav_mvnorm_missing_llik_pattern(
+    llik <- lav_mvn_mi_llik_pattern(
       y = y, wt = wt, mu = mu,
       sigma_1 = sigma_1, x_idx = x_idx, sinv_method = sinv_method,
       log2pi = log2pi, minus_two = minus_two
     )
   } else {
-    llik <- lav_mvnorm_missing_llik_casewise(
+    llik <- lav_mvn_mi_llik_casewise(
       y = y, wt = wt, mu = mu,
       sigma_1 = sigma_1, x_idx = x_idx, sinv_method = sinv_method,
       log2pi = log2pi, minus_two = minus_two
@@ -73,7 +73,7 @@ lav_mvnorm_missing_loglik_data <- function(y = NULL,
 }
 
 # 1b: input are sample statistics (mean, cov, N) per pattern
-lav_mvnorm_missing_loglik_samplestats <- function(yp = NULL, # nolint
+lav_mvn_mi_loglik_samp <- function(yp = NULL,
                                                   mu = NULL,
                                                   sigma_1 = NULL,
                                                   x_idx = integer(0L),
@@ -87,7 +87,7 @@ lav_mvnorm_missing_loglik_samplestats <- function(yp = NULL, # nolint
   p_1 <- length(yp[[1]]$var.idx)
 
   # global inverse + logdet
-  sigma_inv_1 <- lav_matrix_symmetric_inverse(
+  sigma_inv_1 <- lav_mat_sym_inverse(
     s = sigma_1, logdet = TRUE,
     sinv_method = sinv_method
   )
@@ -110,7 +110,7 @@ lav_mvnorm_missing_loglik_samplestats <- function(yp = NULL, # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv <- lav_matrix_symmetric_inverse_update(
+      sigma_inv <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv_1,
         rm_idx = na_idx, logdet = TRUE, s_logdet = sigma_logdet
       )
@@ -141,7 +141,7 @@ lav_mvnorm_missing_loglik_samplestats <- function(yp = NULL, # nolint
     # Note: x.cov should be identical to Sigma[x.idx, x.idx]
     #       so we don't really need x.cov
     n <- sum(sapply(yp, "[[", "freq"))
-    loglik_x <- lav_mvnorm_h1_loglik_samplestats(
+    loglik_x <- lav_mvn_h1_loglik_samp(
       sample_cov = x_cov,
       sample_nobs = n
     )
@@ -155,7 +155,7 @@ lav_mvnorm_missing_loglik_samplestats <- function(yp = NULL, # nolint
 ## casewise loglikelihoods
 
 # casewise Sinv.method
-lav_mvnorm_missing_llik_casewise <- function(y = NULL, # nolint
+lav_mvn_mi_llik_casewise <- function(y = NULL,
                                              wt = NULL,
                                              mu = NULL,
                                              sigma_1 = NULL,
@@ -174,7 +174,7 @@ lav_mvnorm_missing_llik_casewise <- function(y = NULL, # nolint
   ny <- NROW(y)
 
   # global inverse + logdet
-  sigma_inv_1 <- lav_matrix_symmetric_inverse(
+  sigma_inv_1 <- lav_mat_sym_inverse(
     s = sigma_1, logdet = TRUE,
     sinv_method = sinv_method
   )
@@ -213,7 +213,7 @@ lav_mvnorm_missing_llik_casewise <- function(y = NULL, # nolint
     if (length(na_idx) == p) next
 
     # invert Sigma for this pattern
-    sigma_inv <- lav_matrix_symmetric_inverse_update(
+    sigma_inv <- lav_mat_sym_inverse_update(
       s_inv = sigma_inv_1,
       rm_idx = na_idx, logdet = TRUE, s_logdet = sigma_logdet
     )
@@ -242,7 +242,7 @@ lav_mvnorm_missing_llik_casewise <- function(y = NULL, # nolint
 
   # x.idx
   if (length(x_idx) > 0L) {
-    llik_x <- lav_mvnorm_missing_llik_casewise(
+    llik_x <- lav_mvn_mi_llik_casewise(
       y = y[, x_idx, drop = FALSE],
       wt = wt, mu = mu[x_idx],
       sigma_1 = sigma_1[x_idx, x_idx, drop = FALSE],
@@ -256,7 +256,7 @@ lav_mvnorm_missing_llik_casewise <- function(y = NULL, # nolint
 }
 
 # pattern-based, but casewise loglikelihoods
-lav_mvnorm_missing_llik_pattern <- function(y = NULL,   # nolint
+lav_mvn_mi_llik_pattern <- function(y = NULL,
                                             mp = NULL,
                                             wt = NULL,
                                             mu = NULL,
@@ -276,7 +276,7 @@ lav_mvnorm_missing_llik_pattern <- function(y = NULL,   # nolint
   ny <- NROW(y)
 
   # global inverse + logdet
-  sigma_inv_1 <- lav_matrix_symmetric_inverse(
+  sigma_inv_1 <- lav_mat_sym_inverse(
     s = sigma_1, logdet = TRUE,
     sinv_method = sinv_method
   )
@@ -290,7 +290,7 @@ lav_mvnorm_missing_llik_pattern <- function(y = NULL,   # nolint
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # for each pattern, compute sigma.inv/logdet; compute DIST for all
@@ -310,7 +310,7 @@ lav_mvnorm_missing_llik_pattern <- function(y = NULL,   # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv <- lav_matrix_symmetric_inverse_update(
+      sigma_inv <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv_1,
         rm_idx = na_idx, logdet = TRUE, s_logdet = sigma_logdet
       )
@@ -350,7 +350,7 @@ lav_mvnorm_missing_llik_pattern <- function(y = NULL,   # nolint
   # x.idx -- using casewise (as patterns for Y may not be the same as
   #                          patterns for Y[,-x.idx])
   if (length(x_idx) > 0L) {
-    llik_x <- lav_mvnorm_missing_llik_casewise(
+    llik_x <- lav_mvn_mi_llik_casewise(
       y = y[, x_idx, drop = FALSE],
       wt = wt, mu = mu[x_idx],
       sigma_1 = sigma_1[x_idx, x_idx, drop = FALSE],
@@ -369,14 +369,14 @@ lav_mvnorm_missing_llik_pattern <- function(y = NULL,   # nolint
 # 2. Derivatives
 
 # 2a: derivative logl with respect to mu
-lav_mvnorm_missing_dlogl_dmu <- function(y = NULL,
+lav_mvn_mi_dlogl_dmu <- function(y = NULL,
                                          wt = NULL,
                                          mu = NULL,
                                          sigma_1 = NULL,
                                          x_idx = integer(0L),
                                          sigma_inv = NULL,
                                          sinv_method = "eigen") {
-  sc <- lav_mvnorm_missing_scores_mu(
+  sc <- lav_mvn_mi_sc_mu(
     y = y, wt = wt, mu = mu, sigma_1 = sigma_1,
     x_idx = x_idx, sigma_inv = sigma_inv, sinv_method = sinv_method
   )
@@ -385,7 +385,7 @@ lav_mvnorm_missing_dlogl_dmu <- function(y = NULL,
 }
 
 # 2abis: using samplestats
-lav_mvnorm_missing_dlogl_dmu_samplestats <- function(yp = NULL, # nolint
+lav_mvn_mi_dlogl_dmu_samp <- function(yp = NULL,
                                                      mu = NULL,
                                                      sigma_1 = NULL,
                                                      x_idx = integer(0L),
@@ -395,7 +395,7 @@ lav_mvnorm_missing_dlogl_dmu_samplestats <- function(yp = NULL, # nolint
   p_1 <- length(yp[[1]]$var.idx)
 
   if (is.null(sigma_inv)) {
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -414,7 +414,7 @@ lav_mvnorm_missing_dlogl_dmu_samplestats <- function(yp = NULL, # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
@@ -440,7 +440,7 @@ lav_mvnorm_missing_dlogl_dmu_samplestats <- function(yp = NULL, # nolint
 
 
 # 2b: derivative logl with respect to Sigma (full matrix, ignoring symmetry)
-lav_mvnorm_missing_dlogl_dsigma <- function(m_y = NULL,  # nolint
+lav_mvn_mi_dlogl_dsigma <- function(m_y = NULL,
                                             l_mp = NULL,
                                             wt = NULL,
                                             m_mu = NULL,
@@ -459,7 +459,7 @@ lav_mvnorm_missing_dlogl_dsigma <- function(m_y = NULL,  # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = m_sigma, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -473,7 +473,7 @@ lav_mvnorm_missing_dlogl_dsigma <- function(m_y = NULL,  # nolint
 
   # missing patterns
   if (is.null(l_mp)) {
-    l_mp <- lav_data_missing_patterns(m_y)
+    l_mp <- lav_data_mi_patterns(m_y)
   }
 
   # for each pattern
@@ -489,7 +489,7 @@ lav_mvnorm_missing_dlogl_dsigma <- function(m_y = NULL,  # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      local_sigma_inv <- lav_matrix_symmetric_inverse_update(
+      local_sigma_inv <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
@@ -536,7 +536,7 @@ lav_mvnorm_missing_dlogl_dsigma <- function(m_y = NULL,  # nolint
 }
 
 # 2bbis: using samplestats
-lav_mvnorm_missing_dlogl_dsigma_samplestats <- function(yp = NULL, # nolint
+lav_mvn_mi_dlogl_dsigma_samp <- function(yp = NULL,
                                                         mu = NULL,
                                                         sigma_1 = NULL,
                                                         x_idx = integer(0L),
@@ -547,7 +547,7 @@ lav_mvnorm_missing_dlogl_dsigma_samplestats <- function(yp = NULL, # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -566,7 +566,7 @@ lav_mvnorm_missing_dlogl_dsigma_samplestats <- function(yp = NULL, # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
@@ -595,21 +595,21 @@ lav_mvnorm_missing_dlogl_dsigma_samplestats <- function(yp = NULL, # nolint
 
 
 # 2c: derivative logl with respect to vech(Sigma)
-lav_mvnorm_missing_dlogl_dvechsigma <- function(y = NULL, # nolint
+lav_mvn_mi_dlogl_dvechsigma <- function(y = NULL,
                                                 wt = NULL,
                                                 mu = NULL,
                                                 x_idx = integer(0L),
                                                 sigma_1 = NULL,
                                                 sigma_inv = NULL,
                                                 sinv_method = "eigen") {
-  d_sigma <- lav_mvnorm_missing_dlogl_dsigma(
+  d_sigma <- lav_mvn_mi_dlogl_dsigma(
     m_y = y, wt = wt, m_mu = mu,
     m_sigma = sigma_1, x_idx = x_idx, sigma_inv = sigma_inv,
     sinv_method = sinv_method
   )
 
-  dvech_sigma <- as.numeric(lav_matrix_duplication_pre(
-    as.matrix(lav_matrix_vec(d_sigma))
+  dvech_sigma <- as.numeric(lav_mat_dup_pre(
+    as.matrix(lav_mat_vec(d_sigma))
   ))
 
   dvech_sigma
@@ -628,7 +628,7 @@ lav_mvnorm_missing_dlogl_dvechsigma_samplestats <- # nolint
 
     if (is.null(sigma_inv)) {
       # invert Sigma
-      sigma_inv <- lav_matrix_symmetric_inverse(
+      sigma_inv <- lav_mat_sym_inverse(
         s = sigma_1, logdet = FALSE,
         sinv_method = sinv_method
       )
@@ -647,7 +647,7 @@ lav_mvnorm_missing_dlogl_dvechsigma_samplestats <- # nolint
 
       # invert Sigma for this pattern
       if (length(na_idx) > 0L) {
-        sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+        sigma_inv_1 <- lav_mat_sym_inverse_update(
           s_inv = sigma_inv,
           rm_idx = na_idx, logdet = FALSE
         )
@@ -668,8 +668,8 @@ lav_mvnorm_missing_dlogl_dvechsigma_samplestats <- # nolint
       }
 
       # convert to vechSigma
-      dvech_sigma_pattern <- as.numeric(lav_matrix_duplication_pre(
-        as.matrix(lav_matrix_vec(d_sigma_pattern))
+      dvech_sigma_pattern <- as.numeric(lav_mat_dup_pre(
+        as.matrix(lav_mat_vec(d_sigma_pattern))
       ))
 
       # update dvechSigma
@@ -685,7 +685,7 @@ lav_mvnorm_missing_dlogl_dvechsigma_samplestats <- # nolint
 # 3. Casewise scores
 
 # 3a: casewise scores with respect to mu
-lav_mvnorm_missing_scores_mu <- function(y = NULL,
+lav_mvn_mi_sc_mu <- function(y = NULL,
                                          wt = NULL,
                                          mp = NULL,
                                          mu = NULL,
@@ -704,7 +704,7 @@ lav_mvnorm_missing_scores_mu <- function(y = NULL,
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -712,7 +712,7 @@ lav_mvnorm_missing_scores_mu <- function(y = NULL,
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # subtract Mu
@@ -733,7 +733,7 @@ lav_mvnorm_missing_scores_mu <- function(y = NULL,
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
@@ -760,7 +760,7 @@ lav_mvnorm_missing_scores_mu <- function(y = NULL,
 }
 
 # 3b: casewise scores with respect to vech(Sigma)
-lav_mvnorm_missing_scores_vech_sigma <- function(y = NULL, # nolint
+lav_mvn_mi_sc_sigma <- function(y = NULL,
                                                  wt = NULL,
                                                  mp = NULL,
                                                  mu = NULL,
@@ -779,22 +779,22 @@ lav_mvnorm_missing_scores_vech_sigma <- function(y = NULL, # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # for the tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(p_1)
-  idx2 <- lav_matrix_vech_row_idx(p_1)
+  idx1 <- lav_mat_vech_col_idx(p_1)
+  idx2 <- lav_mat_vech_row_idx(p_1)
 
   # vech(Sigma.inv)
-  i_sigma <- lav_matrix_vech(sigma_inv)
+  i_sigma <- lav_mat_vech(sigma_inv)
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # subtract Mu
@@ -816,13 +816,13 @@ lav_mvnorm_missing_scores_vech_sigma <- function(y = NULL, # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
       tmp <- matrix(0, p_1, p_1)
       tmp[var_idx, var_idx] <- sigma_inv_1
-      isigma <- lav_matrix_vech(tmp)
+      isigma <- lav_mat_vech(tmp)
     } else {
       sigma_inv_1 <- sigma_inv
       isigma <- i_sigma
@@ -839,7 +839,7 @@ lav_mvnorm_missing_scores_vech_sigma <- function(y = NULL, # nolint
   }
 
   # adjust for vech
-  sc[, lav_matrix_diagh_idx(p_1)] <- sc[, lav_matrix_diagh_idx(p_1)] / 2
+  sc[, lav_mat_diagh_idx(p_1)] <- sc[, lav_mat_diagh_idx(p_1)] / 2
 
   # weights
   if (!is.null(wt)) {
@@ -848,14 +848,14 @@ lav_mvnorm_missing_scores_vech_sigma <- function(y = NULL, # nolint
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    sc[, lav_matrix_vech_which_idx(n = p_1, idx = x_idx)] <- 0
+    sc[, lav_mat_vech_which_idx(n = p_1, idx = x_idx)] <- 0
   }
 
   sc
 }
 
 # 3c: casewise scores with respect to mu + vech(Sigma)
-lav_mvnorm_missing_scores_mu_vech_sigma <- function(y = NULL, # nolint
+lav_mvn_mi_sc_mu_sigma <- function(y = NULL,
                                                     mp = NULL,
                                                     wt = NULL,
                                                     mu = NULL,
@@ -874,22 +874,22 @@ lav_mvnorm_missing_scores_mu_vech_sigma <- function(y = NULL, # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # for the tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(p_1)
-  idx2 <- lav_matrix_vech_row_idx(p_1)
+  idx1 <- lav_mat_vech_col_idx(p_1)
+  idx2 <- lav_mat_vech_row_idx(p_1)
 
   # vech(Sigma.inv)
-  i_sigma <- lav_matrix_vech(sigma_inv)
+  i_sigma <- lav_mat_vech(sigma_inv)
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # subtract Mu
@@ -914,13 +914,13 @@ lav_mvnorm_missing_scores_mu_vech_sigma <- function(y = NULL, # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
       tmp <- matrix(0, p_1, p_1)
       tmp[var_idx, var_idx] <- sigma_inv_1
-      isigma <- lav_matrix_vech(tmp)
+      isigma <- lav_mat_vech(tmp)
     } else {
       sigma_inv_1 <- sigma_inv
       isigma <- i_sigma
@@ -941,7 +941,7 @@ lav_mvnorm_missing_scores_mu_vech_sigma <- function(y = NULL, # nolint
   }
 
   # adjust for vech
-  sc[, lav_matrix_diagh_idx(p_1)] <- sc[, lav_matrix_diagh_idx(p_1)] / 2
+  sc[, lav_mat_diagh_idx(p_1)] <- sc[, lav_mat_diagh_idx(p_1)] / 2
 
   out <- cbind(dmu, sc)
 
@@ -952,7 +952,7 @@ lav_mvnorm_missing_scores_mu_vech_sigma <- function(y = NULL, # nolint
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    not_x <- lav_matrix_vech_which_idx(n = p_1, idx = x_idx,
+    not_x <- lav_mat_vech_which_idx(n = p_1, idx = x_idx,
                                        #diagonal = !correlation,
                                        add_idx_at_start = TRUE)
     out[, not_x] <- 0
@@ -963,7 +963,7 @@ lav_mvnorm_missing_scores_mu_vech_sigma <- function(y = NULL, # nolint
 
 
 # 4) Hessian of logl
-lav_mvnorm_missing_logl_hessian_data <- function(y = NULL, # nolint
+lav_mvn_mi_logl_hessian_data <- function(y = NULL,
                                                  mp = NULL,
                                                  wt = NULL,
                                                  mu = NULL,
@@ -972,7 +972,7 @@ lav_mvnorm_missing_logl_hessian_data <- function(y = NULL, # nolint
                                                  sinv_method = "eigen",
                                                  sigma_inv = NULL) {
   # missing patterns
-  yp <- lav_samplestats_missing_patterns(y = y, mp = mp, wt = wt)
+  yp <- lav_samp_mi_patterns(y = y, mp = mp, wt = wt)
 
   lav_mvnorm_missing_logl_hessian_samplestats(
     yp = yp, mu = mu,
@@ -993,7 +993,7 @@ lav_mvnorm_missing_logl_hessian_samplestats <- # nolint
     p_1 <- length(yp[[1]]$var.idx)
 
     if (is.null(sigma_inv)) {
-      sigma_inv <- lav_matrix_symmetric_inverse(
+      sigma_inv <- lav_mat_sym_inverse(
         s = sigma_1, logdet = FALSE,
         sinv_method = sinv_method
       )
@@ -1014,7 +1014,7 @@ lav_mvnorm_missing_logl_hessian_samplestats <- # nolint
 
       # invert Sigma for this pattern
       if (length(na_idx) > 0L) {
-        sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+        sigma_inv_1 <- lav_mat_sym_inverse_update(
           s_inv = sigma_inv,
           rm_idx = na_idx, logdet = FALSE
         )
@@ -1036,11 +1036,11 @@ lav_mvnorm_missing_logl_hessian_samplestats <- # nolint
       tmp22[var_idx, var_idx] <- aaa
 
       i11 <- s_inv
-      i21 <- lav_matrix_duplication_pre(tmp21 %x% s_inv)
+      i21 <- lav_mat_dup_pre(tmp21 %x% s_inv)
       # if (lav_use_lavaanC()) {
       #   i22 <- lavaanC::m_kronecker_dup_pre_post(S.inv, tmp22, 0.5)
       # } else {
-        i22 <- (1 / 2) * lav_matrix_duplication_pre_post(s_inv %x% tmp22)
+        i22 <- (1 / 2) * lav_mat_dup_pre_post(s_inv %x% tmp22)
       # }
       h11 <- h11 + pat_freq * i11
       h21 <- h21 + pat_freq * i21
@@ -1056,7 +1056,7 @@ lav_mvnorm_missing_logl_hessian_samplestats <- # nolint
 
     # fixed.x?
     if (length(x_idx) > 0L) {
-      not_x <- lav_matrix_vech_which_idx(n = p_1, idx = x_idx,
+      not_x <- lav_mat_vech_which_idx(n = p_1, idx = x_idx,
                                          #diagonal = !correlation,
                                          add_idx_at_start = TRUE)
       out[, not_x] <- 0
@@ -1074,7 +1074,7 @@ lav_mvnorm_missing_logl_hessian_samplestats <- # nolint
 # 5a: expected unit information Mu and vech(Sigma)
 #     (only useful under MCAR)
 # (old term: Abeta, expected)
-lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
+lav_mvn_mi_info_expected <- function(y = NULL,
                                                     mp = NULL,
                                                     wt = NULL,
                                                     mu = NULL, # unused
@@ -1085,7 +1085,7 @@ lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
   p_1 <- NCOL(y)
 
   if (is.null(sigma_inv)) {
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -1093,7 +1093,7 @@ lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # N
@@ -1120,7 +1120,7 @@ lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
@@ -1134,7 +1134,7 @@ lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
     # if (lav_use_lavaanC()) {
     #   S2.inv <- lavaanC::m_kronecker_dup_pre_post(S.inv, multiplicator = 0.5)
     # } else {
-      s2_inv <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+      s2_inv <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
     # }
 
     if (!is.null(wt)) {
@@ -1147,11 +1147,11 @@ lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
     i22 <- i22 + freq * s2_inv
   }
 
-  out <- lav_matrix_bdiag(i11, i22) / n
+  out <- lav_mat_bdiag(i11, i22) / n
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    not_x <- lav_matrix_vech_which_idx(n = p_1, idx = x_idx,
+    not_x <- lav_mat_vech_which_idx(n = p_1, idx = x_idx,
                                        # diagonal = !correlation,
                                        add_idx_at_start = TRUE)
     out[not_x, ] <- 0
@@ -1163,7 +1163,7 @@ lav_mvnorm_missing_information_expected <- function(y = NULL,  # nolint
 
 # 5b: unit observed information Mu and vech(Sigma) from raw data
 # (old term: Abeta, observed)
-lav_mvnorm_missing_information_observed_data <- function(y = NULL,  # nolint
+lav_mvn_mi_info_observed_data <- function(y = NULL,
                                                          mp = NULL,
                                                          wt = NULL,
                                                          mu = NULL,
@@ -1173,7 +1173,7 @@ lav_mvnorm_missing_information_observed_data <- function(y = NULL,  # nolint
                                                          sigma_inv = NULL) {
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # N
@@ -1188,7 +1188,7 @@ lav_mvnorm_missing_information_observed_data <- function(y = NULL,  # nolint
   }
 
   # observed information
-  observed <- lav_mvnorm_missing_logl_hessian_data(
+  observed <- lav_mvn_mi_logl_hessian_data(
     y = y, mp = mp, wt = wt,
     mu = mu, sigma_1 = sigma_1, x_idx = x_idx,
     sinv_method = sinv_method, sigma_inv = sigma_inv
@@ -1220,7 +1220,7 @@ lav_mvnorm_missing_information_observed_samplestats <- # nolint
 
 # 5c: unit first-order information Mu and vech(Sigma) from raw data
 # (old term: Bbeta)
-lav_mvnorm_missing_information_firstorder <- function(y = NULL,  # nolint
+lav_mvn_mi_info_firstorder <- function(y = NULL,
                                                       mp = NULL,
                                                       wt = NULL,
                                                       cluster_idx = NULL,
@@ -1231,7 +1231,7 @@ lav_mvnorm_missing_information_firstorder <- function(y = NULL,  # nolint
                                                       sigma_inv = NULL) {
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # N
@@ -1245,7 +1245,7 @@ lav_mvnorm_missing_information_firstorder <- function(y = NULL,  # nolint
     n <- sum(mp$freq) # removed empty cases!
   }
 
-  sc <- lav_mvnorm_missing_scores_mu_vech_sigma(
+  sc <- lav_mvn_mi_sc_mu_sigma(
     y = y, mp = mp, wt = wt,
     mu = mu, sigma_1 = sigma_1, x_idx = x_idx, sinv_method = sinv_method,
     sigma_inv = sigma_inv
@@ -1262,12 +1262,12 @@ lav_mvnorm_missing_information_firstorder <- function(y = NULL,  # nolint
     sc <- sc * sqrt(correction_factor)
   }
 
-  lav_matrix_crossprod(sc) / n
+  lav_mat_crossprod(sc) / n
 }
 
 # 5d: both unit first-order information and expected/observed information
 #     from raw data, in one go for efficiency
-lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
+lav_mvn_mi_info_both <- function(y = NULL,
                                                 mp = NULL,
                                                 wt = NULL,
                                                 cluster_idx = NULL,
@@ -1282,26 +1282,26 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # for the tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(p_1)
-  idx2 <- lav_matrix_vech_row_idx(p_1)
+  idx1 <- lav_mat_vech_col_idx(p_1)
+  idx2 <- lav_mat_vech_row_idx(p_1)
 
   # vech(Sigma.inv)
-  i_sigma <- lav_matrix_vech(sigma_inv)
+  i_sigma <- lav_mat_vech(sigma_inv)
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   if (information == "observed") {
-    yp <- lav_samplestats_missing_patterns(y = y, mp = mp, wt = wt)
+    yp <- lav_samp_mi_patterns(y = y, mp = mp, wt = wt)
   }
 
   # N
@@ -1344,13 +1344,13 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 
     # invert Sigma for this pattern
     if (length(na_idx) > 0L) {
-      sigma_inv_1 <- lav_matrix_symmetric_inverse_update(
+      sigma_inv_1 <- lav_mat_sym_inverse_update(
         s_inv = sigma_inv,
         rm_idx = na_idx, logdet = FALSE
       )
       tmp <- matrix(0, p_1, p_1)
       tmp[var_idx, var_idx] <- sigma_inv_1
-      isigma <- lav_matrix_vech(tmp)
+      isigma <- lav_mat_vech(tmp)
     } else {
       sigma_inv_1 <- sigma_inv
       isigma <- i_sigma
@@ -1371,7 +1371,7 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
       #   S2.inv <-
       #         lavaanC::m_kronecker_dup_pre_post(S.inv, multiplicator = 0.5)
       # } else {
-        s2_inv <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+        s2_inv <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
       # }
 
       i11_1 <- i11_1 + freq * s_inv
@@ -1390,11 +1390,11 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
       tmp22[var_idx, var_idx] <- aaa
 
       i11 <- s_inv
-      i21 <- lav_matrix_duplication_pre(tmp21 %x% s_inv)
+      i21 <- lav_mat_dup_pre(tmp21 %x% s_inv)
       # if (lav_use_lavaanC()) {
       #   i22 <- lavaanC::m_kronecker_dup_pre_post(S.inv, tmp22, 0.5)
       # } else {
-        i22 <- (1 / 2) * lav_matrix_duplication_pre_post(s_inv %x% tmp22)
+        i22 <- (1 / 2) * lav_mat_dup_pre_post(s_inv %x% tmp22)
       # }
 
       i11_1 <- i11_1 + pat_freq * i11
@@ -1417,7 +1417,7 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
   }
 
   # adjust for vech
-  sc[, lav_matrix_diagh_idx(p_1)] <- sc[, lav_matrix_diagh_idx(p_1)] / 2
+  sc[, lav_mat_diagh_idx(p_1)] <- sc[, lav_mat_diagh_idx(p_1)] / 2
 
   # add dmu
   sc <- cbind(dmu, sc)
@@ -1429,7 +1429,7 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    not_x <- lav_matrix_vech_which_idx(n = p_1, idx = x_idx,
+    not_x <- lav_mat_vech_which_idx(n = p_1, idx = x_idx,
                                        #diagonal = !correlation,
                                        add_idx_at_start = TRUE)
     sc[, not_x] <- 0
@@ -1447,11 +1447,11 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
   }
 
   # first order information
-  bbeta <- lav_matrix_crossprod(sc) / n
+  bbeta <- lav_mat_crossprod(sc) / n
 
   # expected/observed information
   if (information == "expected") {
-    abeta <- lav_matrix_bdiag(i11_1, i22_1) / n
+    abeta <- lav_mat_bdiag(i11_1, i22_1) / n
   } else {
     abeta <- rbind(
       cbind(i11_1, t(i21_1)),
@@ -1461,7 +1461,7 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 
   # fixed.x?
   if (length(x_idx) > 0L) {
-    not_x <- lav_matrix_vech_which_idx(n = p_1, idx = x_idx,
+    not_x <- lav_mat_vech_which_idx(n = p_1, idx = x_idx,
                                        # diagonal = !correlation,
                                        add_idx_at_start = TRUE)
     abeta[not_x, ] <- 0
@@ -1485,7 +1485,7 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 #
 #    # missing patterns
 #    if(is.null(Mp)) {
-#        Mp <- lav_data_missing_patterns(Y)
+#        Mp <- lav_data_mi_patterns(Y)
 #    }
 #
 #    # N
@@ -1502,13 +1502,13 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 #
 #        sigma <- matrix(0, P, P)
 #        sigma[var.idx, var.idx] <- Sigma[var.idx, var.idx]
-#        sigma2 <- 2 * lav_matrix_duplication_ginv_pre_post(sigma %x% sigma)
+#        sigma2 <- 2 * lav_mat_dup_ginv_pre_post(sigma %x% sigma)
 #
 #        I11 <- I11 + Mp$freq[p] * sigma
 #        I22 <- I22 + Mp$freq[p] * sigma2
 #    }
 #
-#    lav_matrix_bdiag(I11, I22)/N
+#    lav_mat_bdiag(I11, I22)/N
 # }
 
 #    6b: /
@@ -1532,7 +1532,7 @@ lav_mvnorm_missing_information_both <- function(y = NULL, # nolint
 
 # single imputation missing cells, under the normal model, pattern-based
 # FIXME: add wt
-lav_mvnorm_missing_impute_pattern <- function(y = NULL, # nolint
+lav_mvn_mi_impute_pattern <- function(y = NULL,
                                               mp = NULL,
                                               mu = NULL,
                                               sigma_1 = NULL,
@@ -1545,12 +1545,12 @@ lav_mvnorm_missing_impute_pattern <- function(y = NULL, # nolint
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -1577,7 +1577,7 @@ lav_mvnorm_missing_impute_pattern <- function(y = NULL, # nolint
 
     # invert Sigma (Sigma_22, observed part only) for this pattern
     sigma_22_inv <- try(
-      lav_matrix_symmetric_inverse_update(
+      lav_mat_sym_inverse_update(
         s_inv = sigma_inv, rm_idx = na_idx, logdet = FALSE
       ),
       silent = TRUE
@@ -1600,7 +1600,7 @@ lav_mvnorm_missing_impute_pattern <- function(y = NULL, # nolint
 
 # E-step: expectations of sum, sum of squares, sum of crossproducts
 # plus correction
-lav_mvnorm_missing_estep <- function(y = NULL,
+lav_mvn_mi_estep <- function(y = NULL,
                                      mp = NULL,
                                      wt = NULL,
                                      mu = NULL,
@@ -1612,12 +1612,12 @@ lav_mvnorm_missing_estep <- function(y = NULL,
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   if (is.null(sigma_inv)) {
     # invert Sigma
-    sigma_inv <- lav_matrix_symmetric_inverse(
+    sigma_inv <- lav_mat_sym_inverse(
       s = sigma_1, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -1659,7 +1659,7 @@ lav_mvnorm_missing_estep <- function(y = NULL,
 
     # invert Sigma (Sigma_22, observed part only) for this pattern
     sigma_22_inv <- try(
-      lav_matrix_symmetric_inverse_update(
+      lav_mat_sym_inverse_update(
         s_inv = sigma_inv, rm_idx = na_idx, logdet = FALSE
       ),
       silent = TRUE

--- a/R/lav_mvnorm_missing_h1.R
+++ b/R/lav_mvnorm_missing_h1.R
@@ -8,7 +8,7 @@
 
 # here, we estimate Mu and Sigma from Y with missing values, assuming normality
 # this is a rewrite of the 'estimate.moments.EM' function in <= 0.5-22
-lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
+lav_mvn_mi_h1_est_moments <- function(y = NULL,
                                                    mp = NULL,
                                                    yp = NULL,
                                                    wt = NULL,
@@ -26,10 +26,10 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
 
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
   if (is.null(yp)) {
-    yp <- lav_samplestats_missing_patterns(y = y, mp = mp, wt = wt)
+    yp <- lav_samp_mi_patterns(y = y, mp = mp, wt = wt)
   }
 
   # covariances with zero coverage (perhaps planned?)
@@ -64,7 +64,7 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
   # verbose?
   if (lav_verbose()) {
     cat("\n")
-    cat("lav_mvnorm_missing_h1_estimate_moments: start EM steps\n")
+    cat("lav_mvn_mi_h1_est_moments: start EM steps\n")
   }
 
   # starting values; zero covariances to guarantee a pd matrix
@@ -102,7 +102,7 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
   # report
   if (lav_verbose()) {
     # fx0 <- lav_model_objective_fiml(Sigma.hat=Sigma, Mu.hat=Mu, M=Yp)
-    fx0 <- lav_mvnorm_missing_loglik_samplestats(
+    fx0 <- lav_mvn_mi_loglik_samp(
       yp = yp,
       mu = mu, sigma_1 = sigma_1,
       log2pi = FALSE,
@@ -118,7 +118,7 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
   # EM steps
   for (i in 1:max_iter) {
     # E-step
-    estep <- lav_mvnorm_missing_estep(
+    estep <- lav_mvn_mi_estep(
       y = y, mp = mp, wt = wt,
       mu = mu, sigma_1 = sigma_1,
       sinv_method = sinv_method
@@ -144,13 +144,13 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
     }
 
     # max absolute difference in parameter values
-    mm_delta <- max(abs(c(mu, lav_matrix_vech(sigma_1)) -
-      c(mu0, lav_matrix_vech(sigma0))))
+    mm_delta <- max(abs(c(mu, lav_mat_vech(sigma_1)) -
+      c(mu0, lav_mat_vech(sigma0))))
 
     # report fx
     if (lav_verbose()) {
       # fx <- lav_model_objective_fiml(Sigma.hat=Sigma, Mu.hat=Mu, M=Yp)
-      fx <- lav_mvnorm_missing_loglik_samplestats(
+      fx <- lav_mvn_mi_loglik_samp(
         yp = yp,
         mu = mu, sigma_1 = sigma_1,
         log2pi = FALSE,
@@ -185,7 +185,7 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
   # compute fx if we haven't already
   if (!lav_verbose()) {
     # fx <- lav_model_objective_fiml(Sigma.hat = Sigma, Mu.hat = Mu, M = Yp)
-    fx <- lav_mvnorm_missing_loglik_samplestats(
+    fx <- lav_mvn_mi_loglik_samp(
       yp = yp,
       mu = mu, sigma_1 = sigma_1,
       log2pi = FALSE,
@@ -218,7 +218,7 @@ lav_mvnorm_missing_h1_estimate_moments <- function(y = NULL,    # nolint
 # plain FIML and nlminb() instead
 #
 # single level only
-lav_mvnorm_missing_h1_estimate_moments_chol <- function(lavdata = NULL, # nolint
+lav_mvn_mi_h1_est_moments_chol <- function(lavdata = NULL,
                                                         lavsamplestats = NULL,
                                                         lavoptions = NULL,
                                                         group = 1L) {
@@ -230,7 +230,7 @@ lav_mvnorm_missing_h1_estimate_moments_chol <- function(lavdata = NULL, # nolint
 
   # construct unrestricted partable (using chol parameterization)
   # for this group only
-  lavpartable <- lav_partable_unrestricted_chol(
+  lavpartable <- lav_pt_unrestricted_chol(
                              lavdata = lavdata, lavoptions = lavoptions,
                              lavpta = NULL, group = group)
 
@@ -270,7 +270,7 @@ lav_mvnorm_missing_h1_estimate_moments_chol <- function(lavdata = NULL, # nolint
 # in the literature: - `Omega_{SW}'
 #                    - `Gamma for incomplete data'
 #                    - (N times the) sandwich estimator for acov(mu,vech(Sigma))
-lav_mvnorm_missing_h1_omega_sw <- function(y = NULL,
+lav_mvn_mi_h1_omega_sw <- function(y = NULL,
                                            mp = NULL,
                                            wt = NULL,
                                            cluster_idx = NULL,
@@ -283,23 +283,23 @@ lav_mvnorm_missing_h1_omega_sw <- function(y = NULL,
                                            information = "observed") {
   # missing patterns
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y)
+    mp <- lav_data_mi_patterns(y)
   }
 
   # sample stats per pattern
   if (is.null(yp) && (information == "observed" || is.null(sigma_1))) {
-    yp <- lav_samplestats_missing_patterns(y = y, mp = mp, wt = wt)
+    yp <- lav_samp_mi_patterns(y = y, mp = mp, wt = wt)
   }
 
   # Sigma and Mu
   if (is.null(sigma_1) || is.null(mu)) {
-    out <- lav_mvnorm_missing_h1_estimate_moments(y = y, mp = mp, yp = yp)
+    out <- lav_mvn_mi_h1_est_moments(y = y, mp = mp, yp = yp)
     mu <- out$Mu
     sigma_1 <- out$Sigma
   }
 
   # information matrices
-  info <- lav_mvnorm_missing_information_both(
+  info <- lav_mvn_mi_info_both(
     y = y, mp = mp, mu = mu,
     wt = wt, cluster_idx = cluster_idx,
     sigma_1 = sigma_1, x_idx = x_idx, sinv_method = sinv_method,
@@ -307,7 +307,7 @@ lav_mvnorm_missing_h1_omega_sw <- function(y = NULL,
   )
 
   a <- info$Abeta
-  a_inv <- lav_matrix_symmetric_inverse(
+  a_inv <- lav_mat_sym_inverse(
     s = a, logdet = FALSE,
     sinv_method = sinv_method
   )

--- a/R/lav_mvreg.R
+++ b/R/lav_mvreg.R
@@ -48,7 +48,7 @@ lav_mvreg_loglik_data <- function(y = NULL,
       res <- y - x %*% beta_1
       dist_1 <- rowSums((res %*% ic_s)^2)
     } else {
-      res_cov_inv <- lav_matrix_symmetric_inverse(
+      res_cov_inv <- lav_mat_sym_inverse(
         s = res_cov, logdet = TRUE,
         sinv_method = sinv_method
       )
@@ -61,7 +61,7 @@ lav_mvreg_loglik_data <- function(y = NULL,
     loglik <- -(q_1 * log_2pi + logdet + dist_1) / 2
   } else {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = TRUE,
       sinv_method = sinv_method
     )
@@ -78,7 +78,7 @@ lav_mvreg_loglik_data <- function(y = NULL,
 
 
 # 2b. input are sample statistics (res.int, res.slopes, res.cov, N) only
-lav_mvreg_loglik_samplestats <- function(sample_res_int = NULL,
+lav_mvreg_loglik_samp <- function(sample_res_int = NULL,
                                          sample_res_slopes = NULL,
                                          sample_res_cov = NULL,
                                          sample_mean_x = NULL,
@@ -113,7 +113,7 @@ lav_mvreg_loglik_samplestats <- function(sample_res_int = NULL,
 
   # res.cov.inv
   if (is.null(res_cov_inv)) {
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = TRUE,
       sinv_method = sinv_method
     )
@@ -164,7 +164,7 @@ lav_mvreg_dlogl_dbeta <- function(y = NULL,
   # res.cov.inv
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -200,7 +200,7 @@ lav_mvreg_dlogl_drescov <- function(y = NULL,
   # res.cov.in
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -240,7 +240,7 @@ lav_mvreg_dlogl_dvechrescov <- function(y = NULL,
   # res.cov.inv
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -255,8 +255,8 @@ lav_mvreg_dlogl_dvechrescov <- function(y = NULL,
   # derivative
   dres_cov <- -(n / 2) * (res_cov_inv -
                          (res_cov_inv %*% w_tilde %*% res_cov_inv))
-  dvechres_cov <- as.numeric(lav_matrix_duplication_pre(
-    as.matrix(lav_matrix_vec(dres_cov))
+  dvechres_cov <- as.numeric(lav_mat_dup_pre(
+    as.matrix(lav_mat_vec(dres_cov))
   ))
 
   dvechres_cov
@@ -267,7 +267,7 @@ lav_mvreg_dlogl_dvechrescov <- function(y = NULL,
 
 # 3a: casewise scores with respect to Beta (=intercepts and slopes)
 #     column order: Y1_int, Y1_x1, Y1_x2, ...| Y2_int, Y2_x1, Y2_x2, ... |
-lav_mvreg_scores_beta <- function(y = NULL,
+lav_mvreg_sc_beta <- function(y = NULL,
                                   exo = NULL,
                                   beta_1 = NULL,
                                   res_int = NULL,
@@ -288,7 +288,7 @@ lav_mvreg_scores_beta <- function(y = NULL,
   # res.cov.inv
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -308,7 +308,7 @@ lav_mvreg_scores_beta <- function(y = NULL,
 
 
 # 3b: casewise scores with respect to vech(res.cov)
-lav_mvreg_scores_vech_sigma <- function(y = NULL,
+lav_mvreg_sc_sigma <- function(y = NULL,
                                         exo = NULL,
                                         beta_1 = NULL,
                                         res_int = NULL,
@@ -328,14 +328,14 @@ lav_mvreg_scores_vech_sigma <- function(y = NULL,
   # res.cov.inv
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # vech(res.cov.inv)
-  isigma <- lav_matrix_vech(res_cov_inv)
+  isigma <- lav_mat_vech(res_cov_inv)
 
   # subtract X %*% Beta
   res <- y - x %*% beta_1
@@ -344,22 +344,22 @@ lav_mvreg_scores_vech_sigma <- function(y = NULL,
   res <- res %*% res_cov_inv
 
   # tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(q_1)
-  idx2 <- lav_matrix_vech_row_idx(q_1)
+  idx1 <- lav_mat_vech_col_idx(q_1)
+  idx2 <- lav_mat_vech_row_idx(q_1)
   z <- res[, idx1] * res[, idx2]
 
   # subtract isigma from each row
   sc <- t(t(z) - isigma)
 
   # adjust for vech (and avoiding the 1/2 factor)
-  sc[, lav_matrix_diagh_idx(q_1)] <- sc[, lav_matrix_diagh_idx(q_1)] / 2
+  sc[, lav_mat_diagh_idx(q_1)] <- sc[, lav_mat_diagh_idx(q_1)] / 2
 
   sc
 }
 
 
 # 3c: casewise scores with respect to beta + vech(res.cov)
-lav_mvreg_scores_beta_vech_sigma <- function(y = NULL,      # nolint
+lav_mvreg_sc_beta_sigma <- function(y = NULL,
                                              exo = NULL,
                                              beta_1 = NULL,
                                              res_int = NULL,
@@ -380,14 +380,14 @@ lav_mvreg_scores_beta_vech_sigma <- function(y = NULL,      # nolint
   # res.cov.inv
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
   }
 
   # vech(res.cov.inv)
-  isigma <- lav_matrix_vech(res_cov_inv)
+  isigma <- lav_mat_vech(res_cov_inv)
 
   # subtract X %*% Beta
   res <- y - x %*% beta_1
@@ -399,15 +399,15 @@ lav_mvreg_scores_beta_vech_sigma <- function(y = NULL,      # nolint
     res[, rep(1:q_1, each = p), drop = FALSE]
 
   # tcrossprod
-  idx1 <- lav_matrix_vech_col_idx(q_1)
-  idx2 <- lav_matrix_vech_row_idx(q_1)
+  idx1 <- lav_mat_vech_col_idx(q_1)
+  idx2 <- lav_mat_vech_row_idx(q_1)
   z <- res[, idx1] * res[, idx2]
 
   # subtract isigma from each row
   sc <- t(t(z) - isigma)
 
   # adjust for vech (and avoiding the 1/2 factor)
-  sc[, lav_matrix_diagh_idx(q_1)] <- sc[, lav_matrix_diagh_idx(q_1)] / 2
+  sc[, lav_mat_diagh_idx(q_1)] <- sc[, lav_mat_diagh_idx(q_1)] / 2
 
   cbind(sc_beta, sc)
 }
@@ -427,7 +427,7 @@ lav_mvreg_logl_hessian_data <- function(y = NULL,
   n <- NROW(y)
 
   # observed information
-  observed <- lav_mvreg_information_observed_data(
+  observed <- lav_mvreg_info_observed_data(
     y = y, exo = exo,
     beta_1 = beta_1, res_int = res_int, res_slopes = res_slopes,
     res_cov = res_cov, res_cov_inv = res_cov_inv,
@@ -439,7 +439,7 @@ lav_mvreg_logl_hessian_data <- function(y = NULL,
 }
 
 # 4b. hessian logl Beta and vech(res.cov) from samplestats
-lav_mvreg_logl_hessian_samplestats <- function(  # nolint
+lav_mvreg_logl_hessian_samp <- function(
       sample_res_int = NULL,
       sample_res_slopes = NULL,
       sample_res_cov = NULL,
@@ -472,7 +472,7 @@ lav_mvreg_logl_hessian_samplestats <- function(  # nolint
 # Information h0
 
 # 5a: unit expected information h0 Beta and vech(res.cov)
-lav_mvreg_information_expected <- function(y = NULL, # not used
+lav_mvreg_info_expected <- function(y = NULL, # not used
                                            exo = NULL, # not used
                                            sample_mean_x = NULL,
                                            sample_cov_x = NULL,
@@ -488,7 +488,7 @@ lav_mvreg_information_expected <- function(y = NULL, # not used
   # res.cov.inv
   if (is.null(res_cov_inv)) {
     # invert res.cov
-    res_cov_inv <- lav_matrix_symmetric_inverse(
+    res_cov_inv <- lav_mat_sym_inverse(
       s = res_cov, logdet = FALSE,
       sinv_method = sinv_method
     )
@@ -506,7 +506,7 @@ lav_mvreg_information_expected <- function(y = NULL, # not used
     sample_mean_x <- base::.colMeans(exo, m = NROW(exo), n = NCOL(exo))
   }
   if (is.null(sample_cov_x)) {
-    sample_cov_x <- lav_matrix_cov(exo)
+    sample_cov_x <- lav_mat_cov(exo)
   }
 
   # construct sample.xx = 1/N*crossprod(X1) (including intercept)
@@ -523,14 +523,14 @@ lav_mvreg_information_expected <- function(y = NULL, # not used
   # if (lav_use_lavaanC()) {
   #   I22 <- lavaanC::m_kronecker_dup_pre_post(res.cov.inv, multiplicator = 0.5)
   # } else {
-    i22 <- 0.5 * lav_matrix_duplication_pre_post(res_cov_inv %x% res_cov_inv)
+    i22 <- 0.5 * lav_mat_dup_pre_post(res_cov_inv %x% res_cov_inv)
   # }
 
-  lav_matrix_bdiag(i11, i22)
+  lav_mat_bdiag(i11, i22)
 }
 
 # 5b: unit observed information h0
-lav_mvreg_information_observed_data <- function(y = NULL,          # nolint
+lav_mvreg_info_observed_data <- function(y = NULL,
                                                 exo = NULL, # no int
                                                 beta_1 = NULL, # int+slopes
                                                 res_int = NULL,
@@ -551,7 +551,7 @@ lav_mvreg_information_observed_data <- function(y = NULL,          # nolint
   sample_res_slopes <- t(sample_b[-1, , drop = FALSE]) # transpose!
   sample_res_cov <- cov(qr.resid(qr_1, y)) * (n - 1) / n
   sample_mean_x <- base::.colMeans(exo, m = NROW(exo), n = NCOL(exo))
-  sample_cov_x <- lav_matrix_cov(exo)
+  sample_cov_x <- lav_mat_cov(exo)
 
   lav_mvreg_information_observed_samplestats(
     sample_res_int = sample_res_int,
@@ -600,14 +600,14 @@ lav_mvreg_information_observed_samplestats <-               # nolint
     # res.cov.inv
     if (is.null(res_cov_inv)) {
       # invert res.cov
-      res_cov_inv <- lav_matrix_symmetric_inverse(
+      res_cov_inv <- lav_mat_sym_inverse(
         s = res_cov, logdet = FALSE,
         sinv_method = sinv_method
       )
     }
 
     h11 <- res_cov_inv %x% sample_xx
-    h21 <- lav_matrix_duplication_pre(res_cov_inv %x%
+    h21 <- lav_mat_dup_pre(res_cov_inv %x%
       (res_cov_inv %*% (crossprod(sample_b - beta_1, sample_xx))))
     h12 <- t(h21)
 
@@ -615,7 +615,7 @@ lav_mvreg_information_observed_samplestats <-               # nolint
     # if (lav_use_lavaanC()) {
     #   H22 <- lavaanC::m_kronecker_dup_pre_post(res.cov.inv, AAA, 0.5)
     # } else {
-      h22 <- (1 / 2) * lav_matrix_duplication_pre_post(res_cov_inv %x% aaa)
+      h22 <- (1 / 2) * lav_mat_dup_pre_post(res_cov_inv %x% aaa)
     # }
 
     out <- rbind(
@@ -627,7 +627,7 @@ lav_mvreg_information_observed_samplestats <-               # nolint
 
 
 # 5c: unit first-order information h0
-lav_mvreg_information_firstorder <- function(y = NULL,        # nolint
+lav_mvreg_info_firstorder <- function(y = NULL,
                                              exo = NULL, # no int
                                              beta_1 = NULL, # int+slopes
                                              res_int = NULL,
@@ -638,7 +638,7 @@ lav_mvreg_information_firstorder <- function(y = NULL,        # nolint
   n <- NROW(y)
 
   # scores
-  sc <- lav_mvreg_scores_beta_vech_sigma(
+  sc <- lav_mvreg_sc_beta_sigma(
     y = y, exo = exo, beta_1 = beta_1,
     res_int = res_int, res_slopes = res_slopes, res_cov = res_cov,
     sinv_method = sinv_method, res_cov_inv = res_cov_inv

--- a/R/lav_mvreg_cluster.R
+++ b/R/lav_mvreg_cluster.R
@@ -12,7 +12,7 @@
 # - beta.w: beta y within part
 # - beta.b: beta y between part
 # - beta.z: beta z (between-only)
-lav_mvreg_cluster_implied22l <- function(lp = NULL,
+lav_mvreg_cl_implied22l <- function(lp = NULL,
                                          implied = NULL,
                                          res_int_w = NULL,
                                          res_int_b = NULL,
@@ -114,7 +114,7 @@ lav_mvreg_cluster_implied22l <- function(lp = NULL,
 
 
 # recreate implied matrices from 2L matrices
-lav_mvreg_cluster_2l2implied <- function(lp,
+lav_mvreg_cl_2l2implied <- function(lp,
                                          sigma_w = NULL,
                                          sigma_b = NULL,
                                          sigma_zz = NULL,
@@ -190,7 +190,7 @@ lav_mvreg_cluster_2l2implied <- function(lp,
   implied
 }
 
-lav_mvreg_cluster_loglik_samplestats_2l <- function(ylp = NULL,   # nolint
+lav_mvreg_cl_loglik_samp_2l <- function(ylp = NULL,
                                                     lp = NULL,
                                                     res_sigma_w = NULL,
                                                     res_int_w = NULL,
@@ -204,7 +204,7 @@ lav_mvreg_cluster_loglik_samplestats_2l <- function(ylp = NULL,   # nolint
                                                     minus_two = TRUE) {
   # map implied to 2l matrices
   if (is.null(out)) {
-    out <- lav_mvreg_cluster_implied22l(
+    out <- lav_mvreg_cl_implied22l(
       lp = lp, implied = NULL,
       res_sigma_w = res_sigma_w,
       res_int_w = res_int_w, res_pi_w = res_pi_w,
@@ -275,13 +275,13 @@ lav_mvreg_cluster_loglik_samplestats_2l <- function(ylp = NULL,   # nolint
   s_pw <- (y1y1_wb_res - y2y2w_res) / sum(cluster_size - 1)
 
   # common parts:
-  sigma_w_inv <- lav_matrix_symmetric_inverse(
+  sigma_w_inv <- lav_mat_sym_inverse(
     s = sigma_w,
     logdet = TRUE
   )
   sigma_w_logdet <- attr(sigma_w_inv, "logdet")
   if (length(between_y_idx) > 0L) {
-    sigma_zz_inv <- lav_matrix_symmetric_inverse(
+    sigma_zz_inv <- lav_mat_sym_inverse(
       s = sigma_zz,
       logdet = TRUE
     )
@@ -318,7 +318,7 @@ lav_mvreg_cluster_loglik_samplestats_2l <- function(ylp = NULL,   # nolint
 
     # construct sigma.j
     sigma_j <- (nj * sigma_b_z) + sigma_w
-    sigma_j_inv <- lav_matrix_symmetric_inverse(
+    sigma_j_inv <- lav_mat_sym_inverse(
       s = sigma_j,
       logdet = TRUE
     )
@@ -368,7 +368,7 @@ lav_mvreg_cluster_loglik_samplestats_2l <- function(ylp = NULL,   # nolint
 }
 
 # first derivative -2*logl wrt Beta.W, Beta.B, Sigma.W, Sigma.B
-lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
+lav_mvreg_cl_dlogl_2l_samp <- function(ylp = NULL,
                                                    lp = NULL,
                                                    res_sigma_w = NULL,
                                                    res_int_w = NULL,
@@ -381,7 +381,7 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
                                                    sinv_method = "eigen") {
   # map implied to 2l matrices
   if (is.null(out)) {
-    out <- lav_mvreg_cluster_implied22l(
+    out <- lav_mvreg_cl_implied22l(
       lp = lp, implied = NULL,
       res_sigma_w = res_sigma_w,
       res_int_w = res_int_w, res_pi_w = res_pi_w,
@@ -452,20 +452,20 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
   s_pw <- (y1y1_wb_res - y2y2w_res) / sum(cluster_size - 1)
 
   # common parts:
-  sigma_w_inv <- lav_matrix_symmetric_inverse(s = sigma_w)
+  sigma_w_inv <- lav_mat_sym_inverse(s = sigma_w)
 
   g_beta_w <- matrix(0, ncluster_sizes, length(beta_w))
   g_beta_b <- matrix(0, ncluster_sizes, length(beta_b))
   # g_beta_wb <- matrix(0, ncluster_sizes, length(beta_wb))
-  g_sigma_w1_1 <- matrix(0, ncluster_sizes, length(lav_matrix_vech(sigma_w)))
-  g_sigma_b_1 <- matrix(0, ncluster_sizes, length(lav_matrix_vech(sigma_b)))
+  g_sigma_w1_1 <- matrix(0, ncluster_sizes, length(lav_mat_vech(sigma_w)))
+  g_sigma_b_1 <- matrix(0, ncluster_sizes, length(lav_mat_vech(sigma_b)))
 
   if (length(between_y_idx) > 0L) {
     g_beta_z <- matrix(0, ncluster_sizes, length(beta_z))
-    g_sigma_zz_1 <- matrix(0, ncluster_sizes, length(lav_matrix_vech(sigma_zz)))
+    g_sigma_zz_1 <- matrix(0, ncluster_sizes, length(lav_mat_vech(sigma_zz)))
     g_sigma_yz_1 <- matrix(0, ncluster_sizes, length(sigma_yz))
 
-    sigma_zz_inv <- lav_matrix_symmetric_inverse(s = sigma_zz)
+    sigma_zz_inv <- lav_mat_sym_inverse(s = sigma_zz)
     sigma_yz_zi <- sigma_yz %*% sigma_zz_inv
     sigma_zi_zy <- t(sigma_yz_zi)
     sigma_b_z <- sigma_b - sigma_yz %*% sigma_zi_zy
@@ -488,7 +488,7 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b_z) + sigma_w
-      sigma_j_inv <- lav_matrix_symmetric_inverse(s = sigma_j)
+      sigma_j_inv <- lav_mat_sym_inverse(s = sigma_j)
       sigma_ji_yz_zi <- sigma_j_inv %*% sigma_yz_zi
       sigma_zi_zy_ji <- t(sigma_ji_yz_zi)
       sigma_ji_yz <- sigma_j_inv %*% sigma_yz
@@ -511,13 +511,13 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
       g_sigma_w1 <- ns_sigma_j_inv - j_yzj
       tmp <- g_sigma_w1 * 2
       diag(tmp) <- diag(g_sigma_w1)
-      g_sigma_w1_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_w1_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * g_sigma_w1
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZZ
       yz1 <- zz_zi_yz_ji %*% sigma_yz
@@ -528,7 +528,7 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
         nj * sigma_zz_inv %*% tmp %*% sigma_zz_inv)
       tmp <- g_sigma_zz * 2
       diag(tmp) <- diag(g_sigma_zz)
-      g_sigma_zz_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_zz_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZY
       tmp1 <- crossprod(zz_zi_yz_ji, sigma_zz_inv)
@@ -536,7 +536,7 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
       tmp3 <- ji_yz_zi
       tmp4 <- j_yzj %*% sigma_yz_zi
       g_sigma_yz <- 2 * nj * (tmp1 - tmp2 - tmp3 + tmp4)
-      g_sigma_yz_1[clz, ] <- lav_matrix_vec(g_sigma_yz)
+      g_sigma_yz_1[clz, ] <- lav_mat_vec(g_sigma_yz)
 
       # BETA.Z
       a <- (sigma_zz_inv + nj * (sigma_zi_zy_ji %*% sigma_yz_zi)) # symm!
@@ -559,12 +559,12 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
 
     d_beta_w1 <- matrix(colSums(g_beta_w), nrow(beta_w), ncol(beta_w))
     d_beta_b <- matrix(colSums(g_beta_b), nrow(beta_b), ncol(beta_b))
-    d_sigma_w1 <- lav_matrix_vech_reverse(colSums(g_sigma_w1_1))
-    d_sigma_b <- lav_matrix_vech_reverse(colSums(g_sigma_b_1))
+    d_sigma_w1 <- lav_mat_vech_rev(colSums(g_sigma_w1_1))
+    d_sigma_b <- lav_mat_vech_rev(colSums(g_sigma_b_1))
 
     # z
     d_beta_z <- matrix(colSums(g_beta_z), nrow(beta_z), ncol(beta_z))
-    d_sigma_zz <- lav_matrix_vech_reverse(colSums(g_sigma_zz_1))
+    d_sigma_zz <- lav_mat_vech_rev(colSums(g_sigma_zz_1))
     d_sigma_yz <- matrix(colSums(g_sigma_yz_1), nrow(sigma_yz), ncol(sigma_yz))
   # between.y.idx
 
@@ -580,7 +580,7 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b) + sigma_w
-      sigma_j_inv <- lav_matrix_symmetric_inverse(s = sigma_j)
+      sigma_j_inv <- lav_mat_sym_inverse(s = sigma_j)
 
       # common part
       j_yyj <- nj * sigma_j_inv %*% y2yc_yy %*% sigma_j_inv
@@ -589,13 +589,13 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
       g_sigma_w1 <- (n_s[clz] * sigma_j_inv) - j_yyj
       tmp <- g_sigma_w1 * 2
       diag(tmp) <- diag(g_sigma_w1)
-      g_sigma_w1_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_w1_1[clz, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * g_sigma_w1
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[clz, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[clz, ] <- lav_mat_vech(tmp)
 
       # BETA.W (between part only) + BETA.B
       out_b <- -1 * xx_y2_diff %*% sigma_j_inv
@@ -608,8 +608,8 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
 
     d_beta_w1 <- matrix(colSums(g_beta_w), nrow(beta_w), ncol(beta_w))
     d_beta_b <- matrix(colSums(g_beta_b), nrow(beta_b), ncol(beta_b))
-    d_sigma_w1 <- lav_matrix_vech_reverse(colSums(g_sigma_w1_1))
-    d_sigma_b <- lav_matrix_vech_reverse(colSums(g_sigma_b_1))
+    d_sigma_w1 <- lav_mat_vech_rev(colSums(g_sigma_w1_1))
+    d_sigma_b <- lav_mat_vech_rev(colSums(g_sigma_b_1))
 
     # z
     d_beta_z <- matrix(0, 0L, 0L)
@@ -633,7 +633,7 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
   d_beta_w <- d_beta_w1 + d_beta_w2
 
   # rearrange
-  dimplied <- lav_mvreg_cluster_2l2implied(lp,
+  dimplied <- lav_mvreg_cl_2l2implied(lp,
     sigma_w = d_sigma_w, sigma_b = d_sigma_b,
     sigma_zz = d_sigma_zz, sigma_yz = d_sigma_yz,
     beta_w = d_beta_w, beta_b = d_beta_b, beta_z = d_beta_z
@@ -646,17 +646,17 @@ lav_mvreg_cluster_dlogl_2l_samplestats <- function(ylp = NULL,          # nolint
   # as a single vector
   out <- c(
     drop(dimplied$res.int[[1]]),
-    lav_matrix_vec(dimplied$res.slopes[[1]]),
-    lav_matrix_vech(dimplied$res.cov[[1]]),
+    lav_mat_vec(dimplied$res.slopes[[1]]),
+    lav_mat_vech(dimplied$res.cov[[1]]),
     drop(dimplied$res.int[[2]]),
-    lav_matrix_vec(dimplied$res.slopes[[2]]),
-    lav_matrix_vech(dimplied$res.cov[[2]])
+    lav_mat_vec(dimplied$res.slopes[[2]]),
+    lav_mat_vech(dimplied$res.cov[[2]])
   )
   out
 }
 
 # cluster-wise scores -2*logl wrt Beta.W, Beta.B, Sigma.W, Sigma.B
-lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
+lav_mvreg_cl_sc_2l <- function(y1 = NULL,
                                         ylp = NULL,
                                         lp = NULL,
                                         res_sigma_w = NULL,
@@ -669,7 +669,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
                                         sinv_method = "eigen") {
   # map implied to 2l matrices
   if (is.null(out)) {
-    out <- lav_mvreg_cluster_implied22l(
+    out <- lav_mvreg_cl_implied22l(
       lp = lp, implied = NULL,
       res_sigma_w = res_sigma_w,
       res_int_w = res_int_w, res_pi_w = res_pi_w,
@@ -747,21 +747,21 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
   }
 
   # common parts:
-  sigma_w_inv <- lav_matrix_symmetric_inverse(s = sigma_w)
+  sigma_w_inv <- lav_mat_sym_inverse(s = sigma_w)
 
   g_beta_w1 <- matrix(0, nclusters, length(beta_w))
   g_beta_b <- matrix(0, nclusters, length(beta_b))
   # g_beta_wb <- matrix(0, nclusters, length(beta_wb))
-  g_sigma_w1_1 <- matrix(0, nclusters, length(lav_matrix_vech(sigma_w)))
-  g_sigma_b_1 <- matrix(0, nclusters, length(lav_matrix_vech(sigma_b)))
+  g_sigma_w1_1 <- matrix(0, nclusters, length(lav_mat_vech(sigma_w)))
+  g_sigma_b_1 <- matrix(0, nclusters, length(lav_mat_vech(sigma_b)))
 
 
   if (length(between_y_idx) > 0L) {
     g_beta_z <- matrix(0, nclusters, length(beta_z))
-    g_sigma_zz_1 <- matrix(0, nclusters, length(lav_matrix_vech(sigma_zz)))
+    g_sigma_zz_1 <- matrix(0, nclusters, length(lav_mat_vech(sigma_zz)))
     g_sigma_yz_1 <- matrix(0, nclusters, length(sigma_yz))
 
-    sigma_zz_inv <- lav_matrix_symmetric_inverse(s = sigma_zz)
+    sigma_zz_inv <- lav_mat_sym_inverse(s = sigma_zz)
     sigma_yz_zi <- sigma_yz %*% sigma_zz_inv
     sigma_zi_zy <- t(sigma_yz_zi)
     sigma_b_z <- sigma_b - sigma_yz %*% sigma_zi_zy
@@ -782,7 +782,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b_z) + sigma_w
-      sigma_j_inv <- lav_matrix_symmetric_inverse(s = sigma_j)
+      sigma_j_inv <- lav_mat_sym_inverse(s = sigma_j)
       sigma_ji_yz_zi <- sigma_j_inv %*% sigma_yz_zi
       sigma_zi_zy_ji <- t(sigma_ji_yz_zi)
       sigma_ji_yz <- sigma_j_inv %*% sigma_yz
@@ -801,20 +801,20 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
       g_sigma_w1 <- sigma_j_inv - j_yzj
       tmp <- g_sigma_w1 * 2
       diag(tmp) <- diag(g_sigma_w1)
-      g_sigma_w1_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_w1_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.W (within part)
       # g.sigma.w2 <- ( (nj-1) * sigma.w.inv
       #    - sigma.w.inv %*% (crossprod(Y1m) - nj*Y2Yc.yy) %*% sigma.w.inv )
       # tmp <- g.sigma.w2*2; diag(tmp) <- diag(g.sigma.w2)
-      # G.sigma.w2[cl,] <- lav_matrix_vech(tmp)
+      # G.sigma.w2[cl,] <- lav_mat_vech(tmp)
       # G.sigma.w[cl,] <- G.sigma.w1[cl,] + G.sigma.w2[cl,]
 
       # SIGMA.B
       g_sigma_b <- nj * g_sigma_w1
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZZ
       yz1 <- zz_zi_yz_ji %*% sigma_yz
@@ -825,7 +825,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
         nj * sigma_zz_inv %*% tmp %*% sigma_zz_inv)
       tmp <- g_sigma_zz * 2
       diag(tmp) <- diag(g_sigma_zz)
-      g_sigma_zz_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_zz_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.ZY
       # g.sigma.yz <- 2 * nj * (
@@ -837,7 +837,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
       tmp3 <- ji_yz_zi
       tmp4 <- j_yzj %*% sigma_yz_zi
       g_sigma_yz <- 2 * nj * (tmp1 - tmp2 - tmp3 + tmp4)
-      g_sigma_yz_1[cl, ] <- lav_matrix_vec(g_sigma_yz)
+      g_sigma_yz_1[cl, ] <- lav_mat_vec(g_sigma_yz)
 
       # BETA.Z
       # here, we avoid the (sample.z - beta.z) approach
@@ -893,7 +893,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
 
       # construct sigma.j
       sigma_j <- (nj * sigma_b) + sigma_w
-      sigma_j_inv <- lav_matrix_symmetric_inverse(s = sigma_j)
+      sigma_j_inv <- lav_mat_sym_inverse(s = sigma_j)
 
       # common part
       j_yyj <- nj * sigma_j_inv %*% y2yc_yy %*% sigma_j_inv
@@ -903,19 +903,19 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
       #    - sigma.w.inv %*% (crossprod(Y1m) - nj*Y2Yc.yy) %*% sigma.w.inv
       #    + sigma.j.inv - jYYj )
       # tmp <- g.sigma.w*2; diag(tmp) <- diag(g.sigma.w)
-      # G.sigma.w[cl,] <- lav_matrix_vech(tmp)
+      # G.sigma.w[cl,] <- lav_mat_vech(tmp)
 
       # SIGMA.W (between part)
       g_sigma_w1 <- sigma_j_inv - j_yyj
       tmp <- g_sigma_w1 * 2
       diag(tmp) <- diag(g_sigma_w1)
-      g_sigma_w1_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_w1_1[cl, ] <- lav_mat_vech(tmp)
 
       # SIGMA.B
       g_sigma_b <- nj * (sigma_j_inv - j_yyj)
       tmp <- g_sigma_b * 2
       diag(tmp) <- diag(g_sigma_b)
-      g_sigma_b_1[cl, ] <- lav_matrix_vech(tmp)
+      g_sigma_b_1[cl, ] <- lav_mat_vech(tmp)
 
       # BETA.W (between part only)
       exo2_w <- cbind(1, y2[cl, within_x_idx, drop = FALSE])
@@ -956,17 +956,17 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
 
   y1a_res <- y1_wb_res - y2w_res[cluster_idx, , drop = FALSE]
   y1a_res_i <- y1a_res %*% sigma_w_inv
-  idx1 <- lav_matrix_vech_col_idx(nrow(sigma_w))
-  idx2 <- lav_matrix_vech_row_idx(nrow(sigma_w))
-  sw2 <- matrix(lav_matrix_vech(sigma_w_inv),
+  idx1 <- lav_mat_vech_col_idx(nrow(sigma_w))
+  idx2 <- lav_mat_vech_row_idx(nrow(sigma_w))
+  sw2 <- matrix(lav_mat_vech(sigma_w_inv),
     nrow = nclusters,
-    length(lav_matrix_vech(sigma_w_inv)), byrow = TRUE
+    length(lav_mat_vech(sigma_w_inv)), byrow = TRUE
   )
   sw2 <- sw2 * (cluster_size - 1)
   tmp_1 <- y1a_res_i[, idx1, drop = FALSE] * y1a_res_i[, idx2, drop = FALSE]
   tmp2_1 <- rowsum.default(tmp_1, cluster_idx, reorder = FALSE, na.rm = TRUE)
   g_sigma_w2 <- 2 * (sw2 - tmp2_1)
-  diagh_idx <- lav_matrix_diagh_idx(nrow(sigma_w))
+  diagh_idx <- lav_mat_diagh_idx(nrow(sigma_w))
   g_sigma_w2[, diagh_idx] <- g_sigma_w2[, diagh_idx, drop = FALSE] / 2
   g_sigma_w <- g_sigma_w1_1 + g_sigma_w2
 
@@ -981,7 +981,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
   # 'tilde' matrices: ALL variables within and between
   p_tilde <- length(unique(c(ov_idx[[1]], ov_idx[[2]])))
   p_tilde_star <- p_tilde * (p_tilde + 1) / 2
-  b_tilde <- lav_matrix_vech_reverse(seq_len(p_tilde_star))
+  b_tilde <- lav_mat_vech_rev(seq_len(p_tilde_star))
 
   # only 'y'
   ov_y_idx <- lp$ov.y.idx
@@ -995,12 +995,12 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
   beta_b_idx <- matrix(seq_along(beta_b), nrow(beta_b), ncol(beta_b))
 
   res_int_w <- g_beta_w[, beta_w_idx[1L, ], drop = FALSE]
-  res_pi_w <- g_beta_w[, lav_matrix_vecr(beta_w_idx[-1L, ]), drop = FALSE]
+  res_pi_w <- g_beta_w[, lav_mat_vecr(beta_w_idx[-1L, ]), drop = FALSE]
   res_sigma_w <- g_sigma_w
 
   # Sigma.B
   sigma_b_tilde <- matrix(0, nclusters, p_tilde_star)
-  col_idx <- lav_matrix_vech(b_tilde[ov_y_idx1, ov_y_idx1, drop = FALSE])
+  col_idx <- lav_mat_vech(b_tilde[ov_y_idx1, ov_y_idx1, drop = FALSE])
   sigma_b_tilde[, col_idx] <- g_sigma_b_1
 
   # Int.B
@@ -1010,15 +1010,15 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
 
   # Pi.B
   pi_b <- matrix(0, nclusters, p_tilde * (nrow(beta_b) - 1L))
-  col_idx <- lav_matrix_vecr(beta_b_tilde[-1L, ov_y_idx1, drop = FALSE])
-  pi_b[, col_idx] <- g_beta_b[, lav_matrix_vecr(beta_b_idx[-1L, ]),
+  col_idx <- lav_mat_vecr(beta_b_tilde[-1L, ov_y_idx1, drop = FALSE])
+  pi_b[, col_idx] <- g_beta_b[, lav_mat_vecr(beta_b_idx[-1L, ]),
                                                                 drop = FALSE]
 
   if (length(between_y_idx) > 0L) {
     # Sigma.B: add yz/zz parts
-    col_idx <- lav_matrix_vec(b_tilde[ov_y_idx1, between_y_idx, drop = FALSE])
+    col_idx <- lav_mat_vec(b_tilde[ov_y_idx1, between_y_idx, drop = FALSE])
     sigma_b_tilde[, col_idx] <- g_sigma_yz_1
-    col_idx <- lav_matrix_vech(b_tilde[between_y_idx, between_y_idx,
+    col_idx <- lav_mat_vech(b_tilde[between_y_idx, between_y_idx,
       drop = FALSE
     ])
     sigma_b_tilde[, col_idx] <- g_sigma_zz_1
@@ -1028,18 +1028,18 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
     int_b[, between_y_idx] <- g_beta_z[, beta_z_idx[1L, ], drop = FALSE]
 
     # Pi.B: add beta.z
-    col_idx <- lav_matrix_vecr(beta_b_tilde[-1L, between_y_idx, drop = FALSE])
+    col_idx <- lav_mat_vecr(beta_b_tilde[-1L, between_y_idx, drop = FALSE])
     pi_b[, col_idx] <-
-      g_beta_z[, lav_matrix_vecr(beta_z_idx[-1L, ]), drop = FALSE]
+      g_beta_z[, lav_mat_vecr(beta_z_idx[-1L, ]), drop = FALSE]
   }
 
   # only extract ov.y.idx2 for BETWEEN
-  col_idx <- lav_matrix_vech(b_tilde[ov_y_idx2, ov_y_idx2, drop = FALSE])
+  col_idx <- lav_mat_vech(b_tilde[ov_y_idx2, ov_y_idx2, drop = FALSE])
   res_sigma_b <- sigma_b_tilde[, col_idx, drop = FALSE]
 
   res_int_b <- int_b[, ov_y_idx2, drop = FALSE]
 
-  col_idx <- lav_matrix_vecr(beta_b_tilde[-1, ov_y_idx2])
+  col_idx <- lav_mat_vecr(beta_b_tilde[-1, ov_y_idx2])
   res_pi_b <- pi_b[, col_idx, drop = FALSE]
 
   scores <- cbind(
@@ -1051,7 +1051,7 @@ lav_mvreg_cluster_scores_2l <- function(y1 = NULL,
 }
 
 # first-order information: outer crossprod of scores per cluster
-lav_mvreg_cluster_information_firstorder <- function(y1 = NULL,     # nolint
+lav_mvreg_cl_info_firstorder <- function(y1 = NULL,
                                                      ylp = NULL,
                                                      lp = NULL,
                                                      res_sigma_w = NULL,
@@ -1064,7 +1064,7 @@ lav_mvreg_cluster_information_firstorder <- function(y1 = NULL,     # nolint
                                                      sinv_method = "eigen") {
   # n <- NROW(y1)
 
-  scores <- lav_mvreg_cluster_scores_2l(
+  scores <- lav_mvreg_cl_sc_2l(
     y1 = y1,
     ylp = ylp,
     lp = lp,

--- a/R/lav_object_check_version.R
+++ b/R/lav_object_check_version.R
@@ -48,9 +48,9 @@ lav_object_check_version <- function(object = NULL) {
   # ok, we have potentially an older (saved) lavaan or lavaanList object
   # check needed slots, and if missing, add them
   suppressWarnings(lavobject <- object)
-  ngroups <- lav_partable_ngroups(lavobject@ParTable)
-  nblocks <- lav_partable_nblocks(lavobject@ParTable)
-  nlevels <- lav_partable_nlevels(lavobject@ParTable)
+  ngroups <- lav_pt_ngroups(lavobject@ParTable)
+  nblocks <- lav_pt_nblocks(lavobject@ParTable)
+  nlevels <- lav_pt_nlevels(lavobject@ParTable)
 
   if (!has_version_flag) { # pre 0.6 object!
     # 0.5-10 (25 Oct 2012)
@@ -360,7 +360,7 @@ lav_object_check_version <- function(object = NULL) {
           lavsamplestats = lavobject@SampleStats,
           lavpartable = lavobject@ParTable,
           lavoptions = lavobject@Options)
-        lavobject@baseline <- lav_lavaan_step15_baseline(
+        lavobject@baseline <- lav_step15_baseline(
           lavoptions = lavobject@Options,
           lavsamplestats = lavobject@SampleStats,
           lavdata = lavobject@Data,

--- a/R/lav_object_generate.R
+++ b/R/lav_object_generate.R
@@ -38,8 +38,8 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
       lavoptions$estimator.args <- list()
     }
   } else {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
 
   # if two-level, force conditional.x = FALSE (for now)
@@ -50,12 +50,12 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
   # construct parameter table for independence model
   if (!is.null(lavoptions$baseline.type) &&
     lavoptions$baseline.type == "nested") {
-    lavpartable <- lav_partable_baseline(
+    lavpartable <- lav_pt_baseline(
       lavobject = NULL,
       lavpartable = lavpartable, lavh1 = lavh1
     )
   } else {
-    lavpartable <- lav_partable_indep_or_unrestricted(
+    lavpartable <- lav_pt_indep_or_unrestricted(
       lavobject = NULL,
       lavdata = lavdata, lavpta = lavpta, lavoptions = lavoptions,
       lavsamplestats = lavsamplestats, lavh1 = lavh1, independent = TRUE
@@ -67,7 +67,7 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
     lavoptions$bounds <- "doe.maar"
     lavoptions$effect.coding <- "" # to avoid warning
     lavoptions$optim.bounds <- list(lower = "ov.var")
-    lavpartable <- lav_partable_add_bounds(
+    lavpartable <- lav_pt_add_bounds(
       partable = lavpartable,
       lavh1 = lavh1, lavdata = lavdata,
       lavsamplestats = lavsamplestats, lavoptions = lavoptions
@@ -82,7 +82,7 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
       lavoptions$estimator.args$dls.GammaNT <- "sample"
       dls_a <- lavoptions$estimator.args$dls.a
       for (g in 1:lavsamplestats@ngroups) {
-        gamma_nt <- lav_samplestats_gamma_nt(
+        gamma_nt <- lav_samp_gamma_nt(
           m_cov          = lavsamplestats@cov[[g]],
           m_mean         = lavsamplestats@mean[[g]],
           x_idx          = lavsamplestats@x.idx[[g]],
@@ -93,7 +93,7 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
         )
         w_dls <- (1 - dls_a) * lavsamplestats@NACOV[[g]] + dls_a * gamma_nt
         # overwrite
-        lavsamplestats@WLS.V[[g]] <- lav_matrix_symmetric_inverse(w_dls)
+        lavsamplestats@WLS.V[[g]] <- lav_mat_sym_inverse(w_dls)
       }
     }
   }
@@ -133,7 +133,7 @@ lav_object_independence <- lav_object_baseline <- function(object = NULL,
   lavoptions$rstarts <- 0L # no random starts
 
   # ALWAYS do.fit and set optim.method = "nlminb" (if npar > 0)
-  npar <- lav_partable_npar(lavpartable)
+  npar <- lav_pt_npar(lavpartable)
   if (npar > 0L) {
     lavoptions$do.fit <- TRUE
     if (lavoptions$optim.method != "noniter") {
@@ -210,11 +210,11 @@ lav_object_extended <- function(object, add = NULL,
     }
   }
 
-  # TDJ: Added to prevent error when lav_partable_merge() is called below.
+  # TDJ: Added to prevent error when lav_pt_merge() is called below.
   #      Problematic if object@ParTable is missing one of the requested slots,
   #      which returns a NULL slot with a missing <NA> name.  For example:
   #        example(cfa)
-  #        lav_partable_independence(lavdata = fit@Data, lavpta = fit@pta,
+  #        lav_pt_independence(lavdata = fit@Data, lavpta = fit@pta,
   #                                  lavoptions = lavInspect(fit, "options"))
   #     Has no "label" or "plabel" elements.
   empties <- which(sapply(partable, is.null))
@@ -250,8 +250,8 @@ lav_object_extended <- function(object, add = NULL,
     )
     add_1 <- add
   } else if (is.character(add)) {
-    ngroups <- lav_partable_ngroups(partable)
-    add_orig <- lav_model_partable(add, ngroups = ngroups)
+    ngroups <- lav_pt_ngroups(partable)
+    add_orig <- lav_model_pt(add, ngroups = ngroups)
     add_1 <- add_orig[, c("lhs", "op", "rhs", "user", "label")] # minimum
 
     # always add block/group/level
@@ -281,8 +281,8 @@ lav_object_extended <- function(object, add = NULL,
   }
 
   # merge
-  list_1 <- lav_partable_merge(partable, add_1,
-    remove.duplicated = remove_duplicated,
+  list_1 <- lav_pt_merge(partable, add_1,
+    remove_duplicated = remove_duplicated,
     warn = FALSE
   )
 
@@ -369,7 +369,7 @@ lav_object_catml <- function(lavobject = NULL) {
       partable_catml$free[ov_var_idx] <- 0L
     }
   }
-  partable_catml <- lav_partable_complete(partable_catml)
+  partable_catml <- lav_pt_complete(partable_catml)
 
   # adapt lavsamplestats
   for (g in seq_len(lavdata@ngroups)) {
@@ -380,7 +380,7 @@ lav_object_catml <- function(lavobject = NULL) {
     ev <- eigen(cor_1, symmetric = TRUE, only.values = TRUE)$values
     if (any(ev < .Machine$double.eps^(1 / 2))) {
       # not PD!
-      cov_1 <- cov2cor(lav_matrix_symmetric_force_pd(cor_1, tol = 1e-04))
+      cov_1 <- cov2cor(lav_mat_sym_force_pd(cor_1, tol = 1e-04))
       lavsamplestats@cov[[g]] <- cov_1
       lavsamplestats@var[[g]] <- diag(cov_1)
       refit <- TRUE
@@ -392,7 +392,7 @@ lav_object_catml <- function(lavobject = NULL) {
     if (lav_warn(FALSE)) {
       on.exit(lav_warn(current_warn), TRUE)
     }
-    out <- lav_samplestats_icov(
+    out <- lav_samp_icov(
       cov_1 = cov_1, ridge = 1e-05,
       x_idx = lavsamplestats@x.idx[[g]],
       ngroups = lavdata@ngroups, g = g

--- a/R/lav_object_inspect.R
+++ b/R/lav_object_inspect.R
@@ -46,7 +46,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
   object <- lav_object_check_version(object)
 
   # store partable with pta in object to use cache in called functions
-  object@ParTable <- lav_partable_set_cache(object@ParTable, object@pta)
+  object@ParTable <- lav_pt_set_cache(object@ParTable, object@pta)
 
   # only a single argument
   if (length(what) > 1) {
@@ -59,7 +59,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
   #### model matrices, with different contents ####
   if (what == "free") {
-    lav_object_inspect_modelmatrices(object, what = "free",
+    lav_inspect_modelmatrices(object, what = "free",
       type = "free", add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
@@ -67,63 +67,63 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
     what == "imputed") { # just to ease the transition for semTools!
     object@imputed
   } else if (what == "partable" || what == "user") {
-    lav_object_inspect_modelmatrices(object, what = "free",
+    lav_inspect_modelmatrices(object, what = "free",
       type = "partable", add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "se" ||
     what == "std.err" ||
     what == "standard.errors") {
-    lav_object_inspect_modelmatrices(object, what = "se",
+    lav_inspect_modelmatrices(object, what = "se",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "se.std" ||
     what == "std.se") {
-    lav_object_inspect_modelmatrices(object, what = "std.se",
+    lav_inspect_modelmatrices(object, what = "std.se",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "start" || what == "starting.values") {
-    lav_object_inspect_modelmatrices(object, what = "start",
+    lav_inspect_modelmatrices(object, what = "start",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "est"  || what == "estimates" ||
     what == "x") {
-    lav_object_inspect_modelmatrices(object, what = "est",
+    lav_inspect_modelmatrices(object, what = "est",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "est.unrotated") {
-    lav_object_inspect_modelmatrices(object, what = "est.unrotated",
+    lav_inspect_modelmatrices(object, what = "est.unrotated",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "dx.free") {
-    lav_object_inspect_modelmatrices(object, what = "dx.free",
+    lav_inspect_modelmatrices(object, what = "dx.free",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "dx.all") {
-    lav_object_inspect_modelmatrices(object, what = "dx.all",
+    lav_inspect_modelmatrices(object, what = "dx.all",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "std" || what == "std.all" ||
     what == "est.std" || what == "std.est" ||
     what == "standardized") {
-    lav_object_inspect_modelmatrices(object, what = "std.all",
+    lav_inspect_modelmatrices(object, what = "std.all",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "std.lv") {
-    lav_object_inspect_modelmatrices(object, what = "std.lv",
+    lav_inspect_modelmatrices(object, what = "std.lv",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "std.nox") {
-    lav_object_inspect_modelmatrices(object, what = "std.nox",
+    lav_inspect_modelmatrices(object, what = "std.nox",
       add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
@@ -135,12 +135,12 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
     #### bootstrap coef ####
   } else if (what %in% c("boot", "bootstrap", "boot.coef", "coef.boot")) {
-    lav_object_inspect_boot(object, add_labels = add.labels,
+    lav_inspect_boot(object, add_labels = add.labels,
       add_class = add.class)
 
     #### Monte Carlo coef draws ####
   } else if (what %in% c("monte.carlo", "mc", "mc.coef", "coef.mc")) {
-    lav_object_inspect_mc(object, add_labels = add.labels,
+    lav_inspect_mc(object, add_labels = add.labels,
       add_class = add.class)
 
     #### fit indices ####
@@ -177,7 +177,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
     what == "sample" ||
     what == "samplestatistics") {
     # new in 0.6-3: always use h1 = TRUE!!!
-    lav_object_inspect_sampstat(object, h1 = TRUE, std = FALSE,
+    lav_inspect_sampstat(object, h1 = TRUE, std = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "obs.std" ||
@@ -188,25 +188,25 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
     what == "samp.std" ||
     what == "sample.std" ||
     what == "samplestatistics.std") {
-    lav_object_inspect_sampstat(object, h1 = TRUE, std = TRUE,
+    lav_inspect_sampstat(object, h1 = TRUE, std = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "h1" || what == "missing.h1" || what == "sampstat.h1") {
-    lav_object_inspect_sampstat(object, h1 = TRUE,
+    lav_inspect_sampstat(object, h1 = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
     #### wls.est - wls.obs - wls.v ####
   } else if (what == "wls.est") {
-    lav_object_inspect_wls_est(object,
+    lav_inspect_wls_est(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "wls.obs") {
-    lav_object_inspect_wls_obs(object,
+    lav_inspect_wls_obs(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "wls.v") {
-    lav_object_inspect_wls_v(object,
+    lav_inspect_wls_v(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
@@ -214,10 +214,10 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
     #### data + missingness ####
   } else if (what == "data") {
-    lav_object_inspect_data(object, add_labels = add.labels,
+    lav_inspect_data(object, add_labels = add.labels,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "case.idx") {
-    lav_object_inspect_case_idx(object,
+    lav_inspect_case_idx(object,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "ngroups") {
     object@Data@ngroups
@@ -228,35 +228,35 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
   } else if (what == "nlevels") {
     object@Data@nlevels
   } else if (what == "nclusters") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "nclusters",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "ncluster.size") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "ncluster.size",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cluster.size") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "cluster.size",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cluster.id") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "cluster.id",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cluster.idx") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "cluster.idx",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cluster.label") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "cluster.label",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cluster.sizes") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "cluster.sizes",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "average.cluster.size") {
-    lav_object_inspect_cluster_info(object, level = 2L,
+    lav_inspect_cl_info(object, level = 2L,
       what = "average.cluster.size",
       drop_list_single_group = drop.list.single.group)
   } else if (what == "ordered") {
@@ -272,21 +272,21 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
   } else if (what == "ntotal") {
     sum(unlist(object@Data@nobs))
   } else if (what == "coverage") {
-    lav_object_inspect_missing_coverage(object,
+    lav_inspect_mi_coverage(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what %in% c("patterns", "pattern")) {
-    lav_object_inspect_missing_patterns(object,
+    lav_inspect_mi_patterns(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "empty.idx") {
-    lav_object_inspect_empty_idx(object,
+    lav_inspect_empty_idx(object,
       drop_list_single_group = drop.list.single.group)
 
 
     #### rsquare ####
   } else if (what == "rsquare" || what == "r-square" || what == "r2") {
-    lav_object_inspect_rsquare(object,
+    lav_inspect_rsquare(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
@@ -294,72 +294,72 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
     #### model-implied sample statistics ####
   } else if (what == "implied" || what == "fitted" ||
     what == "expected" || what == "exp") {
-    lav_object_inspect_implied(object,
+    lav_inspect_implied(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "resid" || what == "res" || what == "residual" ||
     what == "residuals") {
-    lav_object_inspect_residuals(object, h1 = TRUE,
+    lav_inspect_residuals(object, h1 = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cov.lv" || what == "veta") {
-    lav_object_inspect_cov_lv(object,
+    lav_inspect_cov_lv(object,
       correlation_metric = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cor.lv") {
-    lav_object_inspect_cov_lv(object,
+    lav_inspect_cov_lv(object,
       correlation_metric = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "mean.lv" || what == "eeta") {
-    lav_object_inspect_mean_lv(object,
+    lav_inspect_mean_lv(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cov.all") {
-    lav_object_inspect_cov_all(object,
+    lav_inspect_cov_all(object,
       correlation_metric = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cor.all") {
-    lav_object_inspect_cov_all(object,
+    lav_inspect_cov_all(object,
       correlation_metric = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cov.ov" || what == "sigma" || what == "sigma.hat") {
-    lav_object_inspect_cov_ov(object,
+    lav_inspect_cov_ov(object,
       correlation_metric = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "cor.ov") {
-    lav_object_inspect_cov_ov(object,
+    lav_inspect_cov_ov(object,
       correlation_metric = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "mean.ov" || what == "mu" || what == "mu.hat") {
-    lav_object_inspect_mean_ov(object,
+    lav_inspect_mean_ov(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "th" || what == "thresholds") {
-    lav_object_inspect_th(object,
+    lav_inspect_th(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "th.idx") {
-    lav_object_inspect_th_idx(object,
+    lav_inspect_th_idx(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "vy") {
-    lav_object_inspect_vy(object,
+    lav_inspect_vy(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what %in% c("fs.reliability", "fs.rel", "fs.reliabilities")) {
-    lav_object_inspect_fs_determinacy(object, squared = TRUE,
+    lav_inspect_fs_determinacy(object, squared = TRUE,
       fs_method = "regression",
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what %in% c("fs.determinacy", "fs.det", "fs.determin",
                          "fs.determinacies")) {
-    lav_object_inspect_fs_determinacy(object, squared = FALSE,
+    lav_inspect_fs_determinacy(object, squared = FALSE,
       fs_method = "regression",
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
@@ -368,7 +368,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
                          "fs.rel.bartlett", "fs.rel.Bartlett",
                          "fs.reliabilities.bartlett",
                          "fs.reliabilities.Bartlett")) {
-    lav_object_inspect_fs_determinacy(object, squared = TRUE,
+    lav_inspect_fs_determinacy(object, squared = TRUE,
       fs_method = "Bartlett",
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
@@ -378,7 +378,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
                          "fs.determin.bartlett", "fs.determin.Bartlett",
                          "fs.determinacies.bartlett",
                          "fs.determinacies.Bartlett")) {
-    lav_object_inspect_fs_determinacy(object, squared = FALSE,
+    lav_inspect_fs_determinacy(object, squared = FALSE,
       fs_method = "Bartlett",
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
@@ -387,29 +387,29 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
     #### specific model matrices? ####
   } else if (what == "theta" || what == "theta.cov") {
-    lav_object_inspect_theta(object,  correlation_metric = FALSE,
+    lav_inspect_theta(object,  correlation_metric = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "theta.cor") {
-    lav_object_inspect_theta(object,  correlation_metric = TRUE,
+    lav_inspect_theta(object,  correlation_metric = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
     #### (squared) Mahalanobis distances ####
   } else if (what == "mdist2.fs") {
-    lav_object_inspect_mdist2(object, type = "lv", squared = TRUE,
+    lav_inspect_mdist2(object, type = "lv", squared = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "mdist2.resid") {
-    lav_object_inspect_mdist2(object, type = "resid", squared = TRUE,
+    lav_inspect_mdist2(object, type = "resid", squared = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "mdist.fs") {
-    lav_object_inspect_mdist2(object, type = "lv", squared = FALSE,
+    lav_inspect_mdist2(object, type = "lv", squared = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "mdist.resid") {
-    lav_object_inspect_mdist2(object, type = "resid", squared = FALSE,
+    lav_inspect_mdist2(object, type = "resid", squared = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
@@ -429,12 +429,12 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
   } else if (what == "parameterization") {
     object@Model@parameterization
   } else if (what == "npar") {
-    lav_object_inspect_npar(object, ceq = FALSE) # ignore equality constraints
+    lav_inspect_npar(object, ceq = FALSE) # ignore equality constraints
   } else if (what == "coef") {
     # this breaks simsem and semTools -- 0.6-1
-    # lav_object_inspect_coef(object, type = "free",
+    # lav_inspect_coef(object, type = "free",
     #                        add_labels = add.labels, add_class = add.class)
-    lav_object_inspect_modelmatrices(object, what = "est",
+    lav_inspect_modelmatrices(object, what = "est",
       type = "free", add_labels = add.labels, add_class = add.class,
       list_by_group =  list.by.group,
       drop_list_single_group = drop.list.single.group)
@@ -442,204 +442,204 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
     #### NACOV samplestats ####
   } else if (what == "gamma") {
-    lav_object_inspect_sampstat_gamma(object,
+    lav_inspect_sampstat_gamma(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
 
     #### gradient, Hessian, information, first.order, vcov ####
   } else if (what == "gradient") {
-    lav_object_inspect_gradient(object,
+    lav_inspect_grad(object,
       add_labels = add.labels, add_class = add.class, logl = FALSE)
   } else if (what == "gradient.logl") {
-    lav_object_inspect_gradient(object,
+    lav_inspect_grad(object,
       add_labels = add.labels, add_class = add.class, logl = TRUE)
   } else if (what == "optim.gradient") {
-    lav_object_inspect_gradient(object,
+    lav_inspect_grad(object,
       add_labels = add.labels, add_class = add.class, optim = TRUE)
   } else if (what == "hessian") {
-    lav_object_inspect_hessian(object,
+    lav_inspect_hessian(object,
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "information") {
-    lav_object_inspect_information(object, information = "default",
+    lav_inspect_info(object, information = "default",
       augmented = FALSE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "information.expected") {
-    lav_object_inspect_information(object, information = "expected",
+    lav_inspect_info(object, information = "expected",
       augmented = FALSE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "information.observed") {
-    lav_object_inspect_information(object, information = "observed",
+    lav_inspect_info(object, information = "observed",
       augmented = FALSE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "information.first.order" ||
     what == "information.firstorder"  ||
     what == "first.order") {
-    lav_object_inspect_information(object, information = "first.order",
+    lav_inspect_info(object, information = "first.order",
       augmented = FALSE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "augmented.information") {
-    lav_object_inspect_information(object, information = "default",
+    lav_inspect_info(object, information = "default",
       augmented = TRUE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "augmented.information.expected") {
-    lav_object_inspect_information(object, information = "expected",
+    lav_inspect_info(object, information = "expected",
       augmented = TRUE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "augmented.information.observed") {
-    lav_object_inspect_information(object, information = "observed",
+    lav_inspect_info(object, information = "observed",
       augmented = TRUE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "augmented.information.first.order" ||
     what == "augmented.first.order") {
-    lav_object_inspect_information(object, information = "first.order",
+    lav_inspect_info(object, information = "first.order",
       augmented = TRUE, inverted = FALSE,
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "inverted.information") {
-    lav_object_inspect_information(object, information = "default",
+    lav_inspect_info(object, information = "default",
       augmented = TRUE, inverted = TRUE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "inverted.information.expected") {
-    lav_object_inspect_information(object, information = "expected",
+    lav_inspect_info(object, information = "expected",
       augmented = TRUE, inverted = TRUE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "inverted.information.observed") {
-    lav_object_inspect_information(object, information = "observed",
+    lav_inspect_info(object, information = "observed",
       augmented = TRUE, inverted = TRUE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "inverted.information.first.order" ||
     what == "inverted.first.order") {
-    lav_object_inspect_information(object, information = "first.order",
+    lav_inspect_info(object, information = "first.order",
       augmented = TRUE, inverted = TRUE,
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "h1.information") {
-    lav_object_inspect_h1_information(object, information = "default",
+    lav_inspect_h1_info(object, information = "default",
       h1_information = "default", inverted = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "h1.information.expected") {
-    lav_object_inspect_h1_information(object, information = "expected",
+    lav_inspect_h1_info(object, information = "expected",
       h1_information = "default", inverted = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "h1.information.observed") {
-    lav_object_inspect_h1_information(object, information = "observed",
+    lav_inspect_h1_info(object, information = "observed",
       h1_information = "default", inverted = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "h1.information.first.order" ||
     what == "h1.information.firstorder"  ||
     what == "h1.first.order") {
-    lav_object_inspect_h1_information(object,
+    lav_inspect_h1_info(object,
       information = "first.order", h1_information = "default",
       inverted = FALSE, add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
   } else if (what == "vcov") {
-    lav_object_inspect_vcov(object,
+    lav_inspect_vcov(object,
       standardized = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.std.all" || what == "vcov.standardized" ||
     what == "vcov.std") {
-    lav_object_inspect_vcov(object,
+    lav_inspect_vcov(object,
       standardized = TRUE, type = "std.all",
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.std.lv") {
-    lav_object_inspect_vcov(object,
+    lav_inspect_vcov(object,
       standardized = TRUE, type = "std.lv",
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.std.nox") {
-    lav_object_inspect_vcov(object,
+    lav_inspect_vcov(object,
       standardized = TRUE, type = "std.nox",
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "vcov.def") {
-    lav_object_inspect_vcov_def(object, joint = FALSE,
+    lav_inspect_vcov_def(object, joint = FALSE,
       standardized = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.def.std.all" || what == "vcov.def.standardized" ||
     what == "vcov.def.std") {
-    lav_object_inspect_vcov_def(object, joint = FALSE,
+    lav_inspect_vcov_def(object, joint = FALSE,
       standardized = TRUE, type = "std.all",
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.def.std.lv") {
-    lav_object_inspect_vcov_def(object, joint = FALSE,
+    lav_inspect_vcov_def(object, joint = FALSE,
       standardized = TRUE, type = "std.lv",
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.def.std.nox") {
-    lav_object_inspect_vcov_def(object, joint = FALSE,
+    lav_inspect_vcov_def(object, joint = FALSE,
       standardized = TRUE, type = "std.nox",
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "vcov.def.joint") {
-    lav_object_inspect_vcov_def(object, joint = TRUE,
+    lav_inspect_vcov_def(object, joint = TRUE,
       standardized = FALSE,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.def.joint.std.all" ||
     what == "vcov.def.joint.standardized" ||
     what == "vcov.def.joint.std") {
-    lav_object_inspect_vcov_def(object, joint = TRUE,
+    lav_inspect_vcov_def(object, joint = TRUE,
       standardized = TRUE, type = "std.all",
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.def.joint.std.lv") {
-    lav_object_inspect_vcov_def(object, joint = TRUE,
+    lav_inspect_vcov_def(object, joint = TRUE,
       standardized = TRUE, type = "std.lv",
       add_labels = add.labels, add_class = add.class)
   } else if (what == "vcov.def.joint.std.nox") {
-    lav_object_inspect_vcov_def(object, joint = TRUE,
+    lav_inspect_vcov_def(object, joint = TRUE,
       standardized = TRUE, type = "std.nox",
       add_labels = add.labels, add_class = add.class)
 
   } else if (what == "ugamma" || what == "ug" || what == "u.gamma") {
-    lav_object_inspect_ugamma(object,
+    lav_inspect_ugamma(object,
       add_labels = add.labels, add_class = add.class)
   } else if (what == "ufromugamma" || what == "u") {
-    lav_object_inspect_u_from_ugamma(object,
+    lav_inspect_u_from_ugamma(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
     ### jacobians ####
   } else if (what == "delta") {
-    lav_object_inspect_delta(object,
+    lav_inspect_delta(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "delta.rownames") {
-    lav_object_inspect_delta_rownames(object,
+    lav_inspect_delta_rownames(object,
       drop_list_single_group = drop.list.single.group)
 
     ### casewise loglikelihoods ###
   } else if (what == "loglik.casewise") {
-    lav_object_inspect_loglik_casewise(object, log_1 = TRUE,
+    lav_inspect_loglik_casewise(object, log_1 = TRUE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "lik.casewise") {
-    lav_object_inspect_loglik_casewise(object, log_1 = FALSE,
+    lav_inspect_loglik_casewise(object, log_1 = FALSE,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
     # multilevel #
   } else if (what == "icc") {
-    lav_object_inspect_icc(object,
+    lav_inspect_icc(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
   } else if (what == "ranef") {
-    lav_object_inspect_ranef(object,
+    lav_inspect_ranef(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
     # instrumental variables
   } else if (what %in% c("iv", "ivs", "miiv", "miivs", "instr", "instruments")) {
-    lav_object_inspect_iv(object,
+    lav_inspect_iv(object,
       drop_list_single_group = drop.list.single.group)
   } else if (what %in% c("eqs")) {
-    lav_object_inspect_eqs(object,
+    lav_inspect_eqs(object,
       drop_list_single_group = drop.list.single.group)
   } else if (what %in% c("sargan")) {
-    lav_object_inspect_sargan(object,
+    lav_inspect_sargan(object,
       drop_list_single_group = drop.list.single.group)
 
     # post-checking
@@ -672,7 +672,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
     # zero cell tables
   } else if (what == "zero.cell.tables") {
-    lav_object_inspect_zero_cell_tables(object,
+    lav_inspect_zero_cell_tables(object,
       add_labels = add.labels, add_class = add.class,
       drop_list_single_group = drop.list.single.group)
 
@@ -689,7 +689,7 @@ lav_lavaan_lavinspect <- function(object,                                # nolin
 
 # helper functions (mostly to deal with older 'object' that may have
 # been saved somewhere)
-lav_object_inspect_est <- function(object, unrotated = FALSE) {
+lav_inspect_est <- function(object, unrotated = FALSE) {
 
   if (inherits(object, "lavaan")) {
     # from 0.5-19, they are in the partable
@@ -716,7 +716,7 @@ lav_object_inspect_est <- function(object, unrotated = FALSE) {
   return_value
 }
 
-lav_object_inspect_se <- function(object) {
+lav_inspect_se <- function(object) {
   # from 0.5-19, they are in the partable
   if (!is.null(object@ParTable$se)) {
     return_value <- object@ParTable$se
@@ -728,7 +728,7 @@ lav_object_inspect_se <- function(object) {
   return_value
 }
 
-lav_object_inspect_std_se <- function(object) {
+lav_inspect_std_se <- function(object) {
 
   if (!is.null(object@ParTable$se.std)) {
     return_value <- object@ParTable$se.std
@@ -740,7 +740,7 @@ lav_object_inspect_std_se <- function(object) {
   return_value
 }
 
-lav_object_inspect_start <- function(object) {
+lav_inspect_start <- function(object) {
   # from 0.5-19, they are in the partable
   if (!is.null(object@ParTable$start)) {
     return_value <- object@ParTable$start
@@ -752,7 +752,7 @@ lav_object_inspect_start <- function(object) {
   return_value
 }
 
-lav_object_inspect_mc <- function(object, add_labels = FALSE,
+lav_inspect_mc <- function(object, add_labels = FALSE,
                                   add_class = FALSE) {
   # retrieve the Monte Carlo coefficient draws used for defined parameter
   # confidence intervals (Preacher & Selig 2012). Returns NULL if MC was
@@ -774,7 +774,7 @@ lav_object_inspect_mc <- function(object, add_labels = FALSE,
   mc_coef
 }
 
-lav_object_inspect_boot <- function(object, add_labels = FALSE,
+lav_inspect_boot <- function(object, add_labels = FALSE,
                                     add_class = FALSE) {
 
   if (object@Options$se   != "bootstrap" &&
@@ -786,7 +786,7 @@ lav_object_inspect_boot <- function(object, add_labels = FALSE,
   tmp <- try(slot(object, "boot"), silent = TRUE)
   if (inherits(tmp, "try-error")) {
     # older version of object?
-    est <- lav_object_inspect_est(object)
+    est <- lav_inspect_est(object)
     tmp_boot <- attr(est, "tmp.boot.COEF")
   } else {
     # 0.5-19 way
@@ -807,7 +807,7 @@ lav_object_inspect_boot <- function(object, add_labels = FALSE,
 }
 
 
-lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
+lav_inspect_modelmatrices <- function(object, what = "free",
     type = "free", add_labels = FALSE, add_class = FALSE,
     list_by_group = FALSE,
     drop_list_single_group = FALSE) {
@@ -817,7 +817,7 @@ lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
   current_verbose <- lav_verbose()
   if (what == "dx.free") {
     if (lav_verbose(FALSE)) on.exit(lav_verbose(current_verbose), TRUE)
-    tmp_dx <- lav_model_gradient(
+    tmp_dx <- lav_model_grad(
       lavmodel       = object@Model,
       glist          = NULL,
       lavsamplestats = object@SampleStats,
@@ -829,7 +829,7 @@ lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
       delta          = NULL)
   } else if (what == "dx.all") {
     if (lav_verbose(FALSE)) on.exit(lav_verbose(current_verbose), TRUE)
-    glist <- lav_model_gradient(
+    glist <- lav_model_grad(
       lavmodel   = object@Model,
       glist          = NULL,
       lavsamplestats = object@SampleStats,
@@ -847,19 +847,19 @@ lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
   } else if (what == "std.nox") {
     tmp_std <- lav_standardize_all_nox(object)
   } else if (what == "se") {
-    tmp_se <- lav_object_inspect_se(object)
+    tmp_se <- lav_inspect_se(object)
   } else if (what == "std.se") {
-    tmp_se <- lav_object_inspect_std_se(object)
+    tmp_se <- lav_inspect_std_se(object)
   } else if (what == "start") {
-    tmp_start <- lav_object_inspect_start(object)
+    tmp_start <- lav_inspect_start(object)
   } else if (what == "est") {
-    tmp_est <- lav_object_inspect_est(object)
+    tmp_est <- lav_inspect_est(object)
   } else if (what == "est.unrotated") {
     if (!is.null(object@Options$rotation) &&
       object@Options$rotation == "none") {
-      tmp_est <- lav_object_inspect_est(object, unrotated = FALSE)
+      tmp_est <- lav_inspect_est(object, unrotated = FALSE)
     } else {
-      tmp_est <- lav_object_inspect_est(object, unrotated = TRUE)
+      tmp_est <- lav_inspect_est(object, unrotated = TRUE)
     }
   }
 
@@ -939,7 +939,7 @@ lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
     rownames(tmp_con) <- NULL
 
     # replace 'labels' by parameter numbers
-    tmp_id <- lav_partable_constraints_label_id(partable)
+    tmp_id <- lav_pt_con_label_id(partable)
     tmp_label <- names(tmp_id)
     for (con in seq_len(nrow(tmp_con))) {
       # lhs
@@ -1026,7 +1026,7 @@ lav_object_inspect_modelmatrices <- function(object, what = "free", # nolint
 #    only return residual in both cases, whenever residual
 # - since 0.6-3, we always extract the values from the @h1 slot (if present)
 #   if meanstructure = FALSE, do NOT include $mean elements any longer
-lav_object_inspect_sampstat <- function(object, h1 = TRUE,        # nolint
+lav_inspect_sampstat <- function(object, h1 = TRUE,
     std = FALSE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
@@ -1270,7 +1270,7 @@ lav_object_inspect_sampstat <- function(object, h1 = TRUE,        # nolint
 }
 
 
-lav_object_inspect_data <- function(object, add_labels = FALSE,
+lav_inspect_data <- function(object, add_labels = FALSE,
                                     drop_list_single_group = FALSE) {
 
   n_g <- object@Data@ngroups
@@ -1306,7 +1306,7 @@ lav_object_inspect_data <- function(object, add_labels = FALSE,
   return_value
 }
 
-lav_object_inspect_case_idx <- function(object,
+lav_inspect_case_idx <- function(object,
                                         drop_list_single_group = FALSE) {
   n_g <- object@Data@ngroups
 
@@ -1323,7 +1323,7 @@ lav_object_inspect_case_idx <- function(object,
   return_value
 }
 
-# lav_object_inspect_case_idx <- function(object, level = 1L,
+# lav_inspect_case_idx <- function(object, level = 1L,
 #                                        drop_list_single_group = FALSE) {
 #    #FIXME: if lavaan ever allows 3-level or cross-classifed models,
 #    #      "level=" should be a character indicating the clustering variable
@@ -1354,7 +1354,7 @@ lav_object_inspect_case_idx <- function(object,
 #
 
 # cluster info
-lav_object_inspect_cluster_info <- function(                # nolint
+lav_inspect_cl_info <- function(
     object,
     what = "cluster.size",
     level = 2L,
@@ -1420,7 +1420,7 @@ lav_object_inspect_cluster_info <- function(                # nolint
 
 
 # count the number of clusters, or obtain tmp.n within each cluster
-# lav_object_inspect_ncluster <- function(object, sizes = FALSE, #level = 2L,
+# lav_inspect_ncluster <- function(object, sizes = FALSE, #level = 2L,
 #                                        drop_list_single_group = FALSE) {
 #    n.g <- object@Data@ngroups
 #    nlevels <- object@Data@nlevels
@@ -1448,7 +1448,7 @@ lav_object_inspect_cluster_info <- function(                # nolint
 #    return.value
 # }
 
-lav_object_inspect_rsquare <- function(object, est_std_all = NULL,
+lav_inspect_rsquare <- function(object, est_std_all = NULL,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   nblocks <- object@Model@nblocks
@@ -1494,7 +1494,7 @@ lav_object_inspect_rsquare <- function(object, est_std_all = NULL,
 }
 
 # model implied sample stats
-lav_object_inspect_implied <- function(object,                    # nolint
+lav_inspect_implied <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   nblocks <- object@Model@nblocks
@@ -1656,7 +1656,7 @@ lav_object_inspect_implied <- function(object,                    # nolint
 
 
 # residuals: _inspect_sampstat - _inspect_implied
-lav_object_inspect_residuals <- function(object, h1 = TRUE,
+lav_inspect_residuals <- function(object, h1 = TRUE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   lav_residuals(object, type = "raw", h1 = h1,
@@ -1665,7 +1665,7 @@ lav_object_inspect_residuals <- function(object, h1 = TRUE,
 }
 
 
-lav_object_inspect_cov_lv <- function(object, correlation_metric = FALSE,
+lav_inspect_cov_lv <- function(object, correlation_metric = FALSE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # compute lv covar
   return_value <- lav_model_veta(lavmodel = object@Model,
@@ -1701,7 +1701,7 @@ lav_object_inspect_cov_lv <- function(object, correlation_metric = FALSE,
   return_value
 }
 
-lav_object_inspect_mean_lv <- function(object,
+lav_inspect_mean_lv <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # compute lv means
   return_value <- lav_model_eeta(lavmodel = object@Model,
@@ -1733,7 +1733,7 @@ lav_object_inspect_mean_lv <- function(object,
   return_value
 }
 
-lav_object_inspect_cov_all <- function(object, correlation_metric = FALSE,
+lav_inspect_cov_all <- function(object, correlation_metric = FALSE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # compute extended model implied covariance matrix (both ov and lv)
   return_value <- lav_model_cov_both(lavmodel = object@Model,
@@ -1770,7 +1770,7 @@ lav_object_inspect_cov_all <- function(object, correlation_metric = FALSE,
 }
 
 
-lav_object_inspect_cov_ov <- function(object, correlation_metric = FALSE,
+lav_inspect_cov_ov <- function(object, correlation_metric = FALSE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # get model-implied covariance matrix observed
   if (object@Model@conditional.x) {
@@ -1808,7 +1808,7 @@ lav_object_inspect_cov_ov <- function(object, correlation_metric = FALSE,
   return_value
 }
 
-lav_object_inspect_mean_ov <- function(object,
+lav_inspect_mean_ov <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # compute ov means
   if (object@Model@conditional.x) {
@@ -1842,7 +1842,7 @@ lav_object_inspect_mean_ov <- function(object,
   return_value
 }
 
-lav_object_inspect_th <- function(object,
+lav_inspect_th <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # thresholds
   if (object@Model@conditional.x) {
@@ -1880,7 +1880,7 @@ lav_object_inspect_th <- function(object,
   return_value
 }
 
-lav_object_inspect_th_idx <- function(object,
+lav_inspect_th_idx <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # thresholds idx
   return_value <- object@SampleStats@th.idx
@@ -1907,7 +1907,7 @@ lav_object_inspect_th_idx <- function(object,
   return_value
 }
 
-lav_object_inspect_vy <- function(object,
+lav_inspect_vy <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # 'unconditional' model-implied variances
   #  - same as diag(Sigma.hat) if all Y are continuous)
@@ -1943,7 +1943,7 @@ lav_object_inspect_vy <- function(object,
   return_value
 }
 
-lav_object_inspect_fs_determinacy <- function(object,  # nolint
+lav_inspect_fs_determinacy <- function(object,
   squared = TRUE, fs_method = "regression",
   add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
@@ -1981,7 +1981,7 @@ lav_object_inspect_fs_determinacy <- function(object,  # nolint
 }
 
 
-lav_object_inspect_theta <- function(object, correlation_metric = FALSE,
+lav_inspect_theta <- function(object, correlation_metric = FALSE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
   # get residual covariances
   return_value <- lav_model_theta(lavmodel = object@Model)
@@ -2020,7 +2020,7 @@ lav_object_inspect_theta <- function(object, correlation_metric = FALSE,
 }
 
 
-lav_object_inspect_missing_coverage <- function(object,          # nolint
+lav_inspect_mi_coverage <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   n_g <- object@Data@ngroups
@@ -2055,7 +2055,7 @@ lav_object_inspect_missing_coverage <- function(object,          # nolint
   return_value
 }
 
-lav_object_inspect_missing_patterns <- function(object,           # nolint
+lav_inspect_mi_patterns <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   n_g <- object@Data@ngroups
@@ -2090,7 +2090,7 @@ lav_object_inspect_missing_patterns <- function(object,           # nolint
   return_value
 }
 
-lav_object_inspect_empty_idx <- function(object,
+lav_inspect_empty_idx <- function(object,
                                          drop_list_single_group = FALSE) {
 
   n_g <- object@Data@ngroups
@@ -2118,13 +2118,13 @@ lav_object_inspect_empty_idx <- function(object,
 }
 
 
-lav_object_inspect_wls_est <- function(object,
+lav_inspect_wls_est <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   return_value <- lav_model_wls_est(object@Model)
 
   if (add_labels) {
-    tmp_names <- lav_object_inspect_delta_rownames(object,
+    tmp_names <- lav_inspect_delta_rownames(object,
       drop_list_single_group = FALSE)
   }
 
@@ -2151,13 +2151,13 @@ lav_object_inspect_wls_est <- function(object,
   return_value
 }
 
-lav_object_inspect_wls_obs <- function(object,
+lav_inspect_wls_obs <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   return_value <- object@SampleStats@WLS.obs ### FIXME: should be in @h1??
 
   if (add_labels) {
-    tmp_names <- lav_object_inspect_delta_rownames(object,
+    tmp_names <- lav_inspect_delta_rownames(object,
       drop_list_single_group = FALSE)
   }
 
@@ -2184,7 +2184,7 @@ lav_object_inspect_wls_obs <- function(object,
   return_value
 }
 
-lav_object_inspect_wls_v <- function(object,
+lav_inspect_wls_v <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   # return.value <- lav_model_wls_v(lavmodel       = object@Model,
@@ -2192,7 +2192,7 @@ lav_object_inspect_wls_v <- function(object,
   #                       structured     = TRUE,
   #                       lavdata        = object@Data)
   # WLS.V == (traditionally) h1 expected information
-  return_value <- lav_model_h1_information_expected(lavobject = object)
+  return_value <- lav_model_h1_info_expected(lavobject = object)
   # this affects fit measures gfi, agfi, pgfi
 
 
@@ -2210,7 +2210,7 @@ lav_object_inspect_wls_v <- function(object,
   }
 
   if (add_labels) {
-    tmp_names <- lav_object_inspect_delta_rownames(object,
+    tmp_names <- lav_inspect_delta_rownames(object,
       drop_list_single_group = FALSE)
   }
 
@@ -2239,7 +2239,7 @@ lav_object_inspect_wls_v <- function(object,
 }
 
 
-lav_object_inspect_sampstat_gamma <- function(object,         # nolint
+lav_inspect_sampstat_gamma <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   if (!is.null(object@SampleStats@NACOV[[1]])) {
@@ -2249,7 +2249,7 @@ lav_object_inspect_sampstat_gamma <- function(object,         # nolint
   }
 
   if (add_labels) {
-    tmp_names <- lav_object_inspect_delta_rownames(object,
+    tmp_names <- lav_inspect_delta_rownames(object,
       drop_list_single_group = FALSE)
   }
 
@@ -2296,7 +2296,7 @@ lav_object_inspect_sampstat_gamma <- function(object,         # nolint
 }
 
 
-lav_object_inspect_gradient <- function(object,
+lav_inspect_grad <- function(object,
     add_labels = FALSE, add_class = FALSE, logl = FALSE,
     optim = FALSE) {
 
@@ -2316,7 +2316,7 @@ lav_object_inspect_gradient <- function(object,
   }
   current_verbose <- lav_verbose()
   if (lav_verbose(FALSE)) on.exit(lav_verbose(current_verbose), TRUE)
-  dx <- lav_model_gradient(
+  dx <- lav_model_grad(
     lavmodel       = lavmodel,
     glist          = NULL,
     lavsamplestats = lavsamplestats,
@@ -2340,7 +2340,7 @@ lav_object_inspect_gradient <- function(object,
           nclusters <- lavdata@Lp[[1]]$nclusters[[2]]
           dx <- dx * (2 * tmp_n) / nclusters
         } else {
-          group_values <- lav_partable_group_values(lavpartable)
+          group_values <- lav_pt_group_values(lavpartable)
           for (g in seq_len(lavdata@ngroups)) {
             tmp_n <- lavdata@Lp[[g]]$nclusters[[1]]
             nclusters <- lavdata@Lp[[g]]$nclusters[[2]]
@@ -2379,7 +2379,7 @@ lav_object_inspect_gradient <- function(object,
   # labels
   if (add_labels) {
     if (optim && lavmodel@eq.constraints) {
-      tmp_names_all <- lav_partable_labels(object@ParTable, type = "free")
+      tmp_names_all <- lav_pt_labels(object@ParTable, type = "free")
       tmp_seq <- seq_along(tmp_names_all)
       pack_seq <- as.numeric((tmp_seq - lavmodel@eq.constraints.k0) %*%
         +lavmodel@eq.constraints.K)
@@ -2388,7 +2388,7 @@ lav_object_inspect_gradient <- function(object,
       tmp_names[ok_idx] <- tmp_names_all[pack_seq[ok_idx]]
       names(dx) <- tmp_names
     } else {
-      names(dx) <- lav_partable_labels(object@ParTable, type = "free")
+      names(dx) <- lav_pt_labels(object@ParTable, type = "free")
     }
   }
 
@@ -2400,7 +2400,7 @@ lav_object_inspect_gradient <- function(object,
   dx
 }
 
-lav_object_inspect_hessian <- function(object,
+lav_inspect_hessian <- function(object,
     add_labels = FALSE, add_class = FALSE) {
 
   return_value <- lav_model_hessian(
@@ -2414,7 +2414,7 @@ lav_object_inspect_hessian <- function(object,
   # labels
   if (add_labels) {
     colnames(return_value) <- rownames(return_value) <-
-      lav_partable_labels(object@ParTable, type = "free")
+      lav_pt_labels(object@ParTable, type = "free")
   }
 
   # class
@@ -2425,7 +2425,7 @@ lav_object_inspect_hessian <- function(object,
   return_value
 }
 
-lav_object_inspect_information <- function(object,
+lav_inspect_info <- function(object,
     information = "default", augmented = FALSE, inverted = FALSE,
     add_labels = FALSE, add_class = FALSE) {
 
@@ -2434,7 +2434,7 @@ lav_object_inspect_information <- function(object,
     object@Options$information <- information
   }
 
-  return_value <- lav_model_information(lavmodel =  object@Model,
+  return_value <- lav_model_info(lavmodel =  object@Model,
     lavsamplestats = object@SampleStats,
     lavdata        = object@Data,
     lavcache       = object@Cache,
@@ -2447,7 +2447,7 @@ lav_object_inspect_information <- function(object,
 
   # labels
   if (add_labels) {
-    tmp_names <- lav_partable_labels(object@ParTable, type = "free")
+    tmp_names <- lav_pt_labels(object@ParTable, type = "free")
     if (augmented) {
       n_extra <- nrow(return_value) - length(tmp_names)
       if (n_extra > 0L) {
@@ -2465,7 +2465,7 @@ lav_object_inspect_information <- function(object,
   return_value
 }
 
-lav_object_inspect_h1_information <- function(object,            # nolint
+lav_inspect_h1_info <- function(object,
     information = "default", h1_information = "default", inverted = FALSE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
@@ -2482,7 +2482,7 @@ lav_object_inspect_h1_information <- function(object,            # nolint
   lavdata  <- object@Data
 
   # list!
-  return_value <- lav_model_h1_information(lavmodel = lavmodel,
+  return_value <- lav_model_h1_info(lavmodel = lavmodel,
     lavsamplestats = object@SampleStats,
     lavdata        = lavdata,
     lavcache       = object@Cache,
@@ -2496,7 +2496,7 @@ lav_object_inspect_h1_information <- function(object,            # nolint
   # }
 
   if (add_labels) {
-    tmp_names <- lav_object_inspect_delta_rownames(object,
+    tmp_names <- lav_inspect_delta_rownames(object,
       drop_list_single_group = FALSE)
   }
 
@@ -2526,7 +2526,7 @@ lav_object_inspect_h1_information <- function(object,            # nolint
   return_value
 }
 
-lav_object_inspect_vcov <- function(object, standardized = FALSE,
+lav_inspect_vcov <- function(object, standardized = FALSE,
     type = "std.all", free_only = TRUE,
     add_labels = FALSE, add_class = FALSE, remove_duplicated = FALSE) {
 
@@ -2535,7 +2535,7 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
 
   # store partable with pta in object to use cache in called functions
   if (is.null(attr(object, "vnames"))) {
-    object@ParTable <- lav_partable_set_cache(object@ParTable, object@pta)
+    object@ParTable <- lav_pt_set_cache(object@ParTable, object@pta)
   }
 
   if (object@optim$npar == 0) {
@@ -2679,7 +2679,7 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
 
     # force return.value to be symmetric and pd
     return_value <- (return_value + t(return_value)) / 2
-    # return.value <- lav_matrix_symmetric_force_pd(return.value,
+    # return.value <- lav_mat_sym_force_pd(return.value,
     #                                     tol = 1e-09) # was 1e-06 < 0.6-9
   }
 
@@ -2689,7 +2689,7 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
     #    # todo
     # } else {
     colnames(return_value) <- rownames(return_value) <-
-      lav_partable_labels(object@ParTable,
+      lav_pt_labels(object@ParTable,
                           ## add "user" labels?
                           type = ifelse(standardized && !free_only,
                                         "user", "free"))
@@ -2698,9 +2698,9 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
 
   # alias?
   if (remove_duplicated && lavmodel@eq.constraints) {
-    simple_flag <- lav_constraints_check_simple(lavmodel)
+    simple_flag <- lav_con_check_simple(lavmodel)
     if (simple_flag) {
-      tmp_lab <- lav_partable_labels(object@ParTable, type = "free")
+      tmp_lab <- lav_pt_labels(object@ParTable, type = "free")
       dup_flag <- duplicated(tmp_lab)
       return_value <- return_value[!dup_flag, !dup_flag, drop = FALSE]
     } else {
@@ -2718,7 +2718,7 @@ lav_object_inspect_vcov <- function(object, standardized = FALSE,
   return_value
 }
 
-lav_object_inspect_vcov_def <- function(object, joint = FALSE,
+lav_inspect_vcov_def <- function(object, joint = FALSE,
     standardized = FALSE, type = "std.all",
     add_labels = FALSE, add_class = FALSE) {
 
@@ -2736,7 +2736,7 @@ lav_object_inspect_vcov_def <- function(object, joint = FALSE,
 
   if (standardized) {
     # Monte Carlo path: empirical cov of the standardized def parameters
-    mc_coef_std <- lav_object_inspect_mc(object)
+    mc_coef_std <- lav_inspect_mc(object)
     if (!is.null(mc_coef_std) && length(def_idx) > 0L) {
       if (type == "std.lv") {
         tmp_fun_std <- lav_standardize_lv_x
@@ -2766,7 +2766,7 @@ lav_object_inspect_vcov_def <- function(object, joint = FALSE,
     }
     # delta-based standardized cov (default path)
     if (is.null(mc_coef_std) || length(def_idx) == 0L) {
-      tmp_vcov <- lav_object_inspect_vcov(object,
+      tmp_vcov <- lav_inspect_vcov(object,
         standardized = TRUE,
         type = type, free_only = FALSE,
         add_labels = FALSE, add_class = FALSE)
@@ -2781,7 +2781,7 @@ lav_object_inspect_vcov_def <- function(object, joint = FALSE,
     x <- lav_model_get_parameters(lavmodel, type = "free")
 
     # bootstrap, Monte Carlo or delta?
-    mc_coef <- lav_object_inspect_mc(object)
+    mc_coef <- lav_inspect_mc(object)
     if (!is.null(object@boot$coef)) {
       tmp_boot <- object@boot$coef
       # remove NA rows
@@ -2813,7 +2813,7 @@ lav_object_inspect_vcov_def <- function(object, joint = FALSE,
       return_value <- cov(mc_def) * (nmc - 1) / nmc
     } else {
       # tmp.vcov
-      tmp_vcov <- lav_object_inspect_vcov(object,
+      tmp_vcov <- lav_inspect_vcov(object,
         standardized = FALSE,
         type = type, free_only = TRUE,
         add_labels = FALSE,
@@ -2911,10 +2911,10 @@ lav_object_inspect_vcov_def <- function(object, joint = FALSE,
   return_value
 }
 
-lav_object_inspect_ugamma <- function(object,                  # nolint
+lav_inspect_ugamma <- function(object,
     add_labels = FALSE, add_class = FALSE) {
 
-  out <- lav_test_satorra_bentler(lavobject = object,
+  out <- lav_test_sb(lavobject = object,
     method = "original",
     return_ugamma = TRUE)
   return_value <- out$UGamma
@@ -2932,10 +2932,10 @@ lav_object_inspect_ugamma <- function(object,                  # nolint
   return_value
 }
 
-lav_object_inspect_u_from_ugamma <- function(object,            # nolint
+lav_inspect_u_from_ugamma <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
-  out <- lav_test_satorra_bentler(lavobject     = object,
+  out <- lav_test_sb(lavobject     = object,
     method        = "original",
     return_u      = TRUE)
   return_value <- out$UfromUGamma
@@ -2955,7 +2955,7 @@ lav_object_inspect_u_from_ugamma <- function(object,            # nolint
 
 
 # Delta (jacobian: d samplestats / d free_parameters)
-lav_object_inspect_delta <- function(object,
+lav_inspect_delta <- function(object,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   lavmodel    <- object@Model
@@ -2963,7 +2963,7 @@ lav_object_inspect_delta <- function(object,
   lavpartable <- object@ParTable
   # lavpta      <- object@pta
 
-  return_value <- lav_object_inspect_delta_internal(lavmodel = lavmodel,
+  return_value <- lav_inspect_delta_internal(lavmodel = lavmodel,
     lavdata = lavdata, lavpartable = lavpartable,
     add_labels = add_labels, add_class = add_class,
     drop_list_single_group = drop_list_single_group)
@@ -2971,7 +2971,7 @@ lav_object_inspect_delta <- function(object,
   return_value
 }
 
-lav_object_inspect_delta_rownames <- function(                # nolint
+lav_inspect_delta_rownames <- function(
     object,
     lavmodel = NULL,
     lavpartable = NULL,
@@ -2983,7 +2983,7 @@ lav_object_inspect_delta_rownames <- function(                # nolint
     lavdata     <- object@Data
   } else {
     lavdata     <- NULL
-    lavpta <- lav_partable_attributes(lavpartable)
+    lavpta <- lav_pt_attributes(lavpartable)
   }
 
   categorical    <- lavmodel@categorical
@@ -3023,10 +3023,10 @@ lav_object_inspect_delta_rownames <- function(                # nolint
     #             paste, collapse = "~~")
 
     # if(categorical) {
-    #    names.cor <- tmp[lav_matrix_vech_idx(nvar, diagonal = FALSE)]
-    #    names.var <- tmp[lav_matrix_diag_idx(nvar)[num.idx[[g]]]]
+    #    names.cor <- tmp[lav_mat_vech_idx(nvar, diagonal = FALSE)]
+    #    names.var <- tmp[lav_mat_diag_idx(nvar)[num.idx[[g]]]]
     # } else {
-    #    names.cov <- tmp[lav_matrix_vech_idx(nvar, diagonal = TRUE)]
+    #    names.cov <- tmp[lav_mat_vech_idx(nvar, diagonal = TRUE)]
     # }
 
     # NOTE: in 0.6-1, we use the same order, but 'label' in row-wise
@@ -3034,12 +3034,12 @@ lav_object_inspect_delta_rownames <- function(                # nolint
     tmp <- matrix(apply(expand.grid(ov_names, ov_names), 1L,
       paste, collapse = "~~"), nrow = nvar)
     if (categorical) {
-      names_cor <- lav_matrix_vechru(tmp, diagonal = FALSE)
+      names_cor <- lav_mat_vechru(tmp, diagonal = FALSE)
       names_var <- diag(tmp)[num_idx[[g]]]
     } else if (correlation) {
-      names_cor <- lav_matrix_vechru(tmp, diagonal = FALSE)
+      names_cor <- lav_mat_vechru(tmp, diagonal = FALSE)
     } else {
-      names_cov <- lav_matrix_vechru(tmp, diagonal = TRUE)
+      names_cov <- lav_mat_vechru(tmp, diagonal = TRUE)
     }
 
 
@@ -3101,7 +3101,7 @@ lav_object_inspect_delta_rownames <- function(                # nolint
   return_value
 }
 
-lav_object_inspect_delta_internal <- function(                   # nolint
+lav_inspect_delta_internal <- function(
     lavmodel = NULL, lavdata  = NULL,
     lavpartable = NULL,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
@@ -3109,8 +3109,8 @@ lav_object_inspect_delta_internal <- function(                   # nolint
   return_value <- lav_model_delta(lavmodel)
 
   if (add_labels) {
-    tmp_pnames <- lav_partable_labels(lavpartable, type = "free")
-    tmp_rownames  <- lav_object_inspect_delta_rownames(object = NULL,
+    tmp_pnames <- lav_pt_labels(lavpartable, type = "free")
+    tmp_rownames  <- lav_inspect_delta_rownames(object = NULL,
       lavmodel = lavmodel, lavpartable = lavpartable,
       drop_list_single_group = FALSE)
   }
@@ -3141,7 +3141,7 @@ lav_object_inspect_delta_internal <- function(                   # nolint
   return_value
 }
 
-lav_object_inspect_zero_cell_tables <-                          # nolint
+lav_inspect_zero_cell_tables <-                          # nolint
   function(object, add_labels = FALSE, add_class = FALSE,
             drop_list_single_group = FALSE) {
   # categorical?
@@ -3173,7 +3173,7 @@ lav_object_inspect_zero_cell_tables <-                          # nolint
       drop_list_single_group = drop_list_single_group)
 }
 
-lav_object_inspect_coef <- function(object, type = "free",
+lav_inspect_coef <- function(object, type = "free",
                                     add_labels = FALSE, add_class = FALSE) {
 
   if (type == "user" || type == "all") {
@@ -3187,12 +3187,12 @@ lav_object_inspect_coef <- function(object, type = "free",
       "%1$s argument must be either %2$s or %3$s",
       "type", "free", "user"))
   }
-  tmp_est <- lav_object_inspect_est(object)
+  tmp_est <- lav_inspect_est(object)
   cof <- tmp_est[idx]
 
   # labels?
   if (add_labels) {
-    names(cof) <- lav_partable_labels(object@ParTable, type = type)
+    names(cof) <- lav_pt_labels(object@ParTable, type = type)
   }
 
   # class
@@ -3203,7 +3203,7 @@ lav_object_inspect_coef <- function(object, type = "free",
   cof
 }
 
-lav_object_inspect_npar <- function(object, ceq = FALSE) {
+lav_inspect_npar <- function(object, ceq = FALSE) {
 
   # free parameters (going to the optimizer)
   npar <- object@Model@nx.free
@@ -3220,7 +3220,7 @@ lav_object_inspect_npar <- function(object, ceq = FALSE) {
   npar
 }
 
-lav_object_inspect_icc <- function(object, add_labels = FALSE,
+lav_inspect_icc <- function(object, add_labels = FALSE,
                                    add_class = FALSE,
                                    drop_list_single_group = FALSE) {
 
@@ -3283,7 +3283,7 @@ lav_object_inspect_icc <- function(object, add_labels = FALSE,
   return_value
 }
 
-lav_object_inspect_ranef <- function(object, add_labels = FALSE,
+lav_inspect_ranef <- function(object, add_labels = FALSE,
                                      add_class = FALSE,
                                      drop_list_single_group = FALSE) {
 
@@ -3312,8 +3312,8 @@ lav_object_inspect_ranef <- function(object, add_labels = FALSE,
     implied_group <- lapply(lavimplied, function(x) x[group_idx])
 
     # random effects (=random intercepts or cluster means)
-    out <- lav_mvnorm_cluster_implied22l(lp = tmp_lp, implied = implied_group)
-    mb_j <- lav_mvnorm_cluster_em_estep_ranef(ylp = tmp_ylp, lp = tmp_lp,
+    out <- lav_mvn_cl_implied22l(lp = tmp_lp, implied = implied_group)
+    mb_j <- lav_mvn_cl_em_estep_ranef(ylp = tmp_ylp, lp = tmp_lp,
       sigma_w = out$sigma.w, sigma_b = out$sigma.b,
       sigma_zz = out$sigma.zz, sigma_yz = out$sigma.yz,
       mu_z = out$mu.z, mu_w = out$mu.w, mu_b = out$mu.b,
@@ -3346,7 +3346,7 @@ lav_object_inspect_ranef <- function(object, add_labels = FALSE,
 }
 
 # casewise loglikelihood contributions
-lav_object_inspect_loglik_casewise <- function(object, log_1 = TRUE, # nolint
+lav_inspect_loglik_casewise <- function(object, log_1 = TRUE,
     add_labels = FALSE, add_class = FALSE, drop_list_single_group = FALSE) {
 
   lavdata <- object@Data
@@ -3374,7 +3374,7 @@ lav_object_inspect_loglik_casewise <- function(object, log_1 = TRUE, # nolint
 
     if (lavsamplestats@missing.flag) {
       return_value[[g]] <-
-        lav_mvnorm_missing_llik_casewise(y = lavdata@X[[g]],
+        lav_mvn_mi_llik_casewise(y = lavdata@X[[g]],
           wt = lavdata@weights[[g]],
           mu = lavimplied$mean[[g]],
           sigma_1 = lavimplied$cov[[g]],
@@ -3400,7 +3400,7 @@ lav_object_inspect_loglik_casewise <- function(object, log_1 = TRUE, # nolint
           tmp_mean <- lavsamplestats@mean[[g]]
         }
         return_value[[g]] <-
-          lav_mvnorm_loglik_data(y = lavdata@X[[g]],
+          lav_mvn_loglik_data(y = lavdata@X[[g]],
             wt = lavdata@weights[[g]],
             mu = tmp_mean,
             sigma_1 = lavimplied$cov[[g]],
@@ -3447,7 +3447,7 @@ lav_object_inspect_loglik_casewise <- function(object, log_1 = TRUE, # nolint
 #  residuals; but asymptotically, only when we use Bartlett factor
 #  scores are the 'true scores' (=LAMBDA %*% FS) orthogonal to the
 #  casewise residuals)
-lav_object_inspect_mdist2 <- function(object, type = "resid", squared = TRUE,
+lav_inspect_mdist2 <- function(object, type = "resid", squared = TRUE,
                                       add_labels = FALSE, add_class = FALSE,
                                       drop_list_single_group = FALSE) {
 
@@ -3489,7 +3489,7 @@ lav_object_inspect_mdist2 <- function(object, type = "resid", squared = TRUE,
 
 # N versus N-1 (or N versus N-G in the multiple group setting)
 # Changed 0.5-15: suggestion by Mark Seeto
-lav_object_inspect_ntotal <- function(object) {
+lav_inspect_ntotal <- function(object) {
   if (object@Options$estimator %in% c("ML", "PML", "FML", "catML") &&
     object@Options$likelihood %in% c("default", "normal")) {
     n <- object@SampleStats@ntotal
@@ -3500,7 +3500,7 @@ lav_object_inspect_ntotal <- function(object) {
   n
 }
 
-lav_object_inspect_iv <- function(object, drop_list_single_group = FALSE) {
+lav_inspect_iv <- function(object, drop_list_single_group = FALSE) {
 
   if (is.null(object@internal$eqs)) {
     lav_msg_stop(gettext("no equations/ivs found"))
@@ -3545,7 +3545,7 @@ lav_object_inspect_iv <- function(object, drop_list_single_group = FALSE) {
   return_value
 }
 
-lav_object_inspect_eqs <- function(object, drop_list_single_group = FALSE) {
+lav_inspect_eqs <- function(object, drop_list_single_group = FALSE) {
 
   if (is.null(object@internal$eqs)) {
     lav_msg_stop(gettext("no equations/ivs found"))
@@ -3571,7 +3571,7 @@ lav_object_inspect_eqs <- function(object, drop_list_single_group = FALSE) {
   return_value
 }
 
-lav_object_inspect_sargan <- function(object, drop_list_single_group = FALSE) {
+lav_inspect_sargan <- function(object, drop_list_single_group = FALSE) {
 
   if (is.null(object@internal$eqs)) {
     lav_msg_stop(gettext("no equations/ivs found"))

--- a/R/lav_object_methods.R
+++ b/R/lav_object_methods.R
@@ -153,7 +153,7 @@ setMethod(
     # check object
     object <- lav_object_check_version(object)
 
-    lav_object_inspect_coef(
+    lav_inspect_coef(
       object = object, type = type,
       add_labels = labels, add_class = TRUE
     )
@@ -246,7 +246,7 @@ standardizedSolution <-                                      # nolint start
 
     if (object@Options$se != "none" && se) {
       # add 'se' for standardized parameters
-      tmp_vcov <- try(lav_object_inspect_vcov(object,
+      tmp_vcov <- try(lav_inspect_vcov(object,
         standardized = TRUE,
         type = type, free_only = FALSE,
         add_labels = FALSE,
@@ -304,7 +304,7 @@ standardizedSolution <-                                      # nolint start
 
       # Monte Carlo: asymmetric percentile-based CI for standardized
       # defined parameters (Preacher & Selig 2012)
-      mc_coef <- lav_object_inspect_mc(object)
+      mc_coef <- lav_inspect_mc(object)
       def_idx <- which(tmp_list$op == ":=")
       if (!is.null(mc_coef) && length(def_idx) > 0L) {
         if (type == "std.lv") {
@@ -545,7 +545,7 @@ lavParameterEstimates <- function(object,                      # nolint start
 
     # add se, zstat, pvalue
     if (se && object@Options$se != "none") {
-      tmp_list$se <- lav_object_inspect_se(object)
+      tmp_list$se <- lav_inspect_se(object)
       # handle tiny SEs
       tmp_list$se <- ifelse(tmp_list$se < sqrt(.Machine$double.eps),
         0, tmp_list$se
@@ -580,7 +580,7 @@ lavParameterEstimates <- function(object,                      # nolint start
     if (object@Options$se == "bootstrap" ||
       "bootstrap" %in% object@Options$test ||
       "bollen.stine" %in% object@Options$test) {
-      tmp_boot <- lav_object_inspect_boot(object)
+      tmp_boot <- lav_inspect_boot(object)
       bootstrap_seed <- attr(tmp_boot, "seed") # for bca
       error_idx <- attr(tmp_boot, "error.idx")
       if (length(error_idx) > 0L) {
@@ -602,7 +602,7 @@ lavParameterEstimates <- function(object,                      # nolint start
         ci <- tmp_list$est + tmp_list$se %o% fac
         # Monte Carlo: replace CI for defined parameters with
         # asymmetric percentile-based bounds (Preacher & Selig 2012)
-        mc_coef <- lav_object_inspect_mc(object)
+        mc_coef <- lav_inspect_mc(object)
         def_idx <- which(object@ParTable$op == ":=")
         if (!is.null(mc_coef) && length(def_idx) > 0L) {
           mc_def <- apply(mc_coef, 1L, object@Model@def.function)
@@ -938,7 +938,7 @@ lavParameterEstimates <- function(object,                      # nolint start
         lav_msg_warn(
           gettext("rsquare = TRUE, but there are no dependent variables"))
       } else {
-        if (lav_partable_nlevels(tmp_list) == 1L) {
+        if (lav_pt_nlevels(tmp_list) == 1L) {
           block <- rep(seq_along(r2), sapply(r2, length))
           first_block_idx <- which(!duplicated(tmp_list$block) &
             tmp_list$block > 0L)
@@ -981,7 +981,7 @@ lavParameterEstimates <- function(object,                      # nolint start
           step1_idx <- which(r2$lhs %in% ov_ind)
           r2$step[step1_idx] <- 1L
         }
-        tmp_list <- lav_partable_merge(pt1 = tmp_list, pt2 = r2, warn = FALSE)
+        tmp_list <- lav_pt_merge(pt1 = tmp_list, pt2 = r2, warn = FALSE)
       }
     }
 
@@ -1254,7 +1254,7 @@ setMethod(
       return(lavPredict(object, type = "ov", label = labels))
     }
 
-    lav_object_inspect_implied(object,
+    lav_inspect_implied(object,
       add_labels = labels, add_class = TRUE,
       drop_list_single_group = TRUE
     )
@@ -1306,7 +1306,7 @@ setMethod(
     ## verify there are any user-defined parameters
     #FIXME? smarter to check @ParTable for $op == ":="?
     if (is.null(formals(object@Model@def.function))) {
-      type <- "free" # avoids error in lav_object_inspect_vcov_def()
+      type <- "free" # avoids error in lav_inspect_vcov_def()
     }
 
     if (!is.null(standardized)) {
@@ -1321,7 +1321,7 @@ setMethod(
           "argument \"remove.duplicated\" not supported if type = \"user\""
         ))
       }
-      tmp_varcov <- lav_object_inspect_vcov_def(object,
+      tmp_varcov <- lav_inspect_vcov_def(object,
         joint = TRUE,
         standardized = !is.null(standardized),
         type = ifelse(is.null(standardized), "std.all", standardized),
@@ -1329,7 +1329,7 @@ setMethod(
         add_class = TRUE
       )
     } else if (type == "free") {
-      tmp_varcov <- lav_object_inspect_vcov(object,
+      tmp_varcov <- lav_inspect_vcov(object,
         standardized = !is.null(standardized),
         type = ifelse(is.null(standardized), "std.all", standardized),
         free_only = free.only,
@@ -1473,7 +1473,7 @@ setMethod(
     if (!(mode(add) %in% c("list", "character"))) {
       lav_msg_stop(
         gettext("'add' argument must be model syntax or parameter table.
-                See ?lav_model_partable help page.")
+                See ?lav_model_pt help page.")
       )
     }
     tmp_pt <- lav_object_extended(newfit, add = add)@ParTable

--- a/R/lav_object_summary.R
+++ b/R/lav_object_summary.R
@@ -256,7 +256,7 @@ lav_object_summary <- function(object, header = TRUE,
       lav_msg_warn(gettext(
         "fit measures not available if model did not converge"))
     } else {
-      fit <- lav_fit_measures(object,
+      fit <- lav_fit(object,
        fit_measures = c(list(fit.measures = fit_measures), fm_args),
        baseline_model = baseline_model,
        h1_model = h1_model)

--- a/R/lav_objective.R
+++ b/R/lav_objective.R
@@ -178,7 +178,7 @@ lav_model_objective_fiml <- function(sigma_hat = NULL, mu_hat = NULL, yp = NULL,
   }
 
   # Note: we ignore x.idx (if any)
-  fx <- lav_mvnorm_missing_loglik_samplestats(
+  fx <- lav_mvn_mi_loglik_samp(
     yp = yp,
     mu = mu_hat, sigma_1 = sigma_hat,
     log2pi = FALSE,
@@ -243,7 +243,7 @@ lav_model_objective_pml <- function(sigma_hat = NULL, # model-based var/cov/cor
     return(out)
   }
   cor_hat <- cov2cor(sigma_hat2) # to get correlations (rho!)
-  cors <- lav_matrix_vech(cor_hat, diagonal = FALSE)
+  cors <- lav_mat_vech(cor_hat, diagonal = FALSE)
 
   if (length(cors) > 0L && (any(abs(cors) > 1) ||
     any(is.na(cors)))) {
@@ -475,7 +475,7 @@ lav_model_objective_pml <- function(sigma_hat = NULL, # model-based var/cov/cor
     # - no need to compute 'casewise' (log)likelihoods
 
     pstar_1 <- matrix(0, nvar, nvar) # utility matrix, to get indices
-    pstar_1[lav_matrix_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
+    pstar_1[lav_mat_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
     # n <- NROW(x)
 
     log_lik_pair <- numeric(pstar) # logl per pair (summed over cases)
@@ -484,7 +484,7 @@ lav_model_objective_pml <- function(sigma_hat = NULL, # model-based var/cov/cor
         pstar_idx <- pstar_1[i, j]
         if (ov_types[i] == "numeric" &&
           ov_types[j] == "numeric") {
-          log_lik <- lav_mvnorm_loglik_data(
+          log_lik <- lav_mvn_loglik_data(
             y = x[, c(i, j)], wt = wt, mu = mu_hat[c(i, j)],
             sigma_1 = sigma_hat[c(i, j), c(i, j)], casewise = TRUE
           )
@@ -552,7 +552,7 @@ lav_model_objective_pml <- function(sigma_hat = NULL, # model-based var/cov/cor
   } else {
     lik <- matrix(0, nrow(x), pstar) # likelihood per case, per pair
     pstar_1 <- matrix(0, nvar, nvar) # utility matrix, to get indices
-    pstar_1[lav_matrix_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
+    pstar_1[lav_mat_vech_idx(nvar, diagonal = FALSE)] <- 1:pstar
     # n <- NROW(x)
 
     for (j in seq_len(nvar - 1L)) {
@@ -821,13 +821,13 @@ lav_model_objective_2l <- function(lavmodel = NULL,
     #    return(+Inf)
     # }
     # COR.B <- cov2cor(SIGMA.B)
-    # if(any(abs(lav_matrix_vech(COR.B, diagonal = FALSE)) > 1)) {
+    # if(any(abs(lav_mat_vech(COR.B, diagonal = FALSE)) > 1)) {
     #   return(+Inf)
     # }
 
     y2 <- lavsamplestats@YLp[[group]][[2]]$Y2
     # yp <- lavsamplestats@missing[[group]]
-    loglik <- lav_mvnorm_cluster_missing_loglik_samplestats_2l(
+    loglik <- lav_mvn_cl_mi_loglik_samp_2l(
       y1 = y1,
       y2 = y2, lp = lp, mp = mp,
       mu_w = mu_w, sigma_w = sigma_w,
@@ -837,7 +837,7 @@ lav_model_objective_2l <- function(lavmodel = NULL,
   } else {
     ylp <- lavsamplestats@YLp[[group]]
     if (lavmodel@conditional.x) {
-      loglik <- lav_mvreg_cluster_loglik_samplestats_2l(
+      loglik <- lav_mvreg_cl_loglik_samp_2l(
         ylp = ylp, lp = lp,
         res_sigma_w = res_sigma_w,
         res_int_w = res_int_w, res_pi_w = res_pi_w,
@@ -846,7 +846,7 @@ lav_model_objective_2l <- function(lavmodel = NULL,
         log2pi = FALSE, minus_two = TRUE
       )
     } else {
-      loglik <- lav_mvnorm_cluster_loglik_samplestats_2l(
+      loglik <- lav_mvn_cl_loglik_samp_2l(
         ylp = ylp, lp = lp,
         mu_w = mu_w, sigma_w = sigma_w,
         mu_b = mu_b, sigma_b = sigma_b,

--- a/R/lav_optim_gn.R
+++ b/R/lav_optim_gn.R
@@ -45,7 +45,7 @@ lav_objective_gn <- function(x, lavsamplestats = NULL, lavmodel = NULL,
   wls_obs <- lavsamplestats@WLS.obs
 
   # always use expected information
-  a1 <- lav_model_h1_information_expected(
+  a1 <- lav_model_h1_info_expected(
     lavobject = NULL,
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats,

--- a/R/lav_optim_noniter.R
+++ b/R/lav_optim_noniter.R
@@ -6,8 +6,8 @@
 lav_optim_noniter <- function(lavmodel = NULL, lavsamplestats = NULL,
                               lavpartable = NULL, lavh1 = NULL,
                               lavdata = NULL, lavoptions = NULL) {
-  lavpta <- lav_partable_attributes(lavpartable)
-  lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+  lavpta <- lav_pt_attributes(lavpartable)
+  lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
 
   # no support for many things:
   if (lavmodel@ngroups > 1L) {

--- a/R/lav_partable.R
+++ b/R/lav_partable.R
@@ -15,44 +15,44 @@
 # - 24 March 2019: handle efa sets
 # - 23 May   2020: support for random slopes
 
-lav_model_partable  <- function(
-                                model = NULL,            # nolint start
-                                meanstructure = FALSE,
-                                int.ov.free = FALSE,
-                                int.lv.free = FALSE,
-                                marker.int.zero = FALSE,
-                                orthogonal = FALSE,
-                                orthogonal.y = FALSE,
-                                orthogonal.x = FALSE,
-                                orthogonal.efa = FALSE,
-                                std.lv = FALSE,
-                                correlation = FALSE,
-                                composites = TRUE,
-                                effect.coding = "",
-                                conditional.x = FALSE,
-                                fixed.x = FALSE,
-                                parameterization = "delta",
-                                constraints = NULL,
-                                ceq.simple = FALSE,
-                                auto = FALSE,
-                                model.type = "sem",
-                                auto.fix.first = FALSE,
-                                auto.fix.single = FALSE,
-                                auto.var = FALSE,
-                                auto.cov.lv.x = FALSE,
-                                auto.cov.y = FALSE,
-                                auto.th = FALSE,
-                                auto.delta = FALSE,
-                                auto.efa = FALSE,
-                                varTable = NULL,
-                                ngroups = 1L,
-                                nthresholds = NULL,
-                                group.equal = NULL,
-                                group.partial = NULL,
-                                group.w.free = FALSE,
-                                debug = FALSE,
-                                warn = TRUE,
-                                as.data.frame. = TRUE) {  # nolint end
+lav_model_pt  <- function(
+                          model = NULL,
+                          meanstructure = FALSE,
+                          int_ov_free = FALSE,
+                          int_lv_free = FALSE,
+                          marker_int_zero = FALSE,
+                          orthogonal = FALSE,
+                          orthogonal_y = FALSE,
+                          orthogonal_x = FALSE,
+                          orthogonal_efa = FALSE,
+                          std_lv = FALSE,
+                          correlation = FALSE,
+                          composites = TRUE,
+                          effect_coding = "",
+                          conditional_x = FALSE,
+                          fixed_x = FALSE,
+                          parameterization = "delta",
+                          constraints = NULL,
+                          ceq_simple = FALSE,
+                          auto = FALSE,
+                          model_type = "sem",
+                          auto_fix_first = FALSE,
+                          auto_fix_single = FALSE,
+                          auto_var = FALSE,
+                          auto_cov_lv_x = FALSE,
+                          auto_cov_y = FALSE,
+                          auto_th = FALSE,
+                          auto_delta = FALSE,
+                          auto_efa = FALSE,
+                          var_table = NULL,
+                          ngroups = 1L,
+                          nthresholds = NULL,
+                          group_equal = NULL,
+                          group_partial = NULL,
+                          group_w_free = FALSE,
+                          debug = FALSE,
+                          warn = TRUE,
+                          as_data_frame = TRUE) {
   if (!missing(debug)) {
     current_debug <- lav_debug()
     if (lav_debug(debug))
@@ -64,26 +64,11 @@ lav_model_partable  <- function(
       on.exit(lav_warn(current_warn), TRUE)
   }
 
-  # copy arguments which are not snake_case and modified within function
-  int_ov_free <- int.ov.free
-  int_lv_free <- int.lv.free
-  effect_coding <- effect.coding
-  ceq_simple <- ceq.simple
-  auto_fix_first <- auto.fix.first
-  auto_fix_single <- auto.fix.single
-  auto_var <- auto.var
-  auto_cov_lv_x <- auto.cov.lv.x
-  auto_cov_y <- auto.cov.y
-  auto_th <- auto.th
-  auto_delta <- auto.delta
-  auto_efa <- auto.efa
-  var_table <- varTable
-
   # check if model is already flat or a full parameter table
   if (is.list(model) && !is.null(model$lhs)) {
     if (is.null(model$mod.idx)) {
       lav_msg_warn(gettext("input already looks like a parameter table"))
-      return(lav_partable_set_cache(model))
+      return(lav_pt_set_cache(model))
     } else {
       flat <- model
     }
@@ -148,9 +133,9 @@ lav_model_partable  <- function(
 
   # check for wrongly specified variances/covariances/intercepts
   # of exogenous variables in model syntax (if fixed.x=TRUE)
-  if (fixed.x && lav_warn()) { # we ignore the groups here!
+  if (fixed_x && lav_warn()) { # we ignore the groups here!
     # we only call this function for the warning message
-    tmp <- lav_partable_vnames(flat, "ov.x", force_warn = TRUE)
+    tmp <- lav_pt_vnames(flat, "ov.x", force_warn = TRUE)
     rm(tmp)
   }
 
@@ -163,10 +148,10 @@ lav_model_partable  <- function(
 
   # auto=TRUE?
   if (auto) { # mimic sem/cfa auto behavior
-    if (model.type == "sem") {
+    if (model_type == "sem") {
       int_ov_free <- TRUE
       int_lv_free <- FALSE
-      auto_fix_first <- !std.lv
+      auto_fix_first <- !std_lv
       auto_fix_single <- TRUE
       auto_var <- TRUE
       auto_cov_lv_x <- TRUE
@@ -174,10 +159,10 @@ lav_model_partable  <- function(
       auto_th <- TRUE
       auto_delta <- TRUE
       auto_efa <- TRUE
-    } else if (model.type == "growth") {
+    } else if (model_type == "growth") {
       int_ov_free <- FALSE
       int_lv_free <- TRUE
-      auto_fix_first <- !std.lv
+      auto_fix_first <- !std_lv
       auto_fix_single <- TRUE
       auto_var <- TRUE
       auto_cov_lv_x <- TRUE
@@ -342,9 +327,9 @@ lav_model_partable  <- function(
       }
 
       # new in 0.6-8: if multilevel, use 'global' ov.names.x
-      if (fixed.x && block_lhs == "level") {
-        tmp_ov_names_x <- lav_partable_vnames(flat, "ov.x") # global
-        ov_names_x_block <- lav_partable_vnames(flat_block, "ov.x")
+      if (fixed_x && block_lhs == "level") {
+        tmp_ov_names_x <- lav_pt_vnames(flat, "ov.x") # global
+        ov_names_x_block <- lav_pt_vnames(flat_block, "ov.x")
         if (length(ov_names_x_block) > 0L) {
           idx <- which(!ov_names_x_block %in% tmp_ov_names_x)
           if (length(idx) > 0L) {
@@ -364,20 +349,20 @@ lav_model_partable  <- function(
 
       # new in 0.6-12: if multilevel and conditional.x, make sure
       # that 'split' exogenous covariates become 'y' variables
-      if (conditional.x && block_lhs == "level") {
+      if (conditional_x && block_lhs == "level") {
         if (ngroups == 1L) {
-          other_block_names <- lav_partable_vnames(flat, "ov",
+          other_block_names <- lav_pt_vnames(flat, "ov",
             block = seq_len(nblocks)[-block]
           )
         } else {
           # TEST ME
           this_group <- ceiling(block / nlevels)
           blocks_within_group <- (this_group - 1L) * nlevels + seq_len(nlevels)
-          other_block_names <- lav_partable_vnames(flat, "ov",
+          other_block_names <- lav_pt_vnames(flat, "ov",
             block = blocks_within_group[-block]
           )
         }
-        ov_names_x_block <- lav_partable_vnames(flat_block, "ov.x")
+        ov_names_x_block <- lav_pt_vnames(flat_block, "ov.x")
         if (length(ov_names_x_block) > 0L) {
           idx <- which(ov_names_x_block %in% other_block_names)
           if (length(idx) > 0L) {
@@ -388,15 +373,15 @@ lav_model_partable  <- function(
         ov_names_x_block <- NULL
       }
 
-      list_block <- lav_partable_flat(flat_block,
+      list_block <- lav_pt_flat(flat_block,
         blocks = tmp_blocks_lhs,
         block_id = block,
         meanstructure = meanstructure,
         int_ov_free = int_ov_free, int_lv_free = int_lv_free,
-        orthogonal = orthogonal, orthogonal_y = orthogonal.y,
-        orthogonal_x = orthogonal.x, orthogonal_efa = orthogonal.efa,
-        std_lv = std.lv, correlation = correlation, composites = composites,
-        conditional_x = conditional.x, fixed_x = fixed.x,
+        orthogonal = orthogonal, orthogonal_y = orthogonal_y,
+        orthogonal_x = orthogonal_x, orthogonal_efa = orthogonal_efa,
+        std_lv = std_lv, correlation = correlation, composites = composites,
+        conditional_x = conditional_x, fixed_x = fixed_x,
         parameterization = parameterization,
         auto_fix_first = auto_fix_first,
         auto_fix_single = auto_fix_single,
@@ -404,7 +389,7 @@ lav_model_partable  <- function(
         auto_cov_y = auto_cov_y, auto_th = auto_th,
         auto_delta = auto_delta, auto_efa = auto_efa,
         var_table = var_table, group_equal = NULL,
-        group_w_free = group.w.free, ngroups = 1L,
+        group_w_free = group_w_free, ngroups = 1L,
         nthresholds = nthresholds,
         ov_names_x_block = ov_names_x_block
       )
@@ -439,21 +424,21 @@ lav_model_partable  <- function(
       }
     }
   } else {
-    tmp_list <- lav_partable_flat(flat,
+    tmp_list <- lav_pt_flat(flat,
       blocks = "group",
       meanstructure = meanstructure,
       int_ov_free = int_ov_free, int_lv_free = int_lv_free,
-      orthogonal = orthogonal, orthogonal_y = orthogonal.y,
-      orthogonal_x = orthogonal.x, orthogonal_efa = orthogonal.efa,
-      std_lv = std.lv, correlation = correlation, composites = composites,
-      conditional_x = conditional.x, fixed_x = fixed.x,
+      orthogonal = orthogonal, orthogonal_y = orthogonal_y,
+      orthogonal_x = orthogonal_x, orthogonal_efa = orthogonal_efa,
+      std_lv = std_lv, correlation = correlation, composites = composites,
+      conditional_x = conditional_x, fixed_x = fixed_x,
       parameterization = parameterization,
       auto_fix_first = auto_fix_first, auto_fix_single = auto_fix_single,
       auto_var = auto_var, auto_cov_lv_x = auto_cov_lv_x,
       auto_cov_y = auto_cov_y, auto_th = auto_th,
       auto_delta = auto_delta, auto_efa = auto_efa,
-      var_table = var_table, group_equal = group.equal,
-      group_w_free = group.w.free,
+      var_table = var_table, group_equal = group_equal,
+      group_w_free = group_w_free,
       ngroups = ngroups, nthresholds = nthresholds
     )
   }
@@ -486,7 +471,7 @@ lav_model_partable  <- function(
   multilevel <- FALSE
   nlevels <- 1L
   if (!is.null(tmp_list$level)) {
-    nlevels <- lav_partable_nlevels(tmp_list)
+    nlevels <- lav_pt_nlevels(tmp_list)
     if (nlevels > 1L) {
       multilevel <- TRUE
     }
@@ -494,8 +479,8 @@ lav_model_partable  <- function(
   if (multilevel && any(tmp_list$op == "~1")) {
     # fix ov intercepts for all within ov that also appear at level 2
     # FIXME: not tested with > 2 levels
-    ov_names <- lav_partable_vnames(tmp_list, "ov") ## all names
-    level_values <- lav_partable_level_values(tmp_list)
+    ov_names <- lav_pt_vnames(tmp_list, "ov") ## all names
+    level_values <- lav_pt_level_values(tmp_list)
     other_names <- tmp_list$lhs[tmp_list$op == "~1" &
       tmp_list$level %in% level_values[-1L] &
       tmp_list$lhs %in% ov_names]
@@ -509,7 +494,7 @@ lav_model_partable  <- function(
   }
   if (multilevel && any(tmp_list$op == "|")) {
     # fix ALL thresholds at level 1
-    level_values <- lav_partable_level_values(tmp_list)
+    level_values <- lav_pt_level_values(tmp_list)
     th_idx <- which(tmp_list$op == "|" &
       tmp_list$level %in% level_values[1L])
     tmp_list$free[th_idx] <- 0L
@@ -575,7 +560,7 @@ lav_model_partable  <- function(
         #   (as this is a break from < 0.6-6)
         if (length(tmp_mod_label) == 1L) {
           tmp_mod_label <- rep(tmp_mod_label, ngroups)
-          if (is.null(group.equal) || length(group.equal) == 0L) {
+          if (is.null(group_equal) || length(group_equal) == 0L) {
             warn_about_single_label <- TRUE
           }
         }
@@ -737,11 +722,11 @@ lav_model_partable  <- function(
   } else {
     blocks <- "group"
   }
-  label <- lav_partable_labels(
+  label <- lav_pt_labels(
     partable = tmp_list,
     blocks = blocks,
-    group.equal = group.equal,
-    group.partial = group.partial
+    group_equal = group_equal,
+    group_partial = group_partial
   )
 
   if (lav_debug()) {
@@ -759,10 +744,10 @@ lav_model_partable  <- function(
   #       are constrained to be equal to the factor-loadings of the first
   #       set, no further constraints are needed
   if (auto_efa && !is.null(tmp_list$efa)) {
-    tmp_list <- lav_partable_efa_constraints(
+    tmp_list <- lav_pt_efa_con(
       list_1 = tmp_list,
-      orthogonal_efa = orthogonal.efa,
-      group_equal = group.equal
+      orthogonal_efa = orthogonal_efa,
+      group_equal = group_equal
     )
   } # auto_efa
 
@@ -960,7 +945,7 @@ lav_model_partable  <- function(
   if (any(c("loadings", "intercepts") %in% effect_coding)) {
     tmp <- list()
     # for each block
-    nblocks <- lav_partable_nblocks(tmp_list)
+    nblocks <- lav_pt_nblocks(tmp_list)
     for (b in seq_len(nblocks)) {
 
       # which group?
@@ -981,7 +966,7 @@ lav_model_partable  <- function(
           tmp_list$lhs == lv]
 
         if ("loadings" %in% effect_coding &&
-            (!"loadings" %in% group.equal || this_group == 1L)) {
+            (!"loadings" %in% group_equal || this_group == 1L)) {
           # factor loadings indicators of this lv
           loadings_idx <- which(tmp_list$op == "=~" &
             tmp_list$block == b &
@@ -1028,7 +1013,7 @@ lav_model_partable  <- function(
           nlevs <- table(tmp_list$lhs[thresholds_idx]) + 1
           kmax <- max(nlevs)
 
-          if (!"thresholds" %in% group.equal || this_group == 1L) {
+          if (!"thresholds" %in% group_equal || this_group == 1L) {
             # all free?
             if (length(thresholds_idx) > 0L && all(tmp_list$free[thresholds_idx] > 0L)) {
               for (ind in ind_names) {
@@ -1086,7 +1071,7 @@ lav_model_partable  <- function(
         } # thresholds
 
         if ("intercepts" %in% effect_coding &&
-            (!"intercepts" %in% group.equal || this_group == 1L)) {
+            (!"intercepts" %in% group_equal || this_group == 1L)) {
           # intercepts for indicators of this lv
           intercepts_idx <- which(tmp_list$op == "~1" &
             tmp_list$block == b &
@@ -1127,7 +1112,7 @@ lav_model_partable  <- function(
             }
           }
         } else if ("intercepts" %in% effect_coding &&
-                   "intercepts" %in% group.equal &&
+                   "intercepts" %in% group_equal &&
                    this_group > 1L) {
           ## add equality constraints of the newly-freed intercepts
           intercepts_idx <- which(tmp_list$op == "~1" &
@@ -1148,24 +1133,24 @@ lav_model_partable  <- function(
       } # lv
     } # blocks
 
-    tmp_list <- lav_partable_merge(tmp_list, tmp)
+    tmp_list <- lav_pt_merge(tmp_list, tmp)
   }
 
   # marker.int.zero
-  if (meanstructure && marker.int.zero) {
+  if (meanstructure && marker_int_zero) {
     # for each block
-    nblocks <- lav_partable_nblocks(tmp_list)
+    nblocks <- lav_pt_nblocks(tmp_list)
     for (b in seq_len(nblocks)) {
       # lv's for this block/set
-      lv_names <- lav_partable_vnames(tmp_list,
+      lv_names <- lav_pt_vnames(tmp_list,
         type = "lv.regular",
         block = b
       )
-      lv_marker <- lav_partable_vnames(tmp_list,
+      lv_marker <- lav_pt_vnames(tmp_list,
         type = "lv.marker",
         block = b
       )
-      ov_num <- lav_partable_vnames(tmp_list,
+      ov_num <- lav_pt_vnames(tmp_list,
         type = "ov.num",
         block = b
       )
@@ -1204,7 +1189,7 @@ lav_model_partable  <- function(
     } else {
       lv_names <- unique(tmp_list$lhs[tmp_list$op == "=~"])
     }
-    group_values <- lav_partable_group_values(tmp_list)
+    group_values <- lav_pt_group_values(tmp_list)
 
     for (lv in lv_names) {
       # factor variances
@@ -1250,7 +1235,7 @@ lav_model_partable  <- function(
       }
     } # lv
 
-    tmp_list <- lav_partable_merge(tmp_list, tmp)
+    tmp_list <- lav_pt_merge(tmp_list, tmp)
   }
 
   # mg.lv.efa.variances
@@ -1264,7 +1249,7 @@ lav_model_partable  <- function(
     } else {
       lv_names <- character(0L)
     }
-    group_values <- lav_partable_group_values(tmp_list)
+    group_values <- lav_pt_group_values(tmp_list)
 
     for (lv in lv_names) {
       # factor variances
@@ -1310,7 +1295,7 @@ lav_model_partable  <- function(
       }
     } # lv
 
-    tmp_list <- lav_partable_merge(tmp_list, tmp)
+    tmp_list <- lav_pt_merge(tmp_list, tmp)
   }
 
 
@@ -1340,14 +1325,55 @@ lav_model_partable  <- function(
   }
 
   # data.frame?
-  if (as.data.frame.) {
+  if (as_data_frame) {
     tmp_list <- as.data.frame(tmp_list, stringsAsFactors = FALSE)
     attr(tmp_list, "ovda") <- ov_names_data
   } else {
-    tmp_list <- lav_partable_set_cache(tmp_list) # add cached "pta" data
+    tmp_list <- lav_pt_set_cache(tmp_list) # add cached "pta" data
   }
 
   tmp_list
 }
-lavParTable <- lav_model_partable   # synonym #nolint
-lavaanify <- lav_model_partable     # synonym
+lavParTable <- lavaanify <- function(              # synonym # nolint start
+                               model = NULL,
+                               meanstructure = FALSE,
+                               int.ov.free = FALSE,
+                               int.lv.free = FALSE,
+                               marker.int.zero = FALSE,
+                               orthogonal = FALSE,
+                               orthogonal.y = FALSE,
+                               orthogonal.x = FALSE,
+                               orthogonal.efa = FALSE,
+                               std.lv = FALSE,
+                               correlation = FALSE,
+                               composites = TRUE,
+                               effect.coding = "",
+                               conditional.x = FALSE,
+                               fixed.x = FALSE,
+                               parameterization = "delta",
+                               constraints = NULL,
+                               ceq.simple = FALSE,
+                               auto = FALSE,
+                               model.type = "sem",
+                               auto.fix.first = FALSE,
+                               auto.fix.single = FALSE,
+                               auto.var = FALSE,
+                               auto.cov.lv.x = FALSE,
+                               auto.cov.y = FALSE,
+                               auto.th = FALSE,
+                               auto.delta = FALSE,
+                               auto.efa = FALSE,
+                               varTable = NULL,
+                               ngroups = 1L,
+                               nthresholds = NULL,
+                               group.equal = NULL,
+                               group.partial = NULL,
+                               group.w.free = FALSE,
+                               debug = FALSE,
+                               warn = TRUE,
+                               as.data.frame. = TRUE) {    # nolint end
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan:::lav_model_pt)
+  eval(sc, parent.frame())
+}

--- a/R/lav_partable_attributes.R
+++ b/R/lav_partable_attributes.R
@@ -1,5 +1,5 @@
 # return 'attributes' of a lavaan partable -- generate a new set if necessary
-lav_partable_attributes <- function(partable, pta = NULL) {
+lav_pt_attributes <- function(partable, pta = NULL) {
   if (is.null(pta)) {
     # attached to partable?
     pta <- attributes(partable)
@@ -13,7 +13,7 @@ lav_partable_attributes <- function(partable, pta = NULL) {
   }
 
   # vnames
-  pta$vnames <- lav_partable_vnames(partable, type = "*")
+  pta$vnames <- lav_pt_vnames(partable, type = "*")
 
   # vidx
   tmp_ov <- pta$vnames$ov
@@ -49,10 +49,10 @@ lav_partable_attributes <- function(partable, pta = NULL) {
   pta$nblocks <- nblocks
 
   # ngroups
-  pta$ngroups <- lav_partable_ngroups(partable)
+  pta$ngroups <- lav_pt_ngroups(partable)
 
   # nlevels
-  pta$nlevels <- lav_partable_nlevels(partable)
+  pta$nlevels <- lav_pt_nlevels(partable)
 
   # nvar
   pta$nvar <- lapply(pta$vnames$ov, length)

--- a/R/lav_partable_bounds.R
+++ b/R/lav_partable_bounds.R
@@ -1,12 +1,12 @@
 # add parameter bounds to the parameter table
 # lavoptions$optim.bounds
-lav_partable_add_bounds <- function(partable = NULL,
+lav_pt_add_bounds <- function(partable = NULL,
                                     lavh1 = NULL,
                                     lavdata = NULL,
                                     lavsamplestats = NULL,
                                     lavoptions = NULL) {
   # no support (yet) for multilevel
-  if (lav_partable_nlevels(partable) > 1L) {
+  if (lav_pt_nlevels(partable) > 1L) {
     return(partable)
   }
 
@@ -155,19 +155,19 @@ lav_partable_add_bounds <- function(partable = NULL,
     upper_auto <- rep(+Inf, length(partable$lhs))
   }
 
-  lavpta <- lav_partable_attributes(partable)
+  lavpta <- lav_pt_attributes(partable)
 
   # check blocks
   if (is.null(partable$block)) {
     partable$block <- rep(1L, length(partable$lhs))
   }
-  # block_values <- lav_partable_block_values(partable)
+  # block_values <- lav_pt_block_values(partable)
 
   # check groups
   if (is.null(partable$group)) {
     partable$group <- rep(1L, length(partable$lhs))
   }
-  group_values <- lav_partable_group_values(partable)
+  group_values <- lav_pt_group_values(partable)
   ngroups <- length(group_values)
 
   # compute bounds per group ### TODO: add levels/classes/...

--- a/R/lav_partable_cache.R
+++ b/R/lav_partable_cache.R
@@ -1,5 +1,5 @@
 # store pta in attributes of partable
-lav_partable_set_cache <- function(partable, pta = NULL, force = FALSE) {
+lav_pt_set_cache <- function(partable, pta = NULL, force = FALSE) {
   if (!force &&
       !is.null(attr(partable, "vnames")) &&
       !is.null(attr(partable, "nvar"))) {
@@ -7,7 +7,7 @@ lav_partable_set_cache <- function(partable, pta = NULL, force = FALSE) {
     }
   if (is.null(pta)) {
     if (force) attr(partable, "vnames") <- NULL
-    pta <- lav_partable_attributes(partable)
+    pta <- lav_pt_attributes(partable)
   }
 
   for (n in names(pta)) {
@@ -17,7 +17,7 @@ lav_partable_set_cache <- function(partable, pta = NULL, force = FALSE) {
   partable
 }
 
-lav_partable_remove_cache <- function(partable) {
+lav_pt_remove_cache <- function(partable) {
   attributelist <- names(attributes(partable))
 
   for (n in attributelist) {

--- a/R/lav_partable_check.R
+++ b/R/lav_partable_check.R
@@ -1,6 +1,6 @@
 # check if the partable is complete/consistent
 # for example, we may have added intercepts/variances (user = 0), fixed to zero
-lav_partable_check <- function(partable, categorical = FALSE) {
+lav_pt_check <- function(partable, categorical = FALSE) {
   check <- TRUE
 
   # check for empty table - or should we WARN?
@@ -9,14 +9,14 @@ lav_partable_check <- function(partable, categorical = FALSE) {
   }
 
   # get observed/latent variables
-  ov_names <- lav_partable_vnames(partable, "ov.nox") # no need to specify exo??
-  lv_names <- lav_partable_vnames(partable, "lv")
-  lv_names_c <- lav_partable_vnames(partable, "lv.composite")
+  ov_names <- lav_pt_vnames(partable, "ov.nox") # no need to specify exo??
+  lv_names <- lav_pt_vnames(partable, "lv")
+  lv_names_c <- lav_pt_vnames(partable, "lv.composite")
   lv_names_noc <- lv_names[!lv_names %in% lv_names_c]
   all.names <- c(ov_names, lv_names_noc)
-  ov_names_ord <- lav_partable_vnames(partable, "ov.ord")
+  ov_names_ord <- lav_pt_vnames(partable, "ov.ord")
 
-  nlevels <- lav_partable_nlevels(partable)
+  nlevels <- lav_pt_nlevels(partable)
 
   # if categorical, we should have some ov.names.ord
   if (categorical && length(ov_names_ord) == 0L) {
@@ -25,7 +25,7 @@ lav_partable_check <- function(partable, categorical = FALSE) {
   }
 
   # we should have a (residual) variance for *each* ov/lv
-  # note: if lav_model_partable() has been used, this is always TRUE
+  # note: if lav_model_pt() has been used, this is always TRUE
   var_idx <- which(partable$op == "~~" &
     partable$lhs == partable$rhs & !partable$lhs %in% lv_names_c)
   missing_idx <- which(is.na(match(all.names, partable$lhs[var_idx])))
@@ -41,7 +41,7 @@ lav_partable_check <- function(partable, categorical = FALSE) {
   meanstructure <- any(partable$op == "~1")
 
   # if meanstructure, check for missing intercepts
-  # note if lav_model_partable() has been used, this is always TRUE
+  # note if lav_model_pt() has been used, this is always TRUE
   if (meanstructure) {
     # we should have an intercept for *each* ov/lv
     int_idx <- which(partable$op == "~1")

--- a/R/lav_partable_complete.R
+++ b/R/lav_partable_complete.R
@@ -1,6 +1,6 @@
 # handle bare-minimum partables
 # add some additional columns
-lav_partable_complete <- function(partable = NULL, start = TRUE) { # nolint
+lav_pt_complete <- function(partable = NULL, start = TRUE) {
   # check if we have a data.frame
   # if so, check for columns that are 'factor' and convert them to 'character'
   ovda <- attr(partable, "ovda")
@@ -151,6 +151,6 @@ lav_partable_complete <- function(partable = NULL, start = TRUE) { # nolint
     }
   }
   attr(partable, "ovda") <- ovda
-  attr(partable, "vnames") <- lav_partable_vnames(partable, "*")
+  attr(partable, "vnames") <- lav_pt_vnames(partable, "*")
   partable
 }

--- a/R/lav_partable_constraints.R
+++ b/R/lav_partable_constraints.R
@@ -1,6 +1,6 @@
 # build def function from partable
-lav_partable_constraints_def <- function(partable, con = NULL, debug = FALSE, # nolint start
-                                         txtOnly = FALSE, warn = TRUE) {      # nolint end
+lav_pt_con_def <- function(partable, con = NULL, debug = FALSE, # nolint start
+                                         txt_only = FALSE, warn = TRUE) {      # nolint end
   if (!missing(debug)) {
     current_debug <- lav_debug()
     if (lav_debug(debug))
@@ -21,7 +21,7 @@ lav_partable_constraints_def <- function(partable, con = NULL, debug = FALSE, # 
 
   # catch empty def
   if (length(def_idx) == 0L) {
-    if (txtOnly) {
+    if (txt_only) {
       return(character(0L))
     } else {
       return(def_function)
@@ -40,7 +40,7 @@ lav_partable_constraints_def <- function(partable, con = NULL, debug = FALSE, # 
 
   # create function
   formals(def_function) <- alist(.x. = , ... = )
-  if (txtOnly) {
+  if (txt_only) {
     body_txt <- ""
   } else {
     body_txt <- paste("{\n# parameter definitions\n\n")
@@ -85,7 +85,7 @@ lav_partable_constraints_def <- function(partable, con = NULL, debug = FALSE, # 
     )
   }
 
-  if (txtOnly) {
+  if (txt_only) {
     return(body_txt)
   }
 
@@ -123,8 +123,8 @@ lav_partable_constraints_def <- function(partable, con = NULL, debug = FALSE, # 
 #             b1 = x[10]; b2 = x[17]
 #             out[1] <- b1 + b2 - 2
 #         }
-lav_partable_constraints_ceq <- function(partable, con = NULL, debug = FALSE, # nolint start
-                                         txtOnly = FALSE) {                   # nolint end
+lav_pt_con_ceq <- function(partable, con = NULL, debug = FALSE, # nolint start
+                                         txt_only = FALSE) {                   # nolint end
   if (!missing(debug)) {
     current_debug <- lav_debug()
     if (lav_debug(debug))
@@ -145,7 +145,7 @@ lav_partable_constraints_ceq <- function(partable, con = NULL, debug = FALSE, # 
 
   # catch empty ceq
   if (length(eq_idx) == 0L) {
-    if (txtOnly) {
+    if (txt_only) {
       return(character(0L))
     } else {
       return(ceq_function)
@@ -154,14 +154,14 @@ lav_partable_constraints_ceq <- function(partable, con = NULL, debug = FALSE, # 
 
   # create function
   formals(ceq_function) <- alist(.x. = , ... = )
-  if (txtOnly) {
+  if (txt_only) {
     body_txt <- ""
   } else {
     body_txt <- paste("{\nout <- rep(NA, ", length(eq_idx), ")\n", sep = "")
   }
 
   # first come the variable definitions
-  def_txt <- lav_partable_constraints_def(partable, txtOnly = TRUE,
+  def_txt <- lav_pt_con_def(partable, txt_only = TRUE,
                                           warn = FALSE)
   def_idx <- which(partable$op == ":=")
   body_txt <- paste(body_txt, def_txt, "\n", sep = "")
@@ -261,7 +261,7 @@ lav_partable_constraints_ceq <- function(partable, con = NULL, debug = FALSE, # 
     body_txt <- paste(body_txt, "out[", i, "] <- ", eq_string, "\n", sep = "")
   }
 
-  if (txtOnly) {
+  if (txt_only) {
     return(body_txt)
   }
 
@@ -299,8 +299,8 @@ lav_partable_constraints_ceq <- function(partable, con = NULL, debug = FALSE, # 
 #
 # NOTE: very similar, but not identitical to ceq, because we need to take
 #       care of the difference between '<' and '>'
-lav_partable_constraints_ciq <- function(partable, con = NULL, debug = FALSE, # nolint start
-                                         txtOnly = FALSE) {                   # nolint end
+lav_pt_con_ciq <- function(partable, con = NULL, debug = FALSE, # nolint start
+                                         txt_only = FALSE) {                   # nolint end
   if (!missing(debug)) {
     current_debug <- lav_debug()
     if (lav_debug(debug))
@@ -335,7 +335,7 @@ lav_partable_constraints_ciq <- function(partable, con = NULL, debug = FALSE, # 
 
   # catch empty ciq
   if (length(ineq_idx) == 0L) {
-    if (txtOnly) {
+    if (txt_only) {
       return(character(0L))
     } else {
       return(cin_function)
@@ -344,14 +344,14 @@ lav_partable_constraints_ciq <- function(partable, con = NULL, debug = FALSE, # 
 
   # create function
   formals(cin_function) <- alist(.x. = , ... = )
-  if (txtOnly) {
+  if (txt_only) {
     body_txt <- ""
   } else {
     body_txt <- paste("{\nout <- rep(NA, ", length(ineq_idx), ")\n", sep = "")
   }
 
   # first come the variable definitions
-  def_txt <- lav_partable_constraints_def(partable, txtOnly = TRUE,
+  def_txt <- lav_pt_con_def(partable, txt_only = TRUE,
                                           warn = FALSE)
   def_idx <- which(partable$op == ":=")
   body_txt <- paste(body_txt, def_txt, "\n", sep = "")
@@ -461,7 +461,7 @@ lav_partable_constraints_ciq <- function(partable, con = NULL, debug = FALSE, # 
     body_txt <- paste(body_txt, "out[", i, "] <- ", ineq_string, "\n", sep = "")
   }
 
-  if (txtOnly) {
+  if (txt_only) {
     return(body_txt)
   }
 
@@ -487,7 +487,7 @@ lav_partable_constraints_ciq <- function(partable, con = NULL, debug = FALSE, # 
 # return a named vector of the 'free' indices, for the labels that
 # are used in a constrained (or optionally a definition)
 # (always 0 for definitions)
-lav_partable_constraints_label_id <- function(partable, con = NULL, # nolint
+lav_pt_con_label_id <- function(partable, con = NULL,
                                               def = TRUE) {
   # if 'con', merge partable + con
   if (!is.null(con)) {

--- a/R/lav_partable_efa.R
+++ b/R/lav_partable_efa.R
@@ -6,12 +6,12 @@
 #       eg., if all the factor-loadings of the 'second' set (time/group)
 #       are constrained to be equal to the factor-loadings of the first
 #       set, no further constraints are needed
-lav_partable_efa_constraints <- function(list_1 = NULL,
+lav_pt_efa_con <- function(list_1 = NULL,
                                          orthogonal_efa = FALSE,
                                          group_equal = character(0L)) {
   # for each set, for each block
-  nblocks <- lav_partable_nblocks(list_1)
-  set_names <- lav_partable_efa_values(list_1)
+  nblocks <- lav_pt_nblocks(list_1)
+  set_names <- lav_pt_efa_values(list_1)
   nsets <- length(set_names)
 
   for (b in seq_len(nblocks)) {

--- a/R/lav_partable_flat.R
+++ b/R/lav_partable_flat.R
@@ -1,4 +1,4 @@
-lav_partable_flat <- function(flat = NULL, # nolint
+lav_pt_flat <- function(flat = NULL,
                               blocks = "group",
                               block_id = NULL,
                               meanstructure = FALSE,
@@ -35,42 +35,42 @@ lav_partable_flat <- function(flat = NULL, # nolint
   ###                   either free or fixed
 
   # extract `names' of various types of variables:
-  lv_names <- lav_partable_vnames(flat, type = "lv") # latent variables
-  # lv.names.r   <- lav_partable_vnames(FLAT, type="lv.regular")
+  lv_names <- lav_pt_vnames(flat, type = "lv") # latent variables
+  # lv.names.r   <- lav_pt_vnames(FLAT, type="lv.regular")
   # regular latent variables
   if (composites) {
     lv_names_f <- character(0L)
-    lv_names_c <- lav_partable_vnames(flat, type = "lv.composite")
-    ov_ind_c <- lav_partable_vnames(flat, type = "ov.cind")
+    lv_names_c <- lav_pt_vnames(flat, type = "lv.composite")
+    ov_ind_c <- lav_pt_vnames(flat, type = "ov.cind")
     lv_names_noc <- lv_names[!lv_names %in% lv_names_c]
   } else {
     lv_names_c <- character(0L)
     ov_ind_c <- character(0L)
-    lv_names_f <- lav_partable_vnames(flat, type = "lv.formative")
+    lv_names_f <- lav_pt_vnames(flat, type = "lv.formative")
     lv_names_noc <- lv_names
   }
 
   # formative latent variables
-  ov_names <- lav_partable_vnames(flat, type = "ov")
+  ov_names <- lav_pt_vnames(flat, type = "ov")
   # observed variables
-  ov_names_x <- lav_partable_vnames(flat, type = "ov.x")
+  ov_names_x <- lav_pt_vnames(flat, type = "ov.x")
   # exogenous x covariates
-  lv_names_int <- lav_partable_vnames(flat, type = "lv.interaction")
+  lv_names_int <- lav_pt_vnames(flat, type = "lv.interaction")
   # lv interactions
 
   if (is.null(ov_names_x_block)) {
     ov_names_x_block <- ov_names_x
   }
-  ov_names_nox <- lav_partable_vnames(flat, type = "ov.nox")
-  lv_names_x <- lav_partable_vnames(flat, type = "lv.x") # exogenous lv
-  ov_names_y <- lav_partable_vnames(flat, type = "ov.y") # dependent ov
-  lv_names_y <- lav_partable_vnames(flat, type = "lv.y") # dependent lv
-  lv_names_efa <- lav_partable_vnames(flat, type = "lv.efa")
+  ov_names_nox <- lav_pt_vnames(flat, type = "ov.nox")
+  lv_names_x <- lav_pt_vnames(flat, type = "lv.x") # exogenous lv
+  ov_names_y <- lav_pt_vnames(flat, type = "ov.y") # dependent ov
+  lv_names_y <- lav_pt_vnames(flat, type = "lv.y") # dependent lv
+  lv_names_efa <- lav_pt_vnames(flat, type = "lv.efa")
   # lvov.names.y <- c(ov.names.y, lv.names.y)
   lvov_names_y <- c(lv_names_y, ov_names_y)
 
   # get 'ordered' variables, either from FLAT or var_table
-  ov_names_ord1 <- lav_partable_vnames(flat, type = "ov.ord")
+  ov_names_ord1 <- lav_pt_vnames(flat, type = "ov.ord")
   # check if we have "|" for exogenous variables
   if (length(ov_names_ord1) > 0L) {
     idx <- which(ov_names_ord1 %in% ov_names_x)
@@ -277,7 +277,7 @@ lav_partable_flat <- function(flat = NULL, # nolint
   # f) efa latent variables COVARIANCES; only needed for 'mediators'
   #    (not in lv.names.x, not in lv.names.y) -- added in 0.6-18
   if (auto_efa && length(lv_names_efa) > 1L) {
-    efa_values <- lav_partable_efa_values(flat)
+    efa_values <- lav_pt_efa_values(flat)
     for (set in efa_values) {
       # correlated factors within each set
       this_set_lv <- unique(flat$lhs[flat$op == "=~" &
@@ -371,8 +371,8 @@ lav_partable_flat <- function(flat = NULL, # nolint
   rhs <- flat$rhs
   mod_idx <- flat$mod.idx
 
-  lv_names <- lav_partable_vnames(flat, type = "lv") # latent variables
-  ov_names <- lav_partable_vnames(flat, type = "ov") # observed variables
+  lv_names <- lav_pt_vnames(flat, type = "lv") # latent variables
+  ov_names <- lav_pt_vnames(flat, type = "ov") # observed variables
   tmp_user <- data.frame(
     lhs = lhs, op = op, rhs = rhs, mod.idx = mod_idx,
     stringsAsFactors = FALSE
@@ -608,7 +608,7 @@ lav_partable_flat <- function(flat = NULL, # nolint
     }
     # 4b. fixed effect (only if we have random slopes)
     if (!is.null(flat$rv) && any(nchar(flat$rv) > 0L)) {
-      lv_names_rv <- lav_partable_vnames(flat, "lv.rv")
+      lv_names_rv <- lav_pt_vnames(flat, "lv.rv")
       lv_rv_idx <- which(op == "~1" &
         lhs %in% lv_names_rv &
         user == 0L)
@@ -760,7 +760,7 @@ lav_partable_flat <- function(flat = NULL, # nolint
         free        = free,
         ustart      = ustart,
         block       = rep(1, length(rhs)))
-      lv_marker <- lav_partable_vnames(tmp_list, "lv.marker")
+      lv_marker <- lav_pt_vnames(tmp_list, "lv.marker")
     }
 
 

--- a/R/lav_partable_from_lm.R
+++ b/R/lav_partable_from_lm.R
@@ -3,8 +3,8 @@
 # YR: this function was broken since Mar 3, 2017, but nobody noticed this!
 #     fixed again Apr 29, 2025.
 
-lav_partable_from_lm <- function(object, est = FALSE, label = FALSE,
-                                 as.data.frame. = FALSE) {           # nolint
+lav_pt_from_lm <- function(object, est = FALSE, label = FALSE,
+                                 as_data_frame = FALSE) {
   # sanity check
   if (!inherits(object, "lm")) {
     lav_msg_stop(gettext("object must be of class lm"))
@@ -55,7 +55,7 @@ lav_partable_from_lm <- function(object, est = FALSE, label = FALSE,
   }
 
   # convert to data.frame?
-  if (as.data.frame.) {
+  if (as_data_frame) {
     partable <- as.data.frame(partable, stringsAsFactors = FALSE)
   }
 

--- a/R/lav_partable_full.R
+++ b/R/lav_partable_full.R
@@ -3,7 +3,7 @@
 #
 # main motivation: univariate scores tests (modification indices)
 #
-lav_partable_full <- function(partable = NULL,
+lav_pt_full <- function(partable = NULL,
                               strict_exo = FALSE,
                               free = FALSE, start = FALSE) {
   # check minimum requirements: lhs, op, rhs
@@ -14,7 +14,7 @@ lav_partable_full <- function(partable = NULL,
   )
 
   # lavpta?
-  lavpta <- lav_partable_attributes(partable)
+  lavpta <- lav_pt_attributes(partable)
 
   # meanstructure
   if (!is.null(lavpta$meanstructure)) {
@@ -33,8 +33,8 @@ lav_partable_full <- function(partable = NULL,
   block <- group <- level <- integer(0L)
 
   # new in 0.6-3:
-  group_values <- lav_partable_group_values(partable)
-  level_values <- lav_partable_level_values(partable)
+  group_values <- lav_pt_group_values(partable)
+  level_values <- lav_pt_level_values(partable)
   if (is.character(group_values[1])) {
     group <- character(0L)
   }

--- a/R/lav_partable_labels.R
+++ b/R/lav_partable_labels.R
@@ -1,8 +1,8 @@
 # generate labels for each parameter
-lav_partable_labels <- function(partable,                                # nolint start
+lav_pt_labels <- function(partable,
                                 blocks = c("group", "level"),
-                                group.equal = "", group.partial = "",
-                                type = "user") {                         # nolint end
+                                group_equal = "", group_partial = "",
+                                type = "user") {
   # catch empty partable
   if (length(partable$lhs) == 0L) {
     return(character(0L))
@@ -18,7 +18,7 @@ lav_partable_labels <- function(partable,                                # nolin
       group_label <- group_label[nchar(group_label) > 0L]
       ngroups <- length(group_label)
     } else {
-      ngroups <- lav_partable_ngroups(partable)
+      ngroups <- lav_pt_ngroups(partable)
       group_label <- 1:ngroups
     }
     if (ngroups > 1L) {
@@ -35,34 +35,34 @@ lav_partable_labels <- function(partable,                                # nolin
   }
 
   # cat("DEBUG: label start:\n"); print(label); cat("\n")
-  # cat("group.equal = ", group.equal, "\n")
-  # cat("group.partial = ", group.partial, "\n")
+  # cat("group_equal = ", group_equal, "\n")
+  # cat("group_partial = ", group_partial, "\n")
 
-  # use group.equal so that equal sets of parameters get the same label
-  if (ngroups > 1L && length(group.equal) > 0L) {
-    if ("intercepts" %in% group.equal ||
-      "residuals" %in% group.equal ||
-      "residual.covariances" %in% group.equal) {
+  # use group_equal so that equal sets of parameters get the same label
+  if (ngroups > 1L && length(group_equal) > 0L) {
+    if ("intercepts" %in% group_equal ||
+      "residuals" %in% group_equal ||
+      "residual.covariances" %in% group_equal) {
       ov_names_nox <- vector("list", length = ngroups)
       for (g in 1:ngroups) {
         ov_names_nox[[g]] <- unique(unlist(
-          lav_partable_vnames(partable, "ov.nox", group = g)))
+          lav_pt_vnames(partable, "ov.nox", group = g)))
       }
     }
-    if ("thresholds" %in% group.equal) {
+    if ("thresholds" %in% group_equal) {
       ov_names_ord <- vector("list", length = ngroups)
       for (g in 1:ngroups) {
         ov_names_ord[[g]] <- unique(unlist(
-          lav_partable_vnames(partable, "ov.ord", group = g)))
+          lav_pt_vnames(partable, "ov.ord", group = g)))
       }
     }
-    if ("means" %in% group.equal ||
-      "lv.variances" %in% group.equal ||
-      "lv.covariances" %in% group.equal) {
+    if ("means" %in% group_equal ||
+      "lv.variances" %in% group_equal ||
+      "lv.covariances" %in% group_equal) {
       lv_names <- vector("list", length = ngroups)
       for (g in 1:ngroups) {
         lv_names[[g]] <- unique(unlist(
-          lav_partable_vnames(partable, "lv", group = g)))
+          lav_pt_vnames(partable, "lv", group = g)))
       }
     }
 
@@ -70,11 +70,11 @@ lav_partable_labels <- function(partable,                                # nolin
     g1_flag <- logical(length(partable$lhs))
 
     # LOADINGS
-    if ("loadings" %in% group.equal) {
+    if ("loadings" %in% group_equal) {
       g1_flag[partable$op == "=~" & partable$group == 1L] <- TRUE
     }
     # COMPOSITE LOADINGS (new in 0.6-4)
-    if ("composite.loadings" %in% group.equal) {
+    if ("composite.loadings" %in% group_equal) {
       # new setting (0.6-20): <~
       if (any(partable$op == "<~" & partable$group == 1L)) {
         lav_msg_warn(gettext("composite.loadings are in fact composite weights;
@@ -83,63 +83,63 @@ lav_partable_labels <- function(partable,                                # nolin
       } else {
         # old school: composites are phantom constructs with zero residual...
         lv_f_names <- unique(unlist(
-          lav_partable_vnames(partable, "lv.formative")))
+          lav_pt_vnames(partable, "lv.formative")))
         g1_flag[partable$op == "~" &
                 partable$lhs %in% lv_f_names &
                 partable$group == 1L] <- TRUE
       }
     }
     # COMPOSITE WEIGHTS (new in 0.6-20) # same as 'loadings'...
-    if ("composite.weights" %in% group.equal) {
+    if ("composite.weights" %in% group_equal) {
       g1_flag[partable$op == "<~" & partable$group == 1L] <- TRUE
     }
     # INTERCEPTS (OV)
-    if ("intercepts" %in% group.equal) {
+    if ("intercepts" %in% group_equal) {
       g1_flag[partable$op == "~1" & partable$group == 1L &
         partable$lhs %in% ov_names_nox[[1L]]] <- TRUE
     }
     # THRESHOLDS (OV-ORD)
-    if ("thresholds" %in% group.equal) {
+    if ("thresholds" %in% group_equal) {
       g1_flag[partable$op == "|" & partable$group == 1L &
         partable$lhs %in% ov_names_ord[[1L]]] <- TRUE
     }
     # MEANS (LV)
-    if ("means" %in% group.equal) {
+    if ("means" %in% group_equal) {
       g1_flag[partable$op == "~1" & partable$group == 1L &
         partable$lhs %in% lv_names[[1L]]] <- TRUE
     }
     # REGRESSIONS
-    if ("regressions" %in% group.equal) {
+    if ("regressions" %in% group_equal) {
       g1_flag[partable$op == "~" & partable$group == 1L] <- TRUE
     }
     # RESIDUAL variances (FIXME: OV ONLY!)
-    if ("residuals" %in% group.equal) {
+    if ("residuals" %in% group_equal) {
       g1_flag[partable$op == "~~" & partable$group == 1L &
         partable$lhs %in% ov_names_nox[[1L]] &
         partable$lhs == partable$rhs] <- TRUE
     }
     # RESIDUAL covariances (FIXME: OV ONLY!)
-    if ("residual.covariances" %in% group.equal) {
+    if ("residual.covariances" %in% group_equal) {
       g1_flag[partable$op == "~~" & partable$group == 1L &
         partable$lhs %in% ov_names_nox[[1L]] &
         partable$lhs != partable$rhs] <- TRUE
     }
     # LV VARIANCES
-    if ("lv.variances" %in% group.equal) {
+    if ("lv.variances" %in% group_equal) {
       g1_flag[partable$op == "~~" & partable$group == 1L &
         partable$lhs %in% lv_names[[1L]] &
         partable$lhs == partable$rhs] <- TRUE
     }
     # LV COVARIANCES
-    if ("lv.covariances" %in% group.equal) {
+    if ("lv.covariances" %in% group_equal) {
       g1_flag[partable$op == "~~" & partable$group == 1L &
         partable$lhs %in% lv_names[[1L]] &
         partable$lhs != partable$rhs] <- TRUE
     }
 
-    # if group.partial, set corresponding flag to FALSE
-    if (length(group.partial) > 0L) {
-      g1_flag[label %in% group.partial &
+    # if group_partial, set corresponding flag to FALSE
+    if (length(group_partial) > 0L) {
+      g1_flag[label %in% group_partial &
         partable$group == 1L] <- FALSE
     }
 
@@ -158,7 +158,7 @@ lav_partable_labels <- function(partable,                                # nolin
   }
 
   # cat("DEBUG: g1.idx = ", g1.idx, "\n")
-  # cat("DEBUG: label after group.equal:\n"); print(label); cat("\n")
+  # cat("DEBUG: label after group_equal:\n"); print(label); cat("\n")
 
   # handle other block identifier (not 'group')
   for (block in blocks) {
@@ -166,7 +166,7 @@ lav_partable_labels <- function(partable,                                # nolin
       next
     } else if (block == "level" && !is.null(partable[[block]])) {
       # all but first level
-      lev_vals <- lav_partable_level_values(partable)
+      lev_vals <- lav_pt_level_values(partable)
       idx <- which(partable[[block]] != lev_vals[1])
       label[idx] <- paste(label[idx], ".", "l",
         partable[[block]][idx],

--- a/R/lav_partable_merge.R
+++ b/R/lav_partable_merge.R
@@ -1,8 +1,8 @@
 # merge two parameter tables
 # - but allow different number of columns
-lav_partable_merge <- function(pt1 = NULL, pt2 = NULL,        # nolint start
-                               remove.duplicated = FALSE,
-                               fromLast = FALSE,
+lav_pt_merge <- function(pt1 = NULL, pt2 = NULL,        # nolint start
+                               remove_duplicated = FALSE,
+                               from_last = FALSE,
                                warn = TRUE) {                 # nolint end
   if (!missing(warn)) {
     current_warn <- lav_warn()
@@ -125,10 +125,10 @@ lav_partable_merge <- function(pt1 = NULL, pt2 = NULL,        # nolint start
 
 
   # check for duplicated elements
-  if (remove.duplicated) {
+  if (remove_duplicated) {
     # if fromLast = TRUE, idx is in pt1
     # if fromLast = FALSE, idx is in pt2
-    idx <- which(duplicated(tmp, fromLast = fromLast))
+    idx <- which(duplicated(tmp, fromLast = from_last))
 
     if (length(idx)) {
       lav_msg_warn(
@@ -138,7 +138,7 @@ lav_partable_merge <- function(pt1 = NULL, pt2 = NULL,        # nolint start
           collapse = " "
         ), collapse = "\n")
       )
-      if (fromLast) {
+      if (from_last) {
         pt1 <- pt1[-idx, ]
       } else {
         idx <- idx - nrow(pt1)

--- a/R/lav_partable_ov_from_data.R
+++ b/R/lav_partable_ov_from_data.R
@@ -1,10 +1,10 @@
 # handle ov.order = "data" by adding attribute "ovda" to FLAT
-lav_partable_ov_from_data <- function(flat = NULL, # nolint
+lav_pt_ov_from_data <- function(flat = NULL,
                                       data = NULL,
                                       sample_cov = NULL,
                                       slot_data = NULL) { # nolint
   # current model-based ov.names
-  ov_names <- lav_partable_vnames(flat, type = "ov")
+  ov_names <- lav_pt_vnames(flat, type = "ov")
 
   # get data-based ov.names
   data_names <- NULL

--- a/R/lav_partable_random.R
+++ b/R/lav_partable_random.R
@@ -6,12 +6,12 @@
 #
 # YR 26 Feb 2024
 
-lav_partable_random <- function(lavpartable = NULL,
+lav_pt_random <- function(lavpartable = NULL,
                                 # needed if we still need to compute bounds:
                                 lavh1 = NULL, lavdata = NULL,
                                 lavsamplestats = NULL, lavoptions = NULL) {
 
-  lavpta <- lav_partable_attributes(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
 
   # ALWAYS (recompute) bounds, as user may have provide other
   # bounds (eg "pos.var") (0.6-20)
@@ -32,7 +32,7 @@ lav_partable_random <- function(lavpartable = NULL,
       min.reliability.marker = 0.1,
       min.var.lv.endo = 0.005
     )
-  lavpartable <- lav_partable_add_bounds(
+  lavpartable <- lav_pt_add_bounds(
     partable = lavpartable,
     lavh1 = lavh1, lavdata = lavdata,
     lavsamplestats = lavsamplestats, lavoptions = lavoptions2
@@ -71,8 +71,8 @@ lav_partable_random <- function(lavpartable = NULL,
   # initial values
   start_1 <- lavpartable$start
 
-  nblocks <- lav_partable_nblocks(lavpartable)
-  block_values <- lav_partable_block_values(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
+  block_values <- lav_pt_block_values(lavpartable)
   for (b in 1:nblocks) {
     ov_names <- lavpta$vnames$ov[[b]]
     lv_names <- lavpta$vnames$lv[[b]]

--- a/R/lav_partable_subset.R
+++ b/R/lav_partable_subset.R
@@ -17,7 +17,7 @@
 #   add them here? (no for now, unless add.ind.predictors = TRUE)
 # - new in 0.6-20: - check for 2nd, 3rd order lv.names...
 #                  - allow for conditional.x (global SAM)
-lav_partable_subset_measurement_model <- function(pt_1 = NULL,       # nolint
+lav_pt_subset_measurement_model <- function(pt_1 = NULL,
                                                   lv_names = NULL,
                                                   add_lv_cov = TRUE,
                                                   add_ind_predictors = FALSE,
@@ -36,11 +36,11 @@ lav_partable_subset_measurement_model <- function(pt_1 = NULL,       # nolint
   }
 
   # lavpta
-  lavpta <- lav_partable_attributes(pt_1)
+  lavpta <- lav_pt_attributes(pt_1)
 
   # nblocks
   nblocks <- lavpta$nblocks
-  block_values <- lav_partable_block_values(pt_1)
+  block_values <- lav_pt_block_values(pt_1)
 
   # lv.names: list with element per block
   if (is.null(lv_names)) {
@@ -149,7 +149,7 @@ lav_partable_subset_measurement_model <- function(pt_1 = NULL,       # nolint
       # get the 'id' numbers and the labels involved in def/constraints
       pt2 <- pt_1
       pt2$free <- pt_1$id # use 'id' numbers instead of 'free' indices
-      id <- lav_partable_constraints_label_id(pt2, def = TRUE)
+      id <- lav_pt_con_label_id(pt2, def = TRUE)
       label <- names(id)
 
       # what are the row indices that we currently keep?
@@ -248,14 +248,14 @@ lav_partable_subset_measurement_model <- function(pt_1 = NULL,       # nolint
 
   # add covariances among latent variables?
   if (add_lv_cov) {
-    pt_1 <- lav_partable_add_lv_cov(
+    pt_1 <- lav_pt_add_lv_cov(
       pt_1 = pt_1,
       lv_names = lv_names
     )
   }
 
   # clean up
-  pt_1 <- lav_partable_complete(pt_1)
+  pt_1 <- lav_pt_complete(pt_1)
 
   if (add_idx) {
     attr(pt_1, "idx") <- keep_idx
@@ -265,18 +265,18 @@ lav_partable_subset_measurement_model <- function(pt_1 = NULL,       # nolint
 }
 
 # NOTE: only within same level
-lav_partable_add_lv_cov <- function(pt_1, lv_names = NULL) {
+lav_pt_add_lv_cov <- function(pt_1, lv_names = NULL) {
   # PT
   if (!is.data.frame(pt_1)) {
     pt_1 <- as.data.frame(pt_1, stringsAsFactors = FALSE)
   }
 
   # lavpta
-  lavpta <- lav_partable_attributes(pt_1)
+  lavpta <- lav_pt_attributes(pt_1)
 
   # nblocks
   nblocks <- lavpta$nblocks
-  block_values <- lav_partable_block_values(pt_1)
+  block_values <- lav_pt_block_values(pt_1)
 
   # lv.names: list with element per block
   if (is.null(lv_names)) {
@@ -344,7 +344,7 @@ lav_partable_add_lv_cov <- function(pt_1, lv_names = NULL) {
           if (!is.null(pt_1$upper)) {
             add$upper <- as.numeric(+Inf)
           }
-          pt_1 <- lav_partable_add(pt_1, add = add)
+          pt_1 <- lav_pt_add(pt_1, add = add)
         }
       }
     } # lv.names
@@ -359,7 +359,7 @@ lav_partable_add_lv_cov <- function(pt_1, lv_names = NULL) {
 # - what to do if we have no regressions among the latent variables?
 #   -> we return all covariances among the latent variables
 #
-lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
+lav_pt_subset_structural_model <- function(pt_1 = NULL,
                                                  add_idx = FALSE,
                                                  idx_only = FALSE,
                                                  add_exo_cov = FALSE,
@@ -385,11 +385,11 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
   }
 
   # lavpta
-  lavpta <- lav_partable_attributes(pt_1)
+  lavpta <- lav_pt_attributes(pt_1)
 
   # nblocks
   nblocks <- lavpta$nblocks
-  block_values <- lav_partable_block_values(pt_1)
+  block_values <- lav_pt_block_values(pt_1)
 
   # eqs.names
   # eqs_x_names <- lavpta$vnames$eqs.x
@@ -445,7 +445,7 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
       # get the 'id' numbers and the labels involved in def/constraints
       pt2 <- pt_1
       pt2$free <- pt_1$id # use 'id' numbers instead of 'free' indices
-      id <- lav_partable_constraints_label_id(pt2, def = TRUE)
+      id <- lav_pt_con_label_id(pt2, def = TRUE)
       label <- names(id)
 
       # what are the row indices that we currently keep?
@@ -539,9 +539,9 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
   # add any missing covariances among exogenous variables
   if (add_exo_cov) {
     if (conditional_x) {
-      pt_1 <- lav_partable_add_exo_cov(pt_1, ov_names_x = lavpta$vnames$ov.x)
+      pt_1 <- lav_pt_add_exo_cov(pt_1, ov_names_x = lavpta$vnames$ov.x)
     } else {
-      pt_1 <- lav_partable_add_exo_cov(pt_1)
+      pt_1 <- lav_pt_add_exo_cov(pt_1)
     }
   }
 
@@ -575,7 +575,7 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
 
     # keep ov.x as in global model!
     for (g in 1:nblocks) {
-      # ov.names.x <- lav_partable_vnames(PT,
+      # ov.names.x <- lav_pt_vnames(PT,
       #   type = "ov.x",
       #   block = block.values[g]
       # )
@@ -620,7 +620,7 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
   if (conditional_x) {
     for (b in 1:nblocks) {
       global_ov_x <- lavpta$vnames$ov.x[[b]]
-      local_ov_x <- lav_partable_vnames(pt_1, type = "ov.x",
+      local_ov_x <- lav_pt_vnames(pt_1, type = "ov.x",
         block = block_values[b]
       )
       extra_idx <- which(!local_ov_x %in% global_ov_x)
@@ -653,7 +653,7 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
           if (!is.null(pt_1$upper)) {
             add$upper <- as.numeric(+Inf)
           }
-          pt_1 <- lav_partable_add(pt_1, add = add)
+          pt_1 <- lav_pt_add(pt_1, add = add)
         } # i
       } # extra.idx
     } # b
@@ -670,7 +670,7 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
   }
 
   # clean up
-  pt_1 <- lav_partable_complete(pt_1)
+  pt_1 <- lav_pt_complete(pt_1)
 
   if (add_idx) {
     attr(pt_1, "idx") <- keep_idx
@@ -680,16 +680,16 @@ lav_partable_subset_structural_model <- function(pt_1 = NULL,          # nolint
 }
 
 # NOTE: only within same level
-lav_partable_add_exo_cov <- function(pt_1, ov_names_x = NULL) {
+lav_pt_add_exo_cov <- function(pt_1, ov_names_x = NULL) {
   # PT
   pt_1 <- as.data.frame(pt_1, stringsAsFactors = FALSE)
 
   # lavpta
-  lavpta <- lav_partable_attributes(pt_1)
+  lavpta <- lav_pt_attributes(pt_1)
 
   # nblocks
   nblocks <- lavpta$nblocks
-  block_values <- lav_partable_block_values(pt_1)
+  block_values <- lav_pt_block_values(pt_1)
 
 
   # ov.names.x: list with element per block
@@ -749,7 +749,7 @@ lav_partable_add_exo_cov <- function(pt_1, ov_names_x = NULL) {
           if (!is.null(pt_1$upper)) {
             add$upper <- as.numeric(+Inf)
           }
-          pt_1 <- lav_partable_add(pt_1, add = add)
+          pt_1 <- lav_pt_add(pt_1, add = add)
         }
       }
     } # ov.names.x

--- a/R/lav_partable_unrestricted.R
+++ b/R/lav_partable_unrestricted.R
@@ -1,9 +1,9 @@
 # YR - 26 Nov 2013: generate partable for the unrestricted model
 # YR - 19 Mar 2017: handle twolevel model
-# YR - 27 May 2021: added lav_partable_unrestricted_chol so we can use
+# YR - 27 May 2021: added lav_pt_unrestricted_chol so we can use
 #                   a cholesky parameterization: S = LAMBDA %*% t(LAMBDA)
 
-lav_partable_unrestricted <- function(lavobject = NULL,          # nolint start
+lav_pt_unrestricted <- function(lavobject = NULL,          # nolint start
                                       # if no object is available,
                                       lavdata = NULL,
                                       lavpta = NULL,
@@ -11,27 +11,27 @@ lav_partable_unrestricted <- function(lavobject = NULL,          # nolint start
                                       lavsamplestats = NULL,
                                       lavh1 = NULL,
                                       # optional user-provided sample stats
-                                      sample.cov = NULL,
-                                      sample.mean = NULL,
-                                      sample.slopes = NULL,
-                                      sample.th = NULL,
-                                      sample.th.idx = NULL,
-                                      sample.cov.x = NULL,
-                                      sample.mean.x = NULL) {   # nolint end
-  lav_partable_indep_or_unrestricted(
+                                      sample_cov = NULL,
+                                      sample_mean = NULL,
+                                      sample_slopes = NULL,
+                                      sample_th = NULL,
+                                      sample_th_idx = NULL,
+                                      sample_cov_x = NULL,
+                                      sample_mean_x = NULL) {   # nolint end
+  lav_pt_indep_or_unrestricted(
     lavobject = lavobject,
     lavdata = lavdata, lavpta = lavpta, lavoptions = lavoptions,
     lavsamplestats = lavsamplestats, lavh1 = lavh1,
-    sample_cov = sample.cov, sample_mean = sample.mean,
-    sample_slopes = sample.slopes,
-    sample_th = sample.th, sample_th_idx = sample.th.idx,
+    sample_cov = sample_cov, sample_mean = sample_mean,
+    sample_slopes = sample_slopes,
+    sample_th = sample_th, sample_th_idx = sample_th_idx,
     independent = FALSE
   )
 }
 
 # generate parameter table for an independence model
-# YR - 12 Sep 2017: special case of lav_partable_unrestricted()
-lav_partable_independence <- function(lavobject = NULL,         # nolint start
+# YR - 12 Sep 2017: special case of lav_pt_unrestricted()
+lav_pt_independence <- function(lavobject = NULL,         # nolint start
                                       # if no object is available,
                                       lavdata = NULL,
                                       lavpta = NULL,
@@ -39,25 +39,25 @@ lav_partable_independence <- function(lavobject = NULL,         # nolint start
                                       lavsamplestats = NULL,
                                       lavh1 = NULL,
                                       # optional user-provided sample stats
-                                      sample.cov = NULL,
-                                      sample.mean = NULL,
-                                      sample.slopes = NULL,
-                                      sample.th = NULL,
-                                      sample.th.idx = NULL,
-                                      sample.cov.x = NULL,
-                                      sample.mean.x = NULL) {   # nolint end
-  lav_partable_indep_or_unrestricted(
+                                      sample_cov = NULL,
+                                      sample_mean = NULL,
+                                      sample_slopes = NULL,
+                                      sample_th = NULL,
+                                      sample_th_idx = NULL,
+                                      sample_cov_x = NULL,
+                                      sample_mean_x = NULL) {   # nolint end
+  lav_pt_indep_or_unrestricted(
     lavobject = lavobject,
     lavdata = lavdata, lavpta = lavpta, lavoptions = lavoptions,
     lavsamplestats = lavsamplestats, lavh1 = lavh1,
-    sample_cov = sample.cov, sample_mean = sample.mean,
-    sample_slopes = sample.slopes,
-    sample_th = sample.th, sample_th_idx = sample.th.idx,
+    sample_cov = sample_cov, sample_mean = sample_mean,
+    sample_slopes = sample_slopes,
+    sample_th = sample_th, sample_th_idx = sample_th_idx,
     independent = TRUE
   )
 }
 
-lav_partable_indep_or_unrestricted <- function(lavobject = NULL, # nolint
+lav_pt_indep_or_unrestricted <- function(lavobject = NULL,
                                                # if no object is available,
                                                lavdata = NULL,
                                                lavpta = NULL,
@@ -204,7 +204,7 @@ lav_partable_indep_or_unrestricted <- function(lavobject = NULL, # nolint
 
     # force local sample.cov to be pd -- just for starting values anyway
     if (!is.null(sample_cov) && !anyNA(sample_cov)) {
-      sample_cov <- lav_matrix_symmetric_force_pd(sample_cov)
+      sample_cov <- lav_mat_sym_force_pd(sample_cov)
     }
 
     for (l in 1:nlevels) {
@@ -269,7 +269,7 @@ lav_partable_indep_or_unrestricted <- function(lavobject = NULL, # nolint
         # force local sample.cov to be strictly pd (and exaggerate)
         # just for starting values anyway, but at least the first
         # evaluation will be feasible
-        sample_cov <- lav_matrix_symmetric_force_pd(sample_cov,
+        sample_cov <- lav_mat_sym_force_pd(sample_cov,
           tol = 1e-03
         )
       }
@@ -317,7 +317,7 @@ lav_partable_indep_or_unrestricted <- function(lavobject = NULL, # nolint
 
         # starting values -- covariances
         if (!is.null(sample_cov)) {
-          sample_cov_vech <- lav_matrix_vech(sample_cov, diagonal = FALSE)
+          sample_cov_vech <- lav_mat_vech(sample_cov, diagonal = FALSE)
           ustart <- c(ustart, sample_cov_vech)
           # check for 'missing by design' cells: here, the sample.cov
           # element is *exactly* zero (new in 0.6-18)
@@ -614,10 +614,10 @@ lav_partable_indep_or_unrestricted <- function(lavobject = NULL, # nolint
             ustart <- c(ustart, rep(0, nel))
           } else {
             # but we probably should do:
-            ustart <- c(ustart, lav_matrix_vec(sample_slopes))
+            ustart <- c(ustart, lav_mat_vec(sample_slopes))
           }
         } else if (!is.null(sample_slopes)) {
-          ustart <- c(ustart, lav_matrix_vec(sample_slopes))
+          ustart <- c(ustart, lav_mat_vec(sample_slopes))
         } else {
           ustart <- c(ustart, rep(as.numeric(NA), nel))
         }
@@ -670,7 +670,7 @@ lav_partable_indep_or_unrestricted <- function(lavobject = NULL, # nolint
 
 # - currently only used for continuous twolevel data
 # - conditional.x not supported (yet)
-lav_partable_unrestricted_chol <- function(lavobject = NULL,
+lav_pt_unrestricted_chol <- function(lavobject = NULL,
                                            # if no object is available,
                                            lavdata = NULL,
                                            lavpta = NULL, # optional
@@ -819,7 +819,7 @@ lav_partable_unrestricted_chol <- function(lavobject = NULL,
       # check for zero coverage at level 1 (new in 0.6-18)
       if (lavdata@missing == "ml" && l == 1 && !is.null(lavdata@Mp[[g]])) {
         coverage <- lavdata@Mp[[g]]$coverage
-        sample_cov_vech <- lav_matrix_vech(coverage, diagonal = FALSE)
+        sample_cov_vech <- lav_mat_vech(coverage, diagonal = FALSE)
         zero_cov <- which(sample_cov_vech == 0)
         if (length(zero_cov) > 0L) {
           n_tmp <- length(free)
@@ -917,7 +917,7 @@ lav_partable_unrestricted_chol <- function(lavobject = NULL,
 # - keep all other (relevant) constraints
 # - this *should* result in a baseline model that is always nested within
 #   the original model
-lav_partable_baseline <- function(lavobject = NULL,
+lav_pt_baseline <- function(lavobject = NULL,
                                   # if no object is available,
                                   lavpartable = NULL,
                                   lavh1 = NULL) {
@@ -930,7 +930,7 @@ lav_partable_baseline <- function(lavobject = NULL,
   }
 
   # number of blocks
-  nblocks <- lav_partable_nblocks(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
 
   # conditional.x ? check res.cov[[1]] slot
   conditional_x <- FALSE
@@ -962,7 +962,7 @@ lav_partable_baseline <- function(lavobject = NULL,
   pt_1$est <- pt_1$se <- NULL
 
   # lv.names
-  lv_names <- lav_partable_vnames(pt_1, "lv")
+  lv_names <- lav_pt_vnames(pt_1, "lv")
 
   # zero-out all directed effects and covariances
   directed_idx <- which(pt_1$op %in% c("=~", "~") & pt_1$free > 0L &
@@ -982,9 +982,9 @@ lav_partable_baseline <- function(lavobject = NULL,
 
   # Question: fill in more elements in PT$start? (only ov variances for now)
   for (b in seq_len(nblocks)) {
-    ov_names_num <- lav_partable_vnames(lavpartable, "ov.num", block = b)
+    ov_names_num <- lav_pt_vnames(lavpartable, "ov.num", block = b)
     if (conditional_x) {
-      ov_names_x <- lav_partable_vnames(lavpartable, "ov.x", block = b)
+      ov_names_x <- lav_pt_vnames(lavpartable, "ov.x", block = b)
       ov_names_num <- ov_names_num[!ov_names_num %in% ov_names_x]
     }
     ovar_idx <- which(lavpartable$block == b &
@@ -995,6 +995,6 @@ lav_partable_baseline <- function(lavobject = NULL,
     pt_1$ustart[ovar_idx] <- diag(sample_cov[[b]])[sample_var_idx]
   }
 
-  pt_1 <- lav_partable_complete(pt_1)
+  pt_1 <- lav_pt_complete(pt_1)
   pt_1
 }

--- a/R/lav_partable_utils.R
+++ b/R/lav_partable_utils.R
@@ -1,5 +1,5 @@
 # what are the block values (not necessarily integers)
-lav_partable_block_values <- function(partable) {
+lav_pt_block_values <- function(partable) {
   if (is.null(partable$block)) {
     block_values <- 1L
   } else {
@@ -13,12 +13,12 @@ lav_partable_block_values <- function(partable) {
 }
 
 # guess number of blocks from a partable
-lav_partable_nblocks <- function(partable) {
-  length(lav_partable_block_values(partable))
+lav_pt_nblocks <- function(partable) {
+  length(lav_pt_block_values(partable))
 }
 
 # what are the group values (not necessarily integers)
-lav_partable_group_values <- function(partable) {
+lav_pt_group_values <- function(partable) {
   # FLAT?
   if (any(partable$op == ":")) {
     colon_idx <- which(partable$op == ":" &
@@ -43,12 +43,12 @@ lav_partable_group_values <- function(partable) {
 }
 
 # guess number of groups from a partable
-lav_partable_ngroups <- function(partable) {
-  length(lav_partable_group_values(partable))
+lav_pt_ngroups <- function(partable) {
+  length(lav_pt_group_values(partable))
 }
 
 # what are the level values (not necessarily integers)
-lav_partable_level_values <- function(partable) {
+lav_pt_level_values <- function(partable) {
   # FLAT?
   if (any(partable$op == ":")) {
     colon_idx <- which(partable$op == ":" &
@@ -74,12 +74,12 @@ lav_partable_level_values <- function(partable) {
 }
 
 # guess number of levels from a partable
-lav_partable_nlevels <- function(partable) {
-  length(lav_partable_level_values(partable))
+lav_pt_nlevels <- function(partable) {
+  length(lav_pt_level_values(partable))
 }
 
 # efa sets values
-lav_partable_efa_values <- function(partable) {
+lav_pt_efa_values <- function(partable) {
   if (is.null(partable$efa)) {
     efa_values <- character(0L)
   } else { # should be character
@@ -93,15 +93,15 @@ lav_partable_efa_values <- function(partable) {
 }
 
 # number of efa sets from a partable
-lav_partable_nefa <- function(partable) {
-  length(lav_partable_efa_values(partable))
+lav_pt_nefa <- function(partable) {
+  length(lav_pt_efa_values(partable))
 }
 
 
 
 
 # number of sample statistics per block
-lav_partable_ndat <- function(partable) {
+lav_pt_ndat <- function(partable) {
   # global
   meanstructure <- any(partable$op == "~1")
   fixed_x <- any(partable$exo > 0L & partable$free == 0L)
@@ -114,16 +114,16 @@ lav_partable_ndat <- function(partable) {
   }
 
   # blocks
-  nblocks <- lav_partable_nblocks(partable)
-  nlevels <- lav_partable_nlevels(partable)
+  nblocks <- lav_pt_nblocks(partable)
+  nlevels <- lav_pt_nlevels(partable)
   ndat <- integer(nblocks)
 
   for (b in seq_len(nblocks)) {
     # how many observed variables in this block?
     if (conditional_x) {
-      ov_names <- lav_partable_vnames(partable, "ov.nox", block = b)
+      ov_names <- lav_pt_vnames(partable, "ov.nox", block = b)
     } else {
-      ov_names <- lav_partable_vnames(partable, "ov", block = b)
+      ov_names <- lav_pt_vnames(partable, "ov", block = b)
     }
     nvar <- length(ov_names)
 
@@ -139,8 +139,8 @@ lav_partable_ndat <- function(partable) {
         pstar <- pstar - nvar
 
         # except within-only 'y'
-        ov_names_y <- lav_partable_vnames(partable, "ov.nox", block = b)
-        ov_names_y2 <- unlist(lav_partable_vnames(partable, "ov",
+        ov_names_y <- lav_pt_vnames(partable, "ov.nox", block = b)
+        ov_names_y2 <- unlist(lav_pt_vnames(partable, "ov",
           block = seq_len(nblocks)[-b]
         ))
         ov_names_y <- ov_names_y[!ov_names_y %in% ov_names_y2]
@@ -149,8 +149,8 @@ lav_partable_ndat <- function(partable) {
         }
 
         # except within-only 'x' (unless fixed.x)
-        ov_names_x <- lav_partable_vnames(partable, "ov.x", block = b)
-        ov_names_x2 <- unlist(lav_partable_vnames(partable, "ov",
+        ov_names_x <- lav_pt_vnames(partable, "ov.x", block = b)
+        ov_names_x2 <- unlist(lav_pt_vnames(partable, "ov",
           block = seq_len(nblocks)[-b]
         ))
         ov_names_x <- ov_names_x[!ov_names_x %in% ov_names_x2]
@@ -164,7 +164,7 @@ lav_partable_ndat <- function(partable) {
 
     # correction for fixed.x?
     if (!conditional_x && fixed_x) {
-      ov_names_x <- lav_partable_vnames(partable, "ov.x", block = b)
+      ov_names_x <- lav_pt_vnames(partable, "ov.x", block = b)
       nvar_x <- length(ov_names_x)
       pstar_x <- nvar_x * (nvar_x + 1) / 2
       if (meanstructure) {
@@ -179,7 +179,7 @@ lav_partable_ndat <- function(partable) {
 
     # composites?
     if (composites) {
-      ov_cind <- lav_partable_vnames(partable, "ov.cind", block = b)
+      ov_cind <- lav_pt_vnames(partable, "ov.cind", block = b)
       covar_idx <- which(partable$op == "~~" &
                          partable$lhs %in% ov_cind &
                          partable$rhs %in% ov_cind &
@@ -189,11 +189,11 @@ lav_partable_ndat <- function(partable) {
 
     # correction for ordinal data?
     if (categorical) {
-      ov_names_x <- lav_partable_vnames(partable, "ov.x", block = b)
+      ov_names_x <- lav_pt_vnames(partable, "ov.x", block = b)
       nexo <- length(ov_names_x)
-      ov_ord <- lav_partable_vnames(partable, "ov.ord", block = b)
+      ov_ord <- lav_pt_vnames(partable, "ov.ord", block = b)
       nvar_ord <- length(ov_ord)
-      th <- lav_partable_vnames(partable, "th", block = b)
+      th <- lav_pt_vnames(partable, "th", block = b)
       nth <- length(th)
       # no variances
       ndat[b] <- ndat[b] - nvar_ord
@@ -203,7 +203,7 @@ lav_partable_ndat <- function(partable) {
       ndat[b] <- ndat[b] + nth
       # add slopes
       if (conditional_x) {
-        ov_names_x <- lav_partable_vnames(partable, "ov.x", block = b)
+        ov_names_x <- lav_pt_vnames(partable, "ov.x", block = b)
         nexo <- length(ov_names_x)
         ndat[b] <- ndat[b] + (nvar * nexo)
       }
@@ -216,7 +216,7 @@ lav_partable_ndat <- function(partable) {
 
     # correction for conditional.x not categorical
     if (conditional_x && !categorical) {
-      ov_names_x <- lav_partable_vnames(partable, "ov.x", block = b)
+      ov_names_x <- lav_pt_vnames(partable, "ov.x", block = b)
       nexo <- length(ov_names_x)
       # add slopes
       ndat[b] <- ndat[b] + (nvar * nexo)
@@ -237,7 +237,7 @@ lav_partable_ndat <- function(partable) {
 }
 
 # total number of free parameters (ignoring equality constraints)
-lav_partable_npar <- function(partable) {
+lav_pt_npar <- function(partable) {
   # we only assume non-zero values
   npar <- length(which(partable$free > 0L))
   npar
@@ -248,9 +248,9 @@ lav_partable_npar <- function(partable) {
 #
 # we need to find the rank of con.jac to find the exact amount
 # of non-redundant equality constraints (this is done in lav_test.R)
-lav_partable_df <- function(partable) {
-  npar <- lav_partable_npar(partable)
-  ndat <- lav_partable_ndat(partable)
+lav_pt_df <- function(partable) {
+  npar <- lav_pt_npar(partable)
+  ndat <- lav_pt_ndat(partable)
 
   # degrees of freedom
   df <- ndat - npar
@@ -260,7 +260,7 @@ lav_partable_df <- function(partable) {
 
 # check order of covariances: we only fill the upper.tri
 # therefore, we 'switch' lhs & rhs if they appear in the wrong order
-lav_partable_covariance_reorder <- function(partable, # nolint
+lav_pt_covariance_reorder <- function(partable,
                                             ov_names = NULL,
                                             lv_names = NULL) {
   # shortcut
@@ -272,12 +272,12 @@ lav_partable_covariance_reorder <- function(partable, # nolint
 
   # get names
   if (is.null(ov_names)) {
-    ov_names <- lav_partable_vnames(partable, "ov")
+    ov_names <- lav_pt_vnames(partable, "ov")
   } else {
     ov_names <- unlist(ov_names)
   }
   if (is.null(lv_names)) {
-    lv_names <- lav_partable_vnames(partable, "lv")
+    lv_names <- lav_pt_vnames(partable, "lv")
     # add random slopes (if any)
     if (!is.null(partable$rv) && any(nchar(partable$rv) > 0L)) {
       rv_names <- unique(partable$rv[nchar(partable$rv) > 0L])
@@ -307,7 +307,7 @@ lav_partable_covariance_reorder <- function(partable, # nolint
 }
 
 # add a single parameter to an existing parameter table
-lav_partable_add <- function(partable = NULL, add = list()) {
+lav_pt_add <- function(partable = NULL, add = list()) {
   # treat partable as list, not as a data.frame
   partable <- as.list(partable)
 
@@ -345,7 +345,7 @@ lav_partable_add <- function(partable = NULL, add = list()) {
 # look for p2-row-idx of p1 elements
 # p1 is usually a subset of p2
 # return NA if not found
-lav_partable_map_id_p1_in_p2 <- function(p1, p2, stopifnotfound = TRUE,
+lav_pt_map_id_p1_in_p2 <- function(p1, p2, stopifnotfound = TRUE,
                                          exclude_nonpar = TRUE) {
   # check if we have a 'block' column (in both p1 and p2)
   if (is.null(p1$block)) {

--- a/R/lav_partable_vnames.R
+++ b/R/lav_partable_vnames.R
@@ -18,7 +18,7 @@ lav_object_vnames <- function(object, type = "ov", ...) { # nolint
     # just a model string?
     partable <- lavParseModelString(object)
   }
-  lav_partable_vnames(partable, type = type, ...)
+  lav_pt_vnames(partable, type = type, ...)
 }
 lavNames <- lav_object_vnames    # synonym #nolint
 
@@ -37,7 +37,7 @@ lavNames <- lav_object_vnames    # synonym #nolint
 #   LDW 30/1/24: 'block' argument not explicitly tested !?
 #   LDW 29/2/24: ov.order = "data" via attribute "ovda"
 # - YR 11/02/25: add type = "lv.ho" for higher-order latent variables
-lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
+lav_pt_vnames <- function(partable, type = NULL, ...,
                                 force_warn = FALSE, ov_x_fatal = FALSE) {
   # This function derives the names of some types of variable (as specified
   # in type) from a 'partable'. The 'warn' parameter needs no explanation.
@@ -53,7 +53,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
   # If the 'partable' contains an attribute vnames and the type is not "*",
   # the 'type' elements of this attribute are used.
 
-  # ----- lav_partable_vnames ---- common ----------------------------------
+  # ----- lav_pt_vnames ---- common ----------------------------------
   # sanity check
   stopifnot(is.list(partable), !missing(type))
   # this is a special function where the default is to suppress warnings,
@@ -115,7 +115,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
   }
   return_value <- NULL
   if (type[1L] != "*" && !is.null(attr(partable, "vnames"))) {
-    # ----- lav_partable_vnames ---- cached data --------------------------
+    # ----- lav_pt_vnames ---- cached data --------------------------
     # uncomment/comment following line to enable/disable trace
     # lav_trace(paste("cached:", paste(type, collapse = ",")))
 
@@ -125,7 +125,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
       return_value <- attr(partable, "vnames")[type]
     }
   }
-  # ----- lav_partable_vnames ---- common ----------------------------------
+  # ----- lav_pt_vnames ---- common ----------------------------------
   if (type[1L] == "all" || type[1L] == "*") {
     type <- type_list
   }
@@ -134,7 +134,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
     partable$block <- rep(1L, length(partable$lhs))
   }
   # per default, use full partable
-  block_select <- lav_partable_block_values(partable)
+  block_select <- lav_pt_block_values(partable)
   # check for ... selection argument(s)
   ndotdotdot <- length(dotdotdot)
   if (ndotdotdot > 0L) {
@@ -177,7 +177,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
     }
   }
   if (is.null(return_value)) {
-    # ----- lav_partable_vnames ---- no cache ------------------------
+    # ----- lav_pt_vnames ---- no cache ------------------------
 
     # uncomment/comment following line to enable/disable trace
     # lav_trace(paste("computed:", paste(type, collapse = ",")))
@@ -230,7 +230,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
         lv_interaction <- character(0L)
       }
       if (length(type) == 1L) {
-        # ----- lav_partable_vnames ---- no cache ----- 1 type -----------
+        # ----- lav_pt_vnames ---- no cache ----- 1 type -----------
         # store lv
         if ("lv" == type) {
           # check if FLAT for random slopes
@@ -305,7 +305,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
           if (is.null(partable$efa)) {
             out <- character(0L)
           } else {
-            set_names <- lav_partable_efa_values(partable)
+            set_names <- lav_pt_efa_values(partable)
             out <- unique(partable$lhs[partable$op == "=~" &
               block_ind &
               partable$efa %in% set_names])
@@ -400,7 +400,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
           # 2. dependent ov's
           ov_y <- eqs_y[!eqs_y %in% c(lv_names2, ov_ind, ov_cind)]
           # 3. independent ov's
-          if (lav_partable_nlevels(partable) > 1L && b > 1L) {
+          if (lav_pt_nlevels(partable) > 1L && b > 1L) {
             # NEW in 0.6-8: if an 'x' was an 'y' in a previous level,
             #               treat it as 'y'
             tmp_eqs_y <- unique(partable$lhs[partable$op == "~"]) # all blocks
@@ -513,7 +513,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
         ))) {
           # correction: is any of these ov.names.x mentioned as a variance,
           #             covariance, or intercept?
-          # this should trigger a warning in lav_model_partable()
+          # this should trigger a warning in lav_model_pt()
           if (is.null(partable$user)) { # FLAT!
             partable$user <- rep(1L, length(partable$lhs))
           }
@@ -818,7 +818,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
           return_value$lv.marker[[b]] <- out
         }
       } else {
-        # ----- lav_partable_vnames ---- no cache ----- more than 1 type ------
+        # ----- lav_pt_vnames ---- no cache ----- more than 1 type ------
         # store lv
         if (any("lv" == type)) {
           # check if FLAT for random slopes
@@ -889,7 +889,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
           if (is.null(partable$efa)) {
             out <- character(0L)
           } else {
-            set_names <- lav_partable_efa_values(partable)
+            set_names <- lav_pt_efa_values(partable)
             out <- unique(partable$lhs[partable$op == "=~" &
               block_ind &
               partable$efa %in% set_names])
@@ -968,7 +968,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
         # 2. dependent ov's
         ov_y <- eqs_y[!eqs_y %in% c(lv_names2, ov_ind, ov_cind)]
         # 3. independent ov's
-        if (lav_partable_nlevels(partable) > 1L && b > 1L) {
+        if (lav_pt_nlevels(partable) > 1L && b > 1L) {
           # NEW in 0.6-8: if an 'x' was an 'y' in a previous level,
           #               treat it as 'y'
           tmp_eqs_y <- unique(partable$lhs[partable$op == "~"]) # all blocks
@@ -1074,7 +1074,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
         ))) {
           # correction: is any of these ov.names.x mentioned as a variance,
           #             covariance, or intercept?
-          # this should trigger a warning in lav_model_partable()
+          # this should trigger a warning in lav_model_pt()
           if (is.null(partable$user)) { # FLAT!
             partable$user <- rep(1L, length(partable$lhs))
           }
@@ -1365,7 +1365,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
       }
     } # b
 
-    # ----- lav_partable_vnames ---- no cache ------------------------
+    # ----- lav_pt_vnames ---- no cache ------------------------
     # new in 0.6-14: if 'da' operator, change order! (for ov.order = "data")
     # now via attribute "ovda"
     ov_names_data <- attr(partable, "ovda")
@@ -1382,7 +1382,7 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
       })
     }
   }
-  # ----- lav_partable_vnames ---- common ------ 1 type --------
+  # ----- lav_pt_vnames ---- common ------ 1 type --------
   # to mimic old behaviour, if length(type) == 1L
   if (length(type) == 1L) {
     return_value <- return_value[[type]]
@@ -1403,6 +1403,6 @@ lav_partable_vnames <- function(partable, type = NULL, ..., # nolint
       return_value <- return_value[block_select]
     }
   }
-  # ----- lav_partable_vnames ---- common ------------------------
+  # ----- lav_pt_vnames ---- common ------------------------
   return_value
 }

--- a/R/lav_plotinfo_positions.R
+++ b/R/lav_plotinfo_positions.R
@@ -142,7 +142,7 @@ lav_plotinfo_positions_one <- function(
     print(edgs1)
     rm(edgs1, nods1)
     cat("matrix with groups after ordering\n")
-    print(lav_groups_matrix(groups))
+    print(lav_groups_mat(groups))
     cat("debug end\n")
   }
   for (g in seq_along(groups)) {
@@ -426,7 +426,7 @@ lav_plotinfo_groups <- function(plotinfo) {
   })
   groups
 }
-lav_groups_matrix <- function(groups) {
+lav_groups_mat <- function(groups) {
   maxrow <- 1L
   maxcol <- 1L
   for (group in groups) {
@@ -482,7 +482,7 @@ lav_groups_matrix <- function(groups) {
         }
       }
     }
-    internaldf <- lav_graph_topological_matrix(defined, definedby,
+    internaldf <- lav_graph_topological_mat(defined, definedby,
                                                bordernodes = bordernodes)
     for (j in seq_along(group$nodes.id)) {
       group$offsets.lin[j] <- internaldf$rows[internaldf$nodes ==
@@ -552,7 +552,7 @@ lav_groups_order <- function(groups, plotinfo) {
   if (nrow(dependencies) == 0L) {
     for (g in groups) dependencies <- add_dependency(dependencies, 999, g$id)
   }
-  groupmatrixdf <- lav_graph_topological_matrix(
+  groupmatrixdf <- lav_graph_topological_mat(
     dependencies$defined,
     dependencies$definedby,
     bordernodes = bordernodes,
@@ -575,7 +575,7 @@ lav_groups_order <- function(groups, plotinfo) {
   #                               not first or last column.
   # Set loc = "b" for measurement groups in another row and
   #                               not first or last column.
-  group_matrix <- lav_groups_matrix(groups)
+  group_matrix <- lav_groups_mat(groups)
   gmcols <- ncol(group_matrix)
   for (g in seq_along(groups)) {
     group <- groups[[g]]

--- a/R/lav_pml_plrt.R
+++ b/R/lav_pml_plrt.R
@@ -9,12 +9,12 @@ lav_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
     lavoptions <- lavobject@Options
     lavsamplestats <- lavobject@SampleStats
     lavcache <- lavobject@Cache
-    lavpartable <- lav_partable_set_cache(lavobject@ParTable, lavobject@pta)
+    lavpartable <- lav_pt_set_cache(lavobject@ParTable, lavobject@pta)
     lavpta <- lavobject@pta
   }
   if (is.null(lavpta)) {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
 
   if (is.null(x)) {
@@ -34,7 +34,7 @@ lav_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
   }
 
   # fit a saturated model 'fittedSat'
-  model_sat <- lav_partable_unrestricted(
+  model_sat <- lav_pt_unrestricted(
     lavobject = NULL,
     lavdata = lavdata,
     lavoptions = lavoptions,
@@ -65,15 +65,15 @@ lav_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
   # we also need a `saturated model', but where the moments are based
   # on the model-implied sample statistics under H0
   model_sat2 <-
-    lav_partable_unrestricted(
+    lav_pt_unrestricted(
       lavobject = NULL,
       lavdata = lavdata,
       lavoptions = lavoptions,
       lavsamplestats = NULL,
-      sample.cov = lav_model_sigma(lavmodel),
-      sample.mean = lav_model_mu(lavmodel),
-      sample.th = lav_model_th(lavmodel),
-      sample.th.idx = lavsamplestats@th.idx
+      sample_cov = lav_model_sigma(lavmodel),
+      sample_mean = lav_model_mu(lavmodel),
+      sample_th = lav_model_th(lavmodel),
+      sample_th_idx = lavsamplestats@th.idx
     )
 
   options2 <- options_1
@@ -241,7 +241,7 @@ lav_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
   #####            the two quadratic quantities
 
   drhodpsi_mat_1 <- vector("list", length = lavsamplestats@ngroups)
-  group_values <- lav_partable_group_values(fitted_sat2@ParTable)
+  group_values <- lav_pt_group_values(fitted_sat2@ParTable)
   for (g in 1:lavsamplestats@ngroups) {
     # delta.g <- lav_model_delta(lavmodel)[[g]] # [[1]] to be substituted by g?
     # The above gives the derivatives of thresholds and polychoric correlations
@@ -255,7 +255,7 @@ lav_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
     # of H1
 
     pt_1 <- fitted_sat2@ParTable
-    pt_1$label <- lav_partable_labels(pt_1)
+    pt_1$label <- lav_pt_labels(pt_1)
     free_idx <- which(pt_1$free > 0 & pt_1$op != "|" &
                        pt_1$group == group_values[g])
     parlabel <- pt_1$label[free_idx]
@@ -287,7 +287,7 @@ lav_pml_plrt <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
 
     # added by YR - 26 April 2018, for 0.6-1
     # we now can get 'labelled' delta rownames
-    delta_g <- lav_object_inspect_delta_internal(
+    delta_g <- lav_inspect_delta_internal(
       lavmodel = lavmodel,
       lavdata = lavdata, lavpartable = lavpartable,
       add_labels = TRUE, add_class = FALSE,

--- a/R/lav_pml_plrt2.R
+++ b/R/lav_pml_plrt2.R
@@ -9,12 +9,12 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
     lavoptions <- lavobject@Options
     lavsamplestats <- lavobject@SampleStats
     lavcache <- lavobject@Cache
-    lavpartable <- lav_partable_set_cache(lavobject@ParTable, lavobject@pta)
+    lavpartable <- lav_pt_set_cache(lavobject@ParTable, lavobject@pta)
     lavpta <- lavobject@pta
   }
   if (is.null(lavpta)) {
-    lavpta <- lav_partable_attributes(lavpartable)
-    lavpartable <- lav_partable_set_cache(lavpartable, lavpta)
+    lavpta <- lav_pt_attributes(lavpartable)
+    lavpartable <- lav_pt_set_cache(lavpartable, lavpta)
   }
 
   if (is.null(x)) {
@@ -34,7 +34,7 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
   }
 
   # fit a saturated model 'fittedSat'
-  model_sat <- lav_partable_unrestricted(
+  model_sat <- lav_pt_unrestricted(
     lavobject = NULL,
     lavdata = lavdata,
     lavoptions = lavoptions,
@@ -65,16 +65,16 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
   # we also need a `saturated model', but where the moments are based
   # on the model-implied sample statistics under H0
   model_sat2 <-
-    lav_partable_unrestricted(
+    lav_pt_unrestricted(
       lavobject = NULL,
       lavdata = lavdata,
       lavoptions = lavoptions,
       lavpta = lavpta,
       lavsamplestats = NULL,
-      sample.cov = lav_model_sigma(lavmodel),
-      sample.mean = lav_model_mu(lavmodel),
-      sample.th = lav_model_th(lavmodel),
-      sample.th.idx = lavsamplestats@th.idx
+      sample_cov = lav_model_sigma(lavmodel),
+      sample_mean = lav_model_mu(lavmodel),
+      sample_th = lav_model_th(lavmodel),
+      sample_th_idx = lavsamplestats@th.idx
     )
 
   options2 <- options_1
@@ -111,7 +111,7 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
 
   # inverted observed information ('H.inv')
   if (is.null(vcov_1)) {
-    h0_inv <- lav_model_information_observed(
+    h0_inv <- lav_model_info_observed(
       lavmodel = lavmodel,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavoptions = lavoptions,
@@ -123,14 +123,14 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
 
   # first order information ('J')
   if (is.null(vcov_1)) {
-    j0 <- lav_model_information_firstorder(
+    j0 <- lav_model_info_firstorder(
       lavmodel = lavmodel, lavoptions = lavoptions,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavcache = lavcache
     )[, ]
   } else {
     # we do not get J, but J.group, FIXME?
-    j0 <- lav_model_information_firstorder(
+    j0 <- lav_model_info_firstorder(
       lavmodel = lavmodel, lavoptions = lavoptions,
       lavsamplestats = lavsamplestats, lavdata = lavdata,
       lavcache = lavcache
@@ -175,7 +175,7 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
   #####            of the two quadratic quantities
 
   drhodpsi_mat_1 <- vector("list", length = lavsamplestats@ngroups)
-  group_values <- lav_partable_group_values(fitted_sat2@ParTable)
+  group_values <- lav_pt_group_values(fitted_sat2@ParTable)
   for (g in 1:lavsamplestats@ngroups) {
     delta_g <- lav_model_delta(lavmodel)[[g]]
     # order of the rows: first the thresholds, then the correlations
@@ -183,7 +183,7 @@ lav_pml_plrt2 <- function(lavobject = NULL, lavmodel = NULL, lavdata = NULL,
     # of H1
 
     pt_1 <- fitted_sat2@ParTable
-    pt_1$label <- lav_partable_labels(pt_1)
+    pt_1$label <- lav_pt_labels(pt_1)
     free_idx <- which(pt_1$free > 0 & pt_1$group == group_values[g])
     parlabel <- pt_1$label[free_idx]
 

--- a/R/lav_pml_test_plrt.R
+++ b/R/lav_pml_test_plrt.R
@@ -71,7 +71,7 @@ lav_pml_test_plrt <- function(fit_obj_h0, fit_obj_h1) {
 
   # handle possible constraints in H1 (and therefore also in objH1_h0)
   inv_hes_theta0 <-
-    lav_model_information_augment_invert(
+    lav_model_info_augment_invert(
       lavmodel = obj_h1_h0@Model,
       information = hes_theta0,
       inverted = TRUE
@@ -240,14 +240,14 @@ lav_pml_test_plrt2 <- function(fit_obj_h0, fit_obj_h1) {
 
   # Compute the sum of the eigenvalues and the sum of the squared eigenvalues
   # so that the adjustment to PLRT can be applied.
-  # Here a couple of functions (e.g. lav_pml_object_inspect_hessian) which are
+  # Here a couple of functions (e.g. lav_pml_inspect_hessian) which are
   # modifications of lavaan functions (e.g. getHessian) are needed. These are
   # defined in the end of the file.
 
   # the quantity below follows the same logic as getHessian of lavaan 0.5-18
   # and it actually gives N*Hessian. That's why the command following the
   # command below.
-  # NHes.theta0 <- lav_pml_object_inspect_hessian (object = obj@Model,
+  # NHes.theta0 <- lav_pml_inspect_hessian (object = obj@Model,
   #                           samplestats = obj@SampleStats ,
   #                           x = obj@Data@X ,
   #                           estimator = "PML",
@@ -260,7 +260,7 @@ lav_pml_test_plrt2 <- function(fit_obj_h0, fit_obj_h1) {
   #                              # input for lav_pml_object_x2glist
   #                           Npar = Npar,
   #                           equal_constr=equal_constr)
-  nhes_theta0 <- lav_pml_object_inspect_hessian(
+  nhes_theta0 <- lav_pml_inspect_hessian(
     object = obj@Model, samplestats = obj@SampleStats,
     x = obj@Data@X, estimator = "PML", lavcache = obj@Cache,
     my_m_el_idx = my_m_el_idx, my_x_el_idx = my_x_el_idx,
@@ -321,7 +321,7 @@ lav_pml_test_plrt2 <- function(fit_obj_h0, fit_obj_h1) {
 # Npar = Npar
 # equal_constr =TRUE
 
-lav_pml_object_inspect_hessian <- function(object, samplestats, x,
+lav_pml_inspect_hessian <- function(object, samplestats, x,
                          estimator = "PML", lavcache,
                          my_m_el_idx, my_x_el_idx,
                          my_m_el_idx2, my_x_el_idx2,
@@ -333,7 +333,7 @@ lav_pml_object_inspect_hessian <- function(object, samplestats, x,
   hessian <- matrix(0, npar, npar) #
 
   # !!!! MYfunction below
-  x_1 <- lav_pml_object_inspect_parameters(
+  x_1 <- lav_pml_inspect_parameters(
     object = object,
     glist = NULL, n = npar, # N the number of parameters to consider
     my_m_el_idx = my_m_el_idx,
@@ -347,9 +347,9 @@ lav_pml_object_inspect_hessian <- function(object, samplestats, x,
     x_left2[j] <- x_1[j] - 2 * h_j
     x_right[j] <- x_1[j] + h_j
     x_right2[j] <- x_1[j] + 2 * h_j
-    # !!!! MYfunction below : lav_pml_object_inspect_gradient and
+    # !!!! MYfunction below : lav_pml_inspect_grad and
     #                         lav_pml_object_x2glist
-    g_left <- lav_pml_object_inspect_gradient(
+    g_left <- lav_pml_inspect_grad(
       object = object,
       glist = lav_pml_object_x2glist(
         object = object, x = x_left,
@@ -363,7 +363,7 @@ lav_pml_object_inspect_hessian <- function(object, samplestats, x,
       equal_constr = equal_constr
     )
 
-    g_left2 <- lav_pml_object_inspect_gradient(
+    g_left2 <- lav_pml_inspect_grad(
       object = object,
       glist = lav_pml_object_x2glist(
         object = object, x = x_left2,
@@ -377,7 +377,7 @@ lav_pml_object_inspect_hessian <- function(object, samplestats, x,
       equal_constr = equal_constr
     )
 
-    g_right <- lav_pml_object_inspect_gradient(
+    g_right <- lav_pml_inspect_grad(
       object = object,
       glist = lav_pml_object_x2glist(
         object = object, x = x_right,
@@ -391,7 +391,7 @@ lav_pml_object_inspect_hessian <- function(object, samplestats, x,
       equal_constr = equal_constr
     )
 
-    g_right2 <- lav_pml_object_inspect_gradient(
+    g_right2 <- lav_pml_inspect_grad(
       object = object,
       glist = lav_pml_object_x2glist(
         object = object, x = x_right2,
@@ -416,9 +416,9 @@ lav_pml_object_inspect_hessian <- function(object, samplestats, x,
 
 
 
-##################################  lav_pml_object_inspect_parameters
+##################################  lav_pml_inspect_parameters
 # different input arguments: my_m_el_idx, my_x_el_idx
-lav_pml_object_inspect_parameters <-         # nolint
+lav_pml_inspect_parameters <-         # nolint
   function(object, glist = NULL, n, # N the number of parameters to consider
            my_m_el_idx, my_x_el_idx) {
   if (is.null(glist)) {
@@ -439,10 +439,10 @@ lav_pml_object_inspect_parameters <-         # nolint
 
 
 
-#############################  lav_pml_object_inspect_gradient
+#############################  lav_pml_inspect_grad
 # the difference are the input arguments my_m_el_idx, my_x_el_idx
 # used  in  lavaan:::lav_model_delta
-lav_pml_object_inspect_gradient <-                  # nolint
+lav_pml_inspect_grad <-                  # nolint
   function(object, glist, samplestats = NULL, x = NULL,
            lavcache = NULL, estimator = "PML",
            my_m_el_idx, my_x_el_idx, equal_constr) {
@@ -579,7 +579,7 @@ lav_pml_model_vcov_firstorder <- function(lavmodel, lavsamplestats = NULL,
     scores = TRUE, negative = FALSE
   )
   group_sc <- sc %*% delta[[g]]
-  b0_group[[g]] <- lav_matrix_crossprod(group_sc)
+  b0_group[[g]] <- lav_mat_crossprod(group_sc)
   # !!!! B0.group[[g]] <- B0.group[[g]]/lavsamplestats@ntotal
   #  !!! skip so that the result is in line with the 0.5-18 version of lavaan
 

--- a/R/lav_pml_utils.R
+++ b/R/lav_pml_utils.R
@@ -271,7 +271,7 @@ lav_pml_dbilogl_dpar_x <- function(y1, y2, exo, rho,
 ###############################################################
 
 
-# The function lav_pml_uni_scores gives, casewise, the derivative of a
+# The function lav_pml_uni_sc gives, casewise, the derivative of a
 # univariate log-likelihood w.r.t. thresholds and slopes if present weighted by
 # the casewise uni-weights as those defined in AC-PL (essentially the number of
 # missing values per case).
@@ -288,7 +288,7 @@ lav_pml_dbilogl_dpar_x <- function(y1, y2, exo, rho,
 #    Otherwise it takes the value NULL.
 
 
-lav_pml_uni_scores <- function(y1, th_y1, exo = NULL, sl_y1 = NULL,
+lav_pml_uni_sc <- function(y1, th_y1, exo = NULL, sl_y1 = NULL,
                        weights_casewise) {
   nth_y1 <- length(th_y1)
   nobs_1 <- length(y1)

--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -118,7 +118,7 @@ lav_predict_internal <- function(lavmodel = NULL,
                                drop_list_single_group = TRUE) {
   # type
   type <- tolower(type)
-  lavpta <- lav_partable_attributes(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
   if (type %in% c("latent", "lv", "factor", "factor.score", "factorscore")) {
     type <- "lv"
   } else if (type %in% c("ov", "yhat")) {
@@ -357,8 +357,8 @@ lav_predict_internal <- function(lavmodel = NULL,
 #         #            returning original factor scores."))
 #         #  return(out[[g]])
 #         #}
-#         #fs.inv.sqrt <- lav_matrix_symmetric_sqrt(FS.cov.inv)
-#         #veta.sqrt <- lav_matrix_symmetric_sqrt(VETA[[g]])
+#         #fs.inv.sqrt <- lav_mat_sym_sqrt(FS.cov.inv)
+#         #veta.sqrt <- lav_mat_sym_sqrt(VETA[[g]])
 #         #tmp <- FS.centered %*% fs.inv.sqrt %*% veta.sqrt
 #         tmp <- FS.centered %*% t(tmat[[b]])
 #         ret <- t(t(tmp) + drop(EETA[[g]]))
@@ -813,7 +813,7 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
     if (newdata_flag) {
       mp_1 <- vector("list", lavdata@ngroups)
       for (g in seq_len(lavdata@ngroups)) {
-        mp_1[[g]] <- lav_data_missing_patterns(data_obs[[g]])
+        mp_1[[g]] <- lav_data_mi_patterns(data_obs[[g]])
       }
     } else {
       mp_1 <- lavdata@Mp
@@ -873,11 +873,11 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
       implied_group <- lapply(lavimplied, function(x) x[group_idx])
 
       # random effects (=random intercepts or cluster means)
-      out <- lav_mvnorm_cluster_implied22l(
+      out <- lav_mvn_cl_implied22l(
         lp = lp,
         implied = implied_group
       )
-      mb_j <- lav_mvnorm_cluster_em_estep_ranef(
+      mb_j <- lav_mvn_cl_em_estep_ranef(
         ylp = ylp, lp = lp,
         sigma_w = out$sigma.w, sigma_b = out$sigma.b,
         sigma_zz = out$sigma.zz, sigma_yz = out$sigma.yz,
@@ -988,7 +988,7 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
         oc <- yc[mp$case.idx[[p]], mp$pat[p, ], drop = FALSE]
 
         # invert sigma (Sigma_22, observed part only) for this pattern
-        sigma_22_inv <- try(lav_matrix_symmetric_inverse_update(
+        sigma_22_inv <- try(lav_mat_sym_inverse_update(
           s_inv = sigma_inv_g, rm_idx = na_idx, logdet = FALSE
         ), silent = TRUE)
         if (inherits(sigma_22_inv, "try-error")) {
@@ -1146,7 +1146,7 @@ lav_predict_eta_bartlett <- function(lavobject = NULL, # for convenience
     if (newdata_flag) {
       mp_1 <- vector("list", lavdata@ngroups)
       for (g in seq_len(lavdata@ngroups)) {
-        mp_1[[g]] <- lav_data_missing_patterns(data_obs[[g]])
+        mp_1[[g]] <- lav_data_mi_patterns(data_obs[[g]])
       }
     } else {
       mp_1 <- lavdata@Mp
@@ -1206,11 +1206,11 @@ lav_predict_eta_bartlett <- function(lavobject = NULL, # for convenience
       # random effects (=random intercepts or cluster means)
       # NOTE: is the 'ML' way not simply using the observed cluster
       #       means?
-      out <- lav_mvnorm_cluster_implied22l(
+      out <- lav_mvn_cl_implied22l(
         lp = lp,
         implied = implied_group
       )
-      mb_j <- lav_mvnorm_cluster_em_estep_ranef(
+      mb_j <- lav_mvn_cl_em_estep_ranef(
         ylp = ylp, lp = lp,
         sigma_w = out$sigma.w, sigma_b = out$sigma.b,
         sigma_zz = out$sigma.zz, sigma_yz = out$sigma.yz,
@@ -1323,7 +1323,7 @@ lav_predict_eta_bartlett <- function(lavobject = NULL, # for convenience
         oc <- yc[mp$case.idx[[p]], mp$pat[p, ], drop = FALSE]
 
         # invert sigma (Sigma_22, observed part only) for this pattern
-        sigma_22_inv <- try(lav_matrix_symmetric_inverse_update(
+        sigma_22_inv <- try(lav_mat_sym_inverse_update(
           s_inv = sigma_inv_g, rm_idx = na_idx, logdet = FALSE
         ), silent = TRUE)
         if (inherits(sigma_22_inv, "try-error")) {
@@ -2045,11 +2045,11 @@ lav_predict_tmat_green <- function(lavobject = NULL,
     sigma_b <- sigma_1[[b]]
     sigma_b_inv <- solve(sigma_b)
     veta <- veta_1[[b]]
-    veta_sqrt <- lav_matrix_symmetric_sqrt(veta)
+    veta_sqrt <- lav_mat_sym_sqrt(veta)
     veta32 <- veta %*% veta_sqrt
     lambda <- mm_lambda[[b]]
     tmp <- veta32 %*% t(lambda) %*% sigma_b_inv %*% lambda %*% veta32
-    tmp_inv_sqrt <- lav_matrix_symmetric_sqrt(solve(tmp))
+    tmp_inv_sqrt <- lav_mat_sym_sqrt(solve(tmp))
     tmat[[b]] <- veta_sqrt %*% tmp_inv_sqrt %*% veta_sqrt
   }
 
@@ -2084,11 +2084,11 @@ lav_predict_tmat_det <- function(lavobject = NULL,
     sigma_b <- sigma_1[[b]]
     sigma_b_inv <- solve(sigma_b)
     veta <- veta_1[[b]]
-    veta_sqrt <- lav_matrix_symmetric_sqrt(veta)
-    veta_inv_sqrt <- lav_matrix_symmetric_sqrt(solve(veta))
+    veta_sqrt <- lav_mat_sym_sqrt(veta)
+    veta_inv_sqrt <- lav_mat_sym_sqrt(solve(veta))
     lambda <- mm_lambda[[b]]
     tmp <- veta_sqrt %*% t(lambda) %*% sigma_b_inv %*% lambda %*% veta_sqrt
-    tmp_sqrt <- lav_matrix_symmetric_sqrt(tmp)
+    tmp_sqrt <- lav_mat_sym_sqrt(tmp)
     tmat[[b]] <- veta_sqrt %*% tmp_sqrt %*% veta_inv_sqrt
   }
 
@@ -2099,10 +2099,10 @@ lav_predict_tmat_det <- function(lavobject = NULL,
 lav_predict_tmat_det_internal <- function(sigma_1 = NULL, veta = NULL,
                                           lambda = NULL) {
     sigma_inv <- solve(sigma_1)
-    veta_sqrt <- lav_matrix_symmetric_sqrt(veta)
-    veta_inv_sqrt <- lav_matrix_symmetric_sqrt(solve(veta))
+    veta_sqrt <- lav_mat_sym_sqrt(veta)
+    veta_inv_sqrt <- lav_mat_sym_sqrt(solve(veta))
     tmp <- veta_sqrt %*% t(lambda) %*% sigma_inv %*% lambda %*% veta_sqrt
-    tmp_sqrt <- lav_matrix_symmetric_sqrt(tmp)
+    tmp_sqrt <- lav_mat_sym_sqrt(tmp)
     tmat <- veta_sqrt %*% tmp_sqrt %*% veta_inv_sqrt
     tmat
 }

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -45,8 +45,8 @@ lav_lavaanlist_print <- function(x, ...) {
 
 
 # prints only lower triangle of a symmetric matrix
-lav_matrix_symmetric_print <- function(x, ..., nd = 3L, shift = 0L,  # nolint start
-                                          diag.na.dot = TRUE) {      # nolint end
+lav_mat_sym_print <- function(x, ..., nd = 3L, shift = 0L,
+                                          diag_na_dot = TRUE) {
   # print only lower triangle of a symmetric matrix
   # this function was inspired by the `print.correlation' function
   # in package nlme
@@ -57,9 +57,9 @@ lav_matrix_symmetric_print <- function(x, ..., nd = 3L, shift = 0L,  # nolint st
   ll <- lower.tri(x, diag = TRUE)
   y[ll] <- format(round(x[ll], digits = nd))
   y[!ll] <- ""
-  if (diag.na.dot) {
+  if (diag_na_dot) {
     # print a "." instead of NA on the main diagonal (eg lav_efalist_summary)
-    diag_idx <- lav_matrix_diag_idx(ncol(x))
+    diag_idx <- lav_mat_diag_idx(ncol(x))
     tmp <- x[diag_idx]
     if (all(is.na(tmp))) {
       y[diag_idx] <- paste(strrep(" ", nd + 2L), ".", sep = "")
@@ -91,7 +91,7 @@ lav_matrix_symmetric_print <- function(x, ..., nd = 3L, shift = 0L,  # nolint st
 }
 
 
-lav_matrix_print <- function(x, ..., nd = 3L, shift = 0L) {
+lav_mat_print <- function(x, ..., nd = 3L, shift = 0L) {
   x <- as.matrix(x) # just in case
   y <- unclass(x)
   attributes(y)[c("header", "footer")] <- NULL
@@ -355,7 +355,7 @@ lav_parameterestimates_print <- function(x, ..., nd = 3L) {
     ngroups <- 1L
     x$group <- rep(1L, length(x$lhs))
   } else {
-    ngroups <- lav_partable_ngroups(x)
+    ngroups <- lav_pt_ngroups(x)
   }
 
   # number of levels
@@ -363,7 +363,7 @@ lav_parameterestimates_print <- function(x, ..., nd = 3L) {
     nlevels <- 1L
     x$level <- rep(1L, length(x$lhs))
   } else {
-    nlevels <- lav_partable_nlevels(x)
+    nlevels <- lav_pt_nlevels(x)
   }
 
   # block column
@@ -804,7 +804,7 @@ lav_parameterestimates_print <- function(x, ..., nd = 3L) {
     } else if (s == "Constraints") {
       row_idx <- which(x$op %in% c("==", "<", ">"))
       if (length(row_idx) == 0) next
-      m[row_idx, 1] <- lav_print_format_constraints(x$lhs[row_idx],
+      m[row_idx, 1] <- lav_print_format_con(x$lhs[row_idx],
                           x$op[row_idx], x$rhs[row_idx], nd = nd)
       m[row_idx, 2] <- sprintf(num_format, abs(x$est[row_idx]))
       m_1 <- m[row_idx, 1:2, drop = FALSE]
@@ -871,7 +871,7 @@ lav_print_format_names <- function(names_1, labels_1, prefix = NULL) {
   sprintf(char_format, prefix, names_1)
 }
 
-lav_print_format_constraints <- function(lhs, op, rhs, nd) {
+lav_print_format_con <- function(lhs, op, rhs, nd) {
   nd <- max(nd, 3)
   m_w <- 41 + (nd - 3) * 3
 

--- a/R/lav_representation.R
+++ b/R/lav_representation.R
@@ -4,7 +4,7 @@ lavMatrixRepresentation <- function(partable, representation = "LISREL", # nolin
                                     add.attributes = FALSE,
                                     as.data.frame. = TRUE) {             # nolint end
   # check parameter table
-  partable <- lav_partable_complete(partable)
+  partable <- lav_pt_complete(partable)
 
   # get model matrices
   if (representation == "LISREL") {

--- a/R/lav_representation_lisrel.R
+++ b/R/lav_representation_lisrel.R
@@ -39,11 +39,11 @@ lav_lisrel <- function(lavpartable = NULL,
   }
 
   # number of blocks
-  nblocks <- lav_partable_nblocks(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
 
   # multilevel?
-  nlevels <- lav_partable_nlevels(lavpartable)
-  ngroups <- lav_partable_ngroups(lavpartable)
+  nlevels <- lav_pt_nlevels(lavpartable)
+  ngroups <- lav_pt_ngroups(lavpartable)
 
   ov_dummy_names_nox <- vector("list", nblocks)
   ov_dummy_names_x <- vector("list", nblocks)
@@ -59,18 +59,18 @@ lav_lisrel <- function(lavpartable = NULL,
   for (g in 1:nblocks) {
     # info from user model per block
     if (gamma) {
-      ov_names <- lav_partable_vnames(lavpartable, "ov.nox", block = g)
+      ov_names <- lav_pt_vnames(lavpartable, "ov.nox", block = g)
     } else {
-      ov_names <- lav_partable_vnames(lavpartable, "ov", block = g)
+      ov_names <- lav_pt_vnames(lavpartable, "ov", block = g)
     }
     nvar <- length(ov_names)
-    lv_names <- lav_partable_vnames(lavpartable, "lv", block = g)
+    lv_names <- lav_pt_vnames(lavpartable, "lv", block = g)
     nfac <- length(lv_names)
-    ov_th <- lav_partable_vnames(lavpartable, "th", block = g)
+    ov_th <- lav_pt_vnames(lavpartable, "th", block = g)
     nth <- length(ov_th)
-    ov_names_x <- lav_partable_vnames(lavpartable, "ov.x", block = g)
+    ov_names_x <- lav_pt_vnames(lavpartable, "ov.x", block = g)
     nexo <- length(ov_names_x)
-    ov_names_nox <- lav_partable_vnames(lavpartable, "ov.nox", block = g)
+    ov_names_nox <- lav_pt_vnames(lavpartable, "ov.nox", block = g)
 
     # in this representation, we need to create 'phantom/dummy' latent
     # variables for all `x' and `y' variables not in lv.names
@@ -86,14 +86,14 @@ lav_lisrel <- function(lavpartable = NULL,
       # are removed from ov.x
       if (nlevels > 1L) {
         if (ngroups == 1L) {
-          other_block_names <- lav_partable_vnames(lavpartable, "ov",
+          other_block_names <- lav_pt_vnames(lavpartable, "ov",
             block = seq_len(nblocks)[-g]
           )
         } else {
           # TEST ME
           this_group <- ceiling(g / nlevels)
           blocks_within_group <- (this_group - 1L) * nlevels + seq_len(nlevels)
-          other_block_names <- lav_partable_vnames(lavpartable,
+          other_block_names <- lav_pt_vnames(lavpartable,
             "ov",
             block = blocks_within_group[-g]
           )
@@ -1559,7 +1559,7 @@ lav_lisrel_residual_variances <- function(mlist = NULL,
 
     nr <- nrow(mm_beta)
     ib <- -mm_beta
-    ib[lav_matrix_diag_idx(nr)] <- 1
+    ib[lav_mat_diag_idx(nr)] <- 1
     ib_inv <- solve(ib)
 
 
@@ -1684,7 +1684,7 @@ lav_lisrel_cov_both <- function(mlist = NULL, delta = TRUE) {
 
   # 'extend' matrices
   lambda2 <- rbind(mm_lambda, diag(nlat))
-  theta2 <- lav_matrix_bdiag(mm_theta, matrix(0, nlat, nlat))
+  theta2 <- lav_mat_bdiag(mm_theta, matrix(0, nlat, nlat))
 
 
   # beta?
@@ -1851,11 +1851,11 @@ lav_lisrel_dsigma_dx <- function(mlist = NULL,
   compute_sigma <- function(x, mm = "wmat", mlist = NULL) {
     mlist_1 <- mlist
     if (mm %in% c("psi", "theta")) {
-      mlist_1[[mm]] <- lav_matrix_vech_reverse(x)
+      mlist_1[[mm]] <- lav_mat_vech_rev(x)
     } else {
       mlist_1[[mm]][, ] <- x
     }
-    lav_matrix_vec(lav_lisrel_sigma(mlist_1))
+    lav_mat_vec(lav_lisrel_sigma(mlist_1))
   }
 
   composites <- FALSE
@@ -1864,7 +1864,7 @@ lav_lisrel_dsigma_dx <- function(mlist = NULL,
   }
 
   # only lower.tri part of sigma (not same order as elimination matrix?)
-  v_idx <- lav_matrix_vech_idx(nvar)
+  v_idx <- lav_mat_vech_idx(nvar)
   pstar <- nvar * (nvar + 1) / 2
 
   # shortcut for gamma, nu, alpha, tau,.... : empty matrix
@@ -1891,7 +1891,7 @@ lav_lisrel_dsigma_dx <- function(mlist = NULL,
 
   # pre
   # if(m == "lambda" || m == "beta")
-  #    IK <- diag(nvar*nvar) + lav_matrix_commutation(nvar, nvar)
+  #    IK <- diag(nvar*nvar) + lav_mat_com(nvar, nvar)
   if (m == "lambda" || m == "beta") {
     l1 <- mm_lambda %*% ib_inv %*% mm_psi %*% t(ib_inv)
   }
@@ -1908,7 +1908,7 @@ lav_lisrel_dsigma_dx <- function(mlist = NULL,
     if (composites) {
       dx <- lav_func_jacobian_complex(
         func = compute_sigma,
-        x = lav_matrix_vec(mlist$beta),
+        x = lav_mat_vec(mlist$beta),
         mm = "beta", mlist = mlist
       )
       dx <- dx[, idx, drop = FALSE]
@@ -1918,26 +1918,26 @@ lav_lisrel_dsigma_dx <- function(mlist = NULL,
         (lambda__ib_inv %x% l1)[, kol_idx, drop = FALSE]
       # this is not really needed (because we select idx=m.el.idx)
       # but just in case we need all elements of beta...
-      dx[, which(idx %in% lav_matrix_diag_idx(nfac))] <- 0.0
+      dx[, which(idx %in% lav_mat_diag_idx(nfac))] <- 0.0
     }
   } else if (m == "psi") {
     if (composites) {
       tmp <- lav_func_jacobian_complex(
         func = compute_sigma,
-        x = lav_matrix_vech(mlist$psi),
+        x = lav_mat_vech(mlist$psi),
         mm = "psi", mlist = mlist
       )
       dx <- matrix(0, nrow = nrow(tmp), ncol = length(mm_psi))
-      dx[, lav_matrix_vech_idx(nrow(mm_psi))] <- tmp
-      dx[, lav_matrix_vechu_idx(nrow(mm_psi), diagonal = FALSE)] <-
-        dx[, lav_matrix_vech_idx(nrow(mm_psi), diagonal = FALSE), drop = FALSE]
+      dx[, lav_mat_vech_idx(nrow(mm_psi))] <- tmp
+      dx[, lav_mat_vechu_idx(nrow(mm_psi), diagonal = FALSE)] <-
+        dx[, lav_mat_vech_idx(nrow(mm_psi), diagonal = FALSE), drop = FALSE]
       dx <- dx[, idx, drop = FALSE]
     } else {
       dx <- (lambda__ib_inv %x% lambda__ib_inv)
       # symmetry correction, but keeping all duplicated elements
       # since we depend on idx=m.el.idx
-      lower_idx <- lav_matrix_vech_idx(nfac, diagonal = FALSE)
-      upper_idx <- lav_matrix_vechru_idx(nfac, diagonal = FALSE)
+      lower_idx <- lav_mat_vech_idx(nfac, diagonal = FALSE)
+      upper_idx <- lav_mat_vechru_idx(nfac, diagonal = FALSE)
       offdiag_sum <- dx[, lower_idx] + dx[, upper_idx]
       dx[, c(lower_idx, upper_idx)] <- cbind(offdiag_sum, offdiag_sum)
       dx <- dx[, idx, drop = FALSE]
@@ -1954,14 +1954,14 @@ lav_lisrel_dsigma_dx <- function(mlist = NULL,
     dd_omega <- (dd %*% omega)
     a <- dd_omega %x% diag(nvar)
     m_b <- diag(nvar) %x% dd_omega
-    dx <- a[, lav_matrix_diag_idx(nvar), drop = FALSE] +
-      m_b[, lav_matrix_diag_idx(nvar), drop = FALSE]
+    dx <- a[, lav_mat_diag_idx(nvar), drop = FALSE] +
+      m_b[, lav_mat_diag_idx(nvar), drop = FALSE]
     dx <- dx[, idx, drop = FALSE]
   } else if (m == "wmat") {
     # just a dummy to get us going
     dx <- lav_func_jacobian_complex(
       func = compute_sigma,
-      x = lav_matrix_vec(mm_wmat),
+      x = lav_mat_vec(mm_wmat),
       mm = "wmat", mlist = mlist
     )
     dx <- dx[, idx, drop = FALSE]
@@ -2036,7 +2036,7 @@ lav_lisrel_dmu_dx <- function(mlist = NULL,
   } else if (m == "beta") {
     dx <- t(ib_inv %*% mm_alpha) %x% (mm_lambda %*% ib_inv)
     # this is not really needed (because we select idx=m.el.idx)
-    dx[, lav_matrix_diag_idx(nfac)] <- 0.0
+    dx[, lav_mat_diag_idx(nfac)] <- 0.0
   } else if (m == "alpha") {
     dx <- mm_lambda %*% ib_inv
   } else {
@@ -2125,7 +2125,7 @@ lav_lisrel_dth_dx <- function(mlist = NULL,
   } else if (m == "beta") {
     dx <- (-1) * t(ib_inv %*% mm_alpha) %x% (mm_lambda %*% ib_inv)
     # this is not really needed (because we select idx=m.el.idx)
-    dx[, lav_matrix_diag_idx(nfac)] <- 0.0
+    dx[, lav_mat_diag_idx(nfac)] <- 0.0
     dx <- k_nu %*% dx
     if (delta_flag) {
       dx <- dx * as.vector(k_nu %*% mm_delta)
@@ -2189,7 +2189,7 @@ lav_lisrel_dpi_dx <- function(mlist = NULL,
   } else if (m == "beta") {
     dx <- t(ib_inv %*% mm_gamma) %x% (mm_lambda %*% ib_inv)
     # this is not really needed (because we select idx=m.el.idx)
-    dx[, lav_matrix_diag_idx(nfac)] <- 0.0
+    dx[, lav_mat_diag_idx(nfac)] <- 0.0
     if (delta_flag) {
       dx <- dx * delta_diag
     }
@@ -2252,7 +2252,7 @@ lav_lisrel_dpsi_dx <- function(mlist = NULL,
                                idx = seq_along(mlist[[m]])) {
   mm_psi <- mlist$psi
   nfac <- nrow(mm_psi)
-  v_idx <- lav_matrix_vech_idx(nfac)
+  v_idx <- lav_mat_vech_idx(nfac)
 
   # shortcut for empty matrices
   if (m != "psi") {
@@ -2274,7 +2274,7 @@ lav_lisrel_dtheta_dx <- function(mlist = NULL,
                                  idx = seq_along(mlist[[m]])) {
   mm_theta <- mlist$theta
   nvar <- nrow(mm_theta)
-  v_idx <- lav_matrix_vech_idx(nvar)
+  v_idx <- lav_mat_vech_idx(nvar)
 
   # shortcut for empty matrices
   if (m != "theta") {
@@ -2387,8 +2387,8 @@ lav_lisrel_dalpha_dx <- function(mlist = NULL,
 }
 
 # MLIST = NULL; meanstructure=TRUE; th=TRUE; delta=TRUE; pi=TRUE; gw=FALSE
-# lav_matrix_vech_idx <- lavaan:::lav_matrix_vech_idx;
-# lav_matrix_vechru_idx <- lavaan:::lav_matrix_vechru_idx
+# lav_mat_vech_idx <- lavaan:::lav_mat_vech_idx;
+# lav_mat_vechru_idx <- lavaan:::lav_mat_vechru_idx
 # vec <- lavaan:::vec;
 # lav_func_jacobian_complex <- lavaan:::lav_func_jacobian_complex
 # lav_lisrel_sigma <- lavaan:::lav_lisrel_sigma
@@ -2450,10 +2450,10 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
     diag(mlist$beta) <- 0.0
     diag(mlist$theta) <- diag(mlist$theta) * diag(mlist$theta) * 10
     diag(mlist$psi) <- diag(mlist$psi) * diag(mlist$psi) * 10
-    mlist$psi[lav_matrix_vechru_idx(nfac)] <-
-      mlist$psi[lav_matrix_vech_idx(nfac)]
-    mlist$theta[lav_matrix_vechru_idx(nvar)] <-
-      mlist$theta[lav_matrix_vech_idx(nvar)]
+    mlist$psi[lav_mat_vechru_idx(nfac)] <-
+      mlist$psi[lav_mat_vech_idx(nfac)]
+    mlist$theta[lav_mat_vechru_idx(nvar)] <-
+      mlist$theta[lav_mat_vech_idx(nvar)]
     if (delta) mlist$delta[, ] <- abs(mlist$delta) * 10
   } else {
     nvar <- nrow(mlist$lambda)
@@ -2462,20 +2462,20 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
   compute_sigma <- function(x, mm = "lambda", mlist = NULL) {
     mlist_1 <- mlist
     if (mm %in% c("psi", "theta")) {
-      mlist_1[[mm]] <- lav_matrix_vech_reverse(x)
+      mlist_1[[mm]] <- lav_mat_vech_rev(x)
     } else {
       mlist_1[[mm]][, ] <- x
     }
     if (theta) {
       mlist_1 <- lav_lisrel_delta(mlist = mlist_1, num_idx = num_idx)
     }
-    lav_matrix_vech(lav_lisrel_sigma(mlist_1))
+    lav_mat_vech(lav_lisrel_sigma(mlist_1))
   }
 
   compute_mu <- function(x, mm = "lambda", mlist = NULL) {
     mlist_1 <- mlist
     if (mm %in% c("psi", "theta")) {
-      mlist_1[[mm]] <- lav_matrix_vech_reverse(x)
+      mlist_1[[mm]] <- lav_mat_vech_rev(x)
     } else {
       mlist_1[[mm]][, ] <- x
     }
@@ -2488,7 +2488,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
   compute_th2 <- function(x, mm = "tau", mlist = NULL, th_idx) {
     mlist_1 <- mlist
     if (mm %in% c("psi", "theta")) {
-      mlist_1[[mm]] <- lav_matrix_vech_reverse(x)
+      mlist_1[[mm]] <- lav_mat_vech_rev(x)
     } else {
       mlist_1[[mm]][, ] <- x
     }
@@ -2501,7 +2501,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
   compute_pi <- function(x, mm = "lambda", mlist = NULL) {
     mlist_1 <- mlist
     if (mm %in% c("psi", "theta")) {
-      mlist_1[[mm]] <- lav_matrix_vech_reverse(x)
+      mlist_1[[mm]] <- lav_mat_vech_rev(x)
     } else {
       mlist_1[[mm]][, ] <- x
     }
@@ -2514,7 +2514,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
   compute_gw <- function(x, mm = "gw", mlist = NULL) {
     mlist_1 <- mlist
     if (mm %in% c("psi", "theta")) {
-      mlist_1[[mm]] <- lav_matrix_vech_reverse(x)
+      mlist_1[[mm]] <- lav_mat_vech_rev(x)
     } else {
       mlist_1[[mm]][, ] <- x
     }
@@ -2531,9 +2531,9 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
 
   for (mm in names(mlist)) {
     if (mm %in% c("psi", "theta")) {
-      x <- lav_matrix_vech(mlist[[mm]])
+      x <- lav_mat_vech(mlist[[mm]])
     } else {
-      x <- lav_matrix_vec(mlist[[mm]])
+      x <- lav_mat_vec(mlist[[mm]])
     }
     if (mm == "delta" && theta) next
     if (lav_debug()) {
@@ -2549,7 +2549,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
     )
     if (mm %in% c("psi", "theta")) {
       # remove duplicated columns of symmetric matrices
-      idx <- lav_matrix_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
+      idx <- lav_mat_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
       if (length(idx) > 0L) dx2 <- dx2[, -idx]
     }
     if (theta) {
@@ -2587,7 +2587,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
     )
     if (mm %in% c("psi", "theta")) {
       # remove duplicated columns of symmetric matrices
-      idx <- lav_matrix_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
+      idx <- lav_mat_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
       if (length(idx) > 0L) dx2 <- dx2[, -idx]
     }
     cat(
@@ -2621,8 +2621,8 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
             m = mm, idx = seq_along(mlist[[mm]]),
             mlist = mlist, delta = !theta
           )
-        var_idx <- which(!lav_matrix_vech_idx(nvar) %in%
-          lav_matrix_vech_idx(nvar, diagonal = FALSE))
+        var_idx <- which(!lav_mat_vech_idx(nvar) %in%
+          lav_mat_vech_idx(nvar, diagonal = FALSE))
         sigma_hat <- lav_lisrel_sigma(mlist = mlist, delta = FALSE)
         dsigma <- diag(sigma_hat)
         # dy/ddsigma = -0.5/(ddsigma*sqrt(ddsigma))
@@ -2645,7 +2645,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
       }
       if (mm %in% c("psi", "theta")) {
         # remove duplicated columns of symmetric matrices
-        idx <- lav_matrix_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
+        idx <- lav_mat_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
         if (length(idx) > 0L) dx2 <- dx2[, -idx]
       }
       cat(
@@ -2673,7 +2673,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
       )
       if (mm %in% c("psi", "theta")) {
         # remove duplicated columns of symmetric matrices
-        idx <- lav_matrix_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
+        idx <- lav_mat_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
         if (length(idx) > 0L) dx2 <- dx2[, -idx]
       }
       if (theta) {
@@ -2685,11 +2685,11 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
           )
         if (mm %in% c("psi", "theta")) {
           # remove duplicated columns of symmetric matrices
-          idx <- lav_matrix_vechru_idx(sqrt(ncol(dx_sigma)), diagonal = FALSE)
+          idx <- lav_mat_vechru_idx(sqrt(ncol(dx_sigma)), diagonal = FALSE)
           if (length(idx) > 0L) dx_sigma <- dx_sigma[, -idx]
         }
-        var_idx <- which(!lav_matrix_vech_idx(nvar) %in%
-          lav_matrix_vech_idx(nvar, diagonal = FALSE))
+        var_idx <- which(!lav_mat_vech_idx(nvar) %in%
+          lav_mat_vech_idx(nvar, diagonal = FALSE))
         sigma_hat <- lav_lisrel_sigma(mlist = mlist, delta = FALSE)
         dsigma <- diag(sigma_hat)
         # dy/ddsigma = -0.5/(ddsigma*sqrt(ddsigma))
@@ -2736,7 +2736,7 @@ lav_lisrel_test_derivatives <- function(mlist = NULL,
       )
       if (mm %in% c("psi", "theta")) {
         # remove duplicated columns of symmetric matrices
-        idx <- lav_matrix_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
+        idx <- lav_mat_vechru_idx(sqrt(ncol(dx2)), diagonal = FALSE)
         if (length(idx) > 0L) dx2 <- dx2[, -idx]
       }
       cat(
@@ -2803,7 +2803,7 @@ lav_mlist_target_psi <- function(mm_beta = NULL, ib_inv = NULL, mm_psi = NULL,
   # IB.inv (if not given)
   if (is.null(ib_inv)) {
     ib <- -mm_beta
-    ib[lav_matrix_diag_idx(nr)] <- 1
+    ib[lav_mat_diag_idx(nr)] <- 1
     ib_inv <- solve(ib)
   }
 
@@ -3081,9 +3081,9 @@ lav_lisrel_dimplied_dx <- function(mlist           = NULL,
 
 
   # vech structure for Sigma
-  r_s <- lav_matrix_vech_row_idx(nvar)
-  c_s <- lav_matrix_vech_col_idx(nvar)
-  sigma_lut <- lav_matrix_vech_reverse(seq_len(pstar))
+  r_s <- lav_mat_vech_row_idx(nvar)
+  c_s <- lav_mat_vech_col_idx(nvar)
+  sigma_lut <- lav_mat_vech_rev(seq_len(pstar))
 
   if (delta_flag) {
     # scaling weights: delta[r] * delta[s] for each vech position
@@ -3388,9 +3388,9 @@ lav_lisrel_dimplied_dx <- function(mlist           = NULL,
       s_diag[num_idx] <- 1.0
     }
     sigma_obs <- sigma_star / tcrossprod(s_diag)
-    sigma_obs_v <- lav_matrix_vech(sigma_obs)
+    sigma_obs_v <- lav_mat_vech(sigma_obs)
 
-    diag_pos <- lav_matrix_diagh_idx(nvar)
+    diag_pos <- lav_mat_diagh_idx(nvar)
     jac_diag_theta <- jac_sigma[diag_pos, , drop = FALSE]
 
     # If Delta itself is in the (compact) column block (e.g. the modindices
@@ -3422,8 +3422,8 @@ lav_lisrel_dimplied_dx <- function(mlist           = NULL,
   # categorical: reorder
   if (categorical) {
     # reorder: first variances (of numeric), then covariances
-    cov_idx <- lav_matrix_vech_idx(nvar)
-    covd_idx <- lav_matrix_vech_idx(nvar, diagonal = FALSE)
+    cov_idx <- lav_mat_vech_idx(nvar)
+    covd_idx <- lav_mat_vech_idx(nvar, diagonal = FALSE)
 
     var_idx <- which(is.na(match(
       cov_idx,
@@ -3439,7 +3439,7 @@ lav_lisrel_dimplied_dx <- function(mlist           = NULL,
 
   # correlation structure
   if (!categorical && correlation) {
-    rm_idx <- lav_matrix_diagh_idx(nvar)
+    rm_idx <- lav_mat_diagh_idx(nvar)
     jac_sigma <- jac_sigma[-rm_idx, , drop = FALSE]
   }
 

--- a/R/lav_representation_ram.R
+++ b/R/lav_representation_ram.R
@@ -36,7 +36,7 @@ lav_ram <- function(partable = NULL,
   # group_w_free <- any(partable$lhs == "group" & partable$op == "%")
 
   # number of blocks
-  nblocks <- lav_partable_nblocks(partable)
+  nblocks <- lav_pt_nblocks(partable)
 
   # always return ov.idx
   ov_idx <- vector("list", nblocks)
@@ -53,13 +53,13 @@ lav_ram <- function(partable = NULL,
 
   for (g in 1:nblocks) {
     # info from user model per block
-    ov_names <- lav_partable_vnames(partable, "ov", block = g)
+    ov_names <- lav_pt_vnames(partable, "ov", block = g)
     nvar <- length(ov_names)
     ov_idx[[g]] <- seq_len(nvar)
     ov_dummy_names_nox[[g]] <- character(0)
     ov_dummy_names_x[[g]] <- character(0)
 
-    lv_names <- lav_partable_vnames(partable, "lv", block = g)
+    lv_names <- lav_pt_vnames(partable, "lv", block = g)
     both_names <- c(ov_names, lv_names)
     nboth <- length(both_names)
 
@@ -201,7 +201,7 @@ lav_ram_sigmahat <- function(mlist = NULL, delta = NULL) {
   s <- mlist$S
 
   # get (I-A)^{-1}
-  ia_inv <- lav_matrix_inverse_iminus(a)
+  ia_inv <- lav_mat_inverse_iminus(a)
 
   # compute Sigma for all ov and lv
   vyeta <- tcrossprod(ia_inv %*% s, ia_inv)
@@ -226,7 +226,7 @@ lav_ram_veta <- function(mlist = NULL) {
   s <- mlist$S
 
   # get (I-A)^{-1}
-  ia_inv <- lav_matrix_inverse_iminus(a)
+  ia_inv <- lav_mat_inverse_iminus(a)
 
   # compute Sigma for all ov and lv
   vyeta <- tcrossprod(ia_inv %*% s, ia_inv)
@@ -249,7 +249,7 @@ lav_ram_muhat <- function(mlist = NULL) {
   }
 
   # get (I-A)^{-1}
-  ia_inv <- lav_matrix_inverse_iminus(a)
+  ia_inv <- lav_mat_inverse_iminus(a)
 
   # all means/intercepts
   eyeta <- ia_inv %*% m
@@ -279,7 +279,7 @@ lav_ram_dsigma <- function(m = "A",
   }
 
   # get (I-A)^{-1}
-  ia_inv <- lav_matrix_inverse_iminus(a)
+  ia_inv <- lav_mat_inverse_iminus(a)
 
   if (m == "A") {
     l1 <- (ia_inv %*% s %*% t(ia_inv))[ov_idx, , drop = FALSE]
@@ -288,13 +288,13 @@ lav_ram_dsigma <- function(m = "A",
       (ia_inv[ov_idx, , drop = FALSE] %x% l1)[, kol_idx, drop = FALSE]
     # this is not really needed (because we select idx=m.el.idx)
     # but just in case we need all elements of beta...
-    dx[, which(idx %in% lav_matrix_diag_idx(nboth))] <- 0.0
+    dx[, which(idx %in% lav_mat_diag_idx(nboth))] <- 0.0
   } else if (m == "S") {
     dx <- (ia_inv[ov_idx, , drop = FALSE] %x% ia_inv[ov_idx, , drop = FALSE])
     # symmetry correction, but keeping all duplicated elements
     # since we depend on idx=m.el.idx
-    lower_idx <- lav_matrix_vech_idx(nboth, diagonal = FALSE)
-    upper_idx <- lav_matrix_vechru_idx(nboth, diagonal = FALSE)
+    lower_idx <- lav_mat_vech_idx(nboth, diagonal = FALSE)
+    upper_idx <- lav_mat_vechru_idx(nboth, diagonal = FALSE)
     offdiag_sum <- dx[, lower_idx] + dx[, upper_idx]
     dx[, c(lower_idx, upper_idx)] <- cbind(offdiag_sum, offdiag_sum)
     dx <- dx[, idx, drop = FALSE]
@@ -304,7 +304,7 @@ lav_ram_dsigma <- function(m = "A",
 
   # vech?
   if (vech) {
-    v_idx <- lav_matrix_vech_idx(nvar)
+    v_idx <- lav_mat_vech_idx(nvar)
     dx <- dx[v_idx, , drop = FALSE]
   }
 
@@ -329,7 +329,7 @@ lav_ram_dmu <- function(m = "A",
   }
 
   # get (I-A)^{-1}
-  ia_inv <- lav_matrix_inverse_iminus(a)
+  ia_inv <- lav_mat_inverse_iminus(a)
 
   if (m == "A") {
     dx <- (t(ia_inv %*% mlist$m) %x% ia_inv)[ov_idx, idx, drop = FALSE]
@@ -352,7 +352,7 @@ lav_ram_df <- function(mlist = NULL, omega = NULL, omega_mu = NULL) {
   # nboth <- nrow(a)
 
   # get (I-A)^{-1}
-  ia_inv <- lav_matrix_inverse_iminus(a)
+  ia_inv <- lav_mat_inverse_iminus(a)
 
   # meanstructure?
   meanstructure <- FALSE
@@ -449,7 +449,7 @@ lav_ram_dimplied_dx <- function(mlist         = NULL,
   }
 
   # precompute
-  ia_inv <- lav_matrix_inverse_iminus(mlist$A)            # nboth x nboth
+  ia_inv <- lav_mat_inverse_iminus(mlist$A)            # nboth x nboth
   fobs   <- ia_inv[ov_idx, , drop = FALSE]                # nvar  x nboth
   m_w      <- ia_inv %*% mlist$S %*% t(fobs)                # nboth x nvar
   wt     <- t(m_w)                                          # nvar  x nboth
@@ -458,8 +458,8 @@ lav_ram_dimplied_dx <- function(mlist         = NULL,
   }
 
   # vech structure for Sigma
-  r_s <- lav_matrix_vech_row_idx(nvar)
-  c_s <- lav_matrix_vech_col_idx(nvar)
+  r_s <- lav_mat_vech_row_idx(nvar)
+  c_s <- lav_mat_vech_col_idx(nvar)
 
   # helper: vec index -> (row, col)
   vec2rc <- function(idx, nr) {

--- a/R/lav_residuals.R
+++ b/R/lav_residuals.R
@@ -106,7 +106,7 @@ lavResiduals <- function(object, type = "cor.bentler", custom.rmr = NULL,  # nol
   # no pretty printing yet...
   if (output == "table") {
     # new in 0.6-18: handle multiple blocks
-    nblocks <- lav_partable_nblocks(object@ParTable)
+    nblocks <- lav_pt_nblocks(object@ParTable)
     out_list <- vector("list", length = nblocks)
     for (block in seq_len(nblocks)) {
       if (nblocks == 1L) {
@@ -115,7 +115,7 @@ lavResiduals <- function(object, type = "cor.bentler", custom.rmr = NULL,  # nol
         res <- out[[block]]$cov
       }
       # extract only below-diagonal elements
-      res_vech <- lav_matrix_vech(res, diagonal = FALSE)
+      res_vech <- lav_mat_vech(res, diagonal = FALSE)
 
       # get names
       p <- nrow(res)
@@ -124,7 +124,7 @@ lavResiduals <- function(object, type = "cor.bentler", custom.rmr = NULL,  # nol
       nam <- expand.grid(
         names_1,
         names_1
-      )[lav_matrix_vech_idx(p, diagonal = FALSE), ]
+      )[lav_mat_vech_idx(p, diagonal = FALSE), ]
       names_vech <- paste(nam[, 1], "~~", nam[, 2], sep = "")
 
       # create table
@@ -277,12 +277,12 @@ lav_residuals <- function(object, type = "raw", h1 = TRUE, custom_rmr = NULL,
   }
 
   # observed and fitted sample statistics
-  obs_list <- lav_object_inspect_sampstat(object,
+  obs_list <- lav_inspect_sampstat(object,
     h1 = h1,
     add_labels = add_labels, add_class = add_class,
     drop_list_single_group = FALSE
   )
-  est_list <- lav_object_inspect_implied(object,
+  est_list <- lav_inspect_implied(object,
     add_labels = add_labels, add_class = add_class,
     drop_list_single_group = FALSE
   )
@@ -501,7 +501,7 @@ lav_residuals_acov <- function(object, type = "raw", z_type = "standardized",
     return(acov_res)
   } else {
     if (z_type == "standardized") {
-      a1 <- lav_model_h1_information(object)
+      a1 <- lav_model_h1_info(object)
       if (lavmodel@estimator == "DWLS" || lavmodel@estimator == "ULS") {
         # A1 is diagonal matrix
         a1 <- lapply(a1, diag)
@@ -537,7 +537,7 @@ lav_residuals_acov <- function(object, type = "raw", z_type = "standardized",
       #               (only needed if information is observed)
       this_options <- object@Options
       this_options$observed.information[1] <- "h1"
-      a0_g_inv <- lav_model_information(
+      a0_g_inv <- lav_model_info(
         lavmodel = lavmodel,
         lavsamplestats = object@SampleStats,
         lavdata = lavdata,
@@ -575,10 +575,10 @@ lav_residuals_acov <- function(object, type = "raw", z_type = "standardized",
             sampstat[[g]][["cov"]]
           }
           ss <- 1 / sqrt(diag(cov_1))
-          tmp <- lav_matrix_vech(tcrossprod(ss))
+          tmp <- lav_mat_vech(tcrossprod(ss))
           g_inv_sqrt <- diag(tmp, nrow = length(tmp))
           if (lavmodel@meanstructure) {
-            gg <- lav_matrix_bdiag(
+            gg <- lav_mat_bdiag(
               diag(ss, nrow = length(ss)),
               g_inv_sqrt
             )
@@ -607,7 +607,7 @@ lav_residuals_acov <- function(object, type = "raw", z_type = "standardized",
           f1 <- lav_deriv_cov2cor_b(cov_1)
           if (lavmodel@meanstructure) {
             ss <- 1 / sqrt(diag(cov_1))
-            ff <- lav_matrix_bdiag(diag(ss, nrow = length(ss)), f1)
+            ff <- lav_mat_bdiag(diag(ss, nrow = length(ss)), f1)
           } else {
             ff <- f1
           }
@@ -664,7 +664,7 @@ lav_residuals_se <- function(object, type = "raw", z_type = "standardized",
       # COR
       nth <- length(lavmodel@th.idx[[g]])
       tmp <- sqrt(diag_acov[-(1:nth)])
-      cov_se <- lav_matrix_vech_reverse(tmp, diagonal = FALSE)
+      cov_se <- lav_mat_vech_rev(tmp, diagonal = FALSE)
 
       # MEAN
       mean_se <- rep(as.numeric(NA), nvar)
@@ -694,7 +694,7 @@ lav_residuals_se <- function(object, type = "raw", z_type = "standardized",
       } else {
         if (lavmodel@meanstructure) {
           tmp <- sqrt(diag_acov[-(1:nvar)])
-          cov_se <- lav_matrix_vech_reverse(tmp)
+          cov_se <- lav_mat_vech_rev(tmp)
           mean_se <- sqrt(diag_acov[1:nvar])
           if (add_class) {
             class(cov_se) <- c("lavaan.matrix.symmetric", "matrix")
@@ -706,7 +706,7 @@ lav_residuals_se <- function(object, type = "raw", z_type = "standardized",
           }
           se_list[[g]] <- list(cov.se = cov_se, mean.se = mean_se)
         } else {
-          cov_se <- lav_matrix_vech_reverse(sqrt(diag_acov))
+          cov_se <- lav_mat_vech_rev(sqrt(diag_acov))
           if (add_class) {
             class(cov_se) <- c("lavaan.matrix.symmetric", "matrix")
           }
@@ -890,11 +890,11 @@ lav_residuals_summary <- function(object, type = c("rmr", "srmr", "crmr"),
           # COR
           nth <- length(lavmodel@th.idx[[g]])
           if (conditional_x) {
-            stats <- lav_matrix_vech(rms_list_g[["res.cov"]],
+            stats <- lav_mat_vech(rms_list_g[["res.cov"]],
               diagonal = FALSE
             )
           } else {
-            stats <- lav_matrix_vech(rms_list_g[["cov"]],
+            stats <- lav_mat_vech(rms_list_g[["cov"]],
               diagonal = FALSE
             )
           }
@@ -995,14 +995,14 @@ lav_residuals_summary <- function(object, type = c("rmr", "srmr", "crmr"),
           # TOTAL -- FIXME: for conditional.x ....
           if (conditional_x) {
             stats <- c(
-              lav_matrix_vech(rms_list_g[["res.cov"]],
+              lav_mat_vech(rms_list_g[["res.cov"]],
                 diagonal = FALSE
               ),
               rms_list_g[["res.th"]]
             )
           } else {
             stats <- c(
-              lav_matrix_vech(rms_list_g[["cov"]],
+              lav_mat_vech(rms_list_g[["cov"]],
                 diagonal = FALSE
               ),
               rms_list_g[["th"]]
@@ -1090,9 +1090,9 @@ lav_residuals_summary <- function(object, type = c("rmr", "srmr", "crmr"),
 
           # COV
           if (conditional_x) {
-            stats <- lav_matrix_vech(rms_list_g[["res.cov"]])
+            stats <- lav_mat_vech(rms_list_g[["res.cov"]])
           } else {
-            stats <- lav_matrix_vech(rms_list_g[["cov"]])
+            stats <- lav_mat_vech(rms_list_g[["cov"]])
           }
           # pstar <- ( length(STATS) - pstar.x )
           pstar <- length(stats)
@@ -1163,12 +1163,12 @@ lav_residuals_summary <- function(object, type = c("rmr", "srmr", "crmr"),
             if (conditional_x) {
               stats <- c(
                 rms_list_g[["res.int"]],
-                lav_matrix_vech(rms_list_g[["res.cov"]])
+                lav_mat_vech(rms_list_g[["res.cov"]])
               )
             } else {
               stats <- c(
                 rms_list_g[["mean"]],
-                lav_matrix_vech(rms_list_g[["cov"]])
+                lav_mat_vech(rms_list_g[["cov"]])
               )
             }
             # pstar <- ( length(STATS) - ( pstar.x + nvar.x) )
@@ -1299,11 +1299,11 @@ lav_residuals_summary <- function(object, type = c("rmr", "srmr", "crmr"),
                 ## diagonal relevant?
                 if (type[typ] == "crmr") diag(custom_rmr[[cus]]$cov) <- FALSE
                 ## extract lower.tri indices
-                vech_idx <- which(lav_matrix_vech(custom_rmr[[cus]]$cov))
+                vech_idx <- which(lav_mat_vech(custom_rmr[[cus]]$cov))
 
                 ## add residuals to STATS, indices to ACOV.idx
                 stats <- c(stats,
-                         lav_matrix_vech(rms_list_g[["cov"]])[vech_idx])
+                         lav_mat_vech(rms_list_g[["cov"]])[vech_idx])
                 acov_idx <- c(acov_idx, vech_idx)
               }
 
@@ -1515,10 +1515,10 @@ lav_residuals_summary_old <- function(res_list = NULL,
         }
         x <- c(x, new_x)
       } else if (is.matrix(el_1) && isSymmetric(el_1)) {
-        tmp <- na.omit(lav_matrix_vech(el_1))
+        tmp <- na.omit(lav_mat_vech(el_1))
         rms <- sqrt(sum(tmp * tmp) / length(tmp))
         mabs <- mean(abs(tmp))
-        tmp2 <- na.omit(lav_matrix_vech(el_1, diagonal = FALSE))
+        tmp2 <- na.omit(lav_mat_vech(el_1, diagonal = FALSE))
         rms_nodiag <- sqrt(sum(tmp2 * tmp2) / length(tmp2))
         mabs_nodiag <- mean(abs(tmp2))
         cov_summary <- c(rms, rms_nodiag, mabs, mabs_nodiag)

--- a/R/lav_sam_step1.R
+++ b/R/lav_sam_step1.R
@@ -142,7 +142,7 @@ lav_sam_step1 <- function(cmd = "sem", mm_list = NULL, mm_args = list(),
   if (!lavoptions$se %in% c("none", "bootstrap")) {
     sigma_11_1 <- matrix(0, npar, npar)
     colnames(sigma_11_1) <- rownames(sigma_11_1) <-
-      lav_partable_labels(fit@ParTable, type = "free")
+      lav_pt_labels(fit@ParTable, type = "free")
   }
   step1_free_idx <- integer(0L)
   block_mm_idx  <- vector("list", length = n_mmblocks)
@@ -166,7 +166,7 @@ lav_sam_step1 <- function(cmd = "sem", mm_list = NULL, mm_args = list(),
     }
 
     # create parameter table for this measurement block only
-    ptm <- lav_partable_subset_measurement_model(
+    ptm <- lav_pt_subset_measurement_model(
       pt_1 = pt_1,
       add_lv_cov = add_lv_cov,
       add_idx = TRUE,
@@ -186,7 +186,7 @@ lav_sam_step1 <- function(cmd = "sem", mm_list = NULL, mm_args = list(),
 
     # update slotData for this measurement block
     ov_names_block <- lapply(1:ngroups, function(g) {
-      unique(unlist(lav_partable_vnames(ptm, type = "ov", group = g)))
+      unique(unlist(lav_pt_vnames(ptm, type = "ov", group = g)))
     })
     slot_data_block <- lav_data_update_subset(fit@Data,
       ov_names = ov_names_block
@@ -278,7 +278,7 @@ lav_sam_step1 <- function(cmd = "sem", mm_list = NULL, mm_args = list(),
     # fill in point estimates measurement block (including slack values)
     ptm <- mm_fit[[mm]]@ParTable
     # pt.idx: the row-numbers in PT that correspond to the rows in PTM
-    # pt.idx <- lav_partable_map_id_p1_in_p2(p1 = PTM, p2 = PT,
+    # pt.idx <- lav_pt_map_id_p1_in_p2(p1 = PTM, p2 = PT,
     #             stopifnotfound = TRUE, exclude.nonpar = FALSE)
     # pt.idx == mm.idx
     ptm_idx <- which((ptm$free > 0L | ptm$op %in% c(":=", "<", ">")) &

--- a/R/lav_sam_step1_local.R
+++ b/R/lav_sam_step1_local.R
@@ -166,19 +166,19 @@ lav_sam_step1_local <- function(step1 = NULL, fit = NULL, y = NULL,
 
     # if lambda has full rank, check if cov.lv is unrestricted
     if (!lsam_analytic_flag[b]) {
-      veta_symbolic_1 <- lav_sam_veta_partable(fit, block = b)
+      veta_symbolic_1 <- lav_sam_veta_pt(fit, block = b)
       # this is the tricky thing: which rows/cols should we remove?
       # none for now
       if (fit@Options$std.lv) {
-        veta_symbolic <- lav_matrix_vech(veta_symbolic_1, diagonal = FALSE)
+        veta_symbolic <- lav_mat_vech(veta_symbolic_1, diagonal = FALSE)
       } else {
-        veta_symbolic <- lav_matrix_vech(veta_symbolic_1, diagonal = TRUE)
+        veta_symbolic <- lav_mat_vech(veta_symbolic_1, diagonal = TRUE)
       }
       if (any(veta_symbolic == 0)) {
         lsam_analytic_flag[b] <- FALSE
         nfac <- ncol(veta_symbolic_1)
         m_free <- which(veta_symbolic_1 != 0)
-        tmp <- lav_matrix_vech_reverse(lav_matrix_vech_idx(nfac))
+        tmp <- lav_mat_vech_rev(lav_mat_vech_idx(nfac))
         x_free <- tmp[which(veta_symbolic_1 != 0)]
         unique_idx <- unique(x_free)
         row_idx <- match(x_free, unique_idx)
@@ -313,7 +313,7 @@ lav_sam_step1_local <- function(step1 = NULL, fit = NULL, y = NULL,
       this_lambda <- this_lambda[, -lavpta$vidx$lv.interaction[[b]]]
     }
     if (lsam_analytic_flag[b]) {
-      mb <- lav_sam_mapping_matrix(
+      mb <- lav_sam_mapping_mat(
         mm_lambda = this_lambda,
         mm_theta = mm_theta[[b]],
         s = cov_1, s_inv = icov,
@@ -342,9 +342,9 @@ lav_sam_step1_local <- function(step1 = NULL, fit = NULL, y = NULL,
     # if (FIT@Model@conditional.x) {
     #   I0 <- diag(x = 0, nrow = length(exo.names))
     #   I1 <- diag(x = 1, nrow = length(exo.names))
-    #   Mb <- lav_matrix_bdiag(Mb, I1)
-    #   LAMBDA[[b]] <- lav_matrix_bdiag(LAMBDA[[b]], I1)
-    #   THETA[[b]] <- lav_matrix_bdiag(THETA[[b]], I0)
+    #   Mb <- lav_mat_bdiag(Mb, I1)
+    #   LAMBDA[[b]] <- lav_mat_bdiag(LAMBDA[[b]], I1)
+    #   THETA[[b]] <- lav_mat_bdiag(THETA[[b]], I0)
     #   NU[[b]] <- c(drop(NU[[b]]), numeric(length(exo.names)))
     # }
 
@@ -646,7 +646,7 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
     mm_ov_idx <- match(step1$MM.FIT[[mm]]@Data@ov.names[[g]],
                        lavdata@ov.names[[g]])
     mm_nvar <- length(lavdata@ov.names[[g]])
-    mm_col_idx <- lav_matrix_vech_which_idx(mm_nvar, idx = mm_ov_idx,
+    mm_col_idx <- lav_mat_vech_which_idx(mm_nvar, idx = mm_ov_idx,
       add_idx_at_start = lavmodel@meanstructure)
     mm_row_idx <- step1$block.mm.idx[[mm]][step1$block.ptm.idx[[mm]]]
     jaca[mm_row_idx, mm_col_idx] <- mm_jac
@@ -695,10 +695,10 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
       if (lavmodel@meanstructure) {
         nvar <- nrow(fit@h1$implied$cov[[g]])
         this_ybar <- x[seq_len(nvar)]
-        this_cov <- lav_matrix_vech_reverse(x[-seq_len(nvar)])
+        this_cov <- lav_mat_vech_rev(x[-seq_len(nvar)])
       } else {
         this_ybar <- fit@h1$implied$mean[[g]]
-        this_cov <- lav_matrix_vech_reverse(x)
+        this_cov <- lav_mat_vech_rev(x)
       }
 
       # change COV/YBAR
@@ -711,23 +711,23 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
       # transform data to comply with the new COV/YBAR
       y <- fit@Data@X[[1]]
       ytrans <- vector("list", nblocks)
-      ytrans[[1]] <- lav_matrix_transform_mean_cov(y, target_mean = this_ybar,
+      ytrans[[1]] <- lav_mat_transform_mean_cov(y, target_mean = this_ybar,
                                                    target_cov = this_cov)
       colnames(ytrans[[1]]) <- fit@pta$vnames$ov[[1]]
 
       step1_1 <- lav_sam_step1_local(step1 = step1_1, fit = fit, y = ytrans,
            sam_method = step1$sam.method, local_options = step1$local.options)
       if (lavmodel@meanstructure) {
-        out <- c(step1_1$EETA[[1]], lav_matrix_vech(step1_1$VETA[[1]]))
+        out <- c(step1_1$EETA[[1]], lav_mat_vech(step1_1$VETA[[1]]))
       } else {
-        out <- lav_matrix_vech(step1_1$VETA[[1]])
+        out <- lav_mat_vech(step1_1$VETA[[1]])
       }
       out
     }
     # shut off verbose
     verbose_flag <- lav_verbose()
     lav_verbose(FALSE)
-    this_x <- lav_matrix_vech(fit@h1$implied$cov[[g]])
+    this_x <- lav_mat_vech(fit@h1$implied$cov[[g]])
     if (lavmodel@meanstructure) {
       this_x <- c(fit@h1$implied$mean[[g]], this_x)
     }
@@ -751,16 +751,16 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
     #   tmp <- lav_sam_step1_local_jac_mean2(ybar = STEP1$YBAR[[g]],
     #     M = STEP1$M[[g]], NU = STEP1$NU[[g]])
     #   dd
-    #   JACb <- lav_matrix_bdiag(tmp, JACb)
+    #   JACb <- lav_mat_bdiag(tmp, JACb)
     # }
 
   } else { # no latent interactions
     mb <- step1$M[[g]]
     mbx_mb <- mb %x% mb
-    row_idx <- lav_matrix_vech_idx(nrow(mb))
-    jacb <- lav_matrix_duplication_post(mbx_mb)[row_idx, , drop = FALSE]
+    row_idx <- lav_mat_vech_idx(nrow(mb))
+    jacb <- lav_mat_dup_post(mbx_mb)[row_idx, , drop = FALSE]
     if (lavmodel@meanstructure) {
-      jacb <- lav_matrix_bdiag(mb, jacb)
+      jacb <- lav_mat_bdiag(mb, jacb)
     }
   }
 
@@ -777,7 +777,7 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
   #   theta.idx  <- which(names(this.model@GLIST) ==  "theta")[b]
   #   LAMBDA <- this.model@GLIST[[lambda.idx]]
   #   THETA  <- this.model@GLIST[[ theta.idx]]
-  #   Mb <- lav_sam_mapping_matrix(LAMBDA = LAMBDA,
+  #   Mb <- lav_sam_mapping_mat(LAMBDA = LAMBDA,
   #                                THETA = THETA, S = COV,
   #                                method = local.options$M.method)
   #   # handle observed-only variables
@@ -801,9 +801,9 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
   #     nu.idx <- which(names(this.model@GLIST) ==  "nu")[b]
   #     NU <- this.model@GLIST[[nu.idx]]
   #     EETA <- lav_sam_eeta(M = Mb, YBAR = YBAR, NU = NU)
-  #     out <- c(EETA, lav_matrix_vech(VETA))
+  #     out <- c(EETA, lav_mat_vech(VETA))
   #   } else {
-  #     out <- lav_matrix_vech(VETA)
+  #     out <- lav_mat_vech(VETA)
   #   }
 
   #   out
@@ -828,9 +828,9 @@ lav_sam_step1_local_jac <- function(step1 = NULL, fit = NULL, p_only = FALSE,
     step1_1 <- lav_sam_step1_local(step1 = step1_1, fit = fit,
            sam_method = step1$sam.method, local_options = step1$local.options)
     if (lavmodel@meanstructure) {
-      out <- c(step1_1$EETA[[1]], lav_matrix_vech(step1_1$VETA[[1]]))
+      out <- c(step1_1$EETA[[1]], lav_mat_vech(step1_1$VETA[[1]]))
     } else {
-      out <- lav_matrix_vech(step1_1$VETA[[1]])
+      out <- lav_mat_vech(step1_1$VETA[[1]])
     }
     out
   }
@@ -883,9 +883,9 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
   idx1 <- rep(seq_len(nfac), each = nfac)
   idx2 <- rep(seq_len(nfac), times = nfac)
 
-  # k_nfac <- lav_matrix_commutation(nfac, nfac)
+  # k_nfac <- lav_mat_com(nfac, nfac)
   # ik <- diag(nfac * nfac) + k_nfac
-  m_d <- lav_matrix_duplication(nfac)
+  m_d <- lav_mat_dup(nfac)
 
   names_1 <- paste(lv_names[idx1], lv_names[idx2], sep = ":")
   names_1[seq_len(nfac)] <- lv_names
@@ -899,9 +899,9 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
 
   this_nu <- step1$NU[[1]]
   this_m  <- step1$M[[1]]
-  this_mtm <- lav_matrix_bdiag(0,
+  this_mtm <- lav_mat_bdiag(0,
                   step1$MTM[[1]][seq_len(nfac - 1), seq_len(nfac - 1)])
-  this <- c(this_nu, lav_matrix_vec(this_m), lav_matrix_vech(this_mtm))
+  this <- c(this_nu, lav_mat_vec(this_m), lav_mat_vech(this_mtm))
   index <- matrix(seq_len(nfac^2 * nfac^2), nfac^2, nfac^2)
 
   x2this <- function(x) {
@@ -914,14 +914,14 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
     # no interaction columns!
     this_lambda <- this_lavmodel@GLIST$lambda[, -rm_idx, drop = FALSE]
     this_theta  <- this_lavmodel@GLIST$theta
-    this_m <- lav_sam_mapping_matrix(mm_lambda = this_lambda,
+    this_m <- lav_sam_mapping_mat(mm_lambda = this_lambda,
                                      mm_theta = this_theta,
                                      s = step1$COV[[1]],
                                      method = step1$local.options$M.method)
     mtm <- this_m %*% this_theta %*% t(this_m)
-    mtm <- lav_matrix_bdiag(0, mtm)
+    mtm <- lav_mat_bdiag(0, mtm)
 
-    out <- c(this_nu, lav_matrix_vec(this_m), lav_matrix_vech(mtm))
+    out <- c(this_nu, lav_mat_vec(this_m), lav_mat_vech(mtm))
     out
   }
   jac_x2this <- numDeriv::jacobian(func = x2this, x = x_step1)
@@ -946,30 +946,30 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
     # (tcrossprod(fi) - MTM) %x% MTM) -- part A
     block_a <- fi %x% do.call("rbind",
             lapply(seq_len(p), function(i) diag(p) %x% mtm[, i]))
-    long_a <- diag(p) %x% lav_matrix_vec(fi %x% mtm)
+    long_a <- diag(p) %x% lav_mat_vec(fi %x% mtm)
     big_a <- block_a + long_a
-    part_a <- big_a[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_a <- big_a[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
     # (MTM %x% (tcrossprod(fi) - MTM)) -- part B
-    block_b <- lav_matrix_vec(fi %x% mtm) %x% diag(p)
+    block_b <- lav_mat_vec(fi %x% mtm) %x% diag(p)
     long_b <- do.call("rbind",
             lapply(seq_len(p), function(i) diag(p) %x% mtm[, i])) %x% fi
     big_b <- block_b + long_b
-    part_b <- big_b[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_b <- big_b[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
-    # lav_matrix_commutation_post((tcrossprod(fi) - MTM) %x% MTM) -- part C
+    # lav_mat_com_post((tcrossprod(fi) - MTM) %x% MTM) -- part C
     block_c <- do.call("rbind",
             lapply(seq_len(p), function(i) fi %x% (diag(p) %x% mtm[, i])))
     long_c  <- do.call("rbind",
             lapply(seq_len(p), function(i) diag(p) %x% (fi %x% mtm[, i])))
     big_c <- block_c + long_c
-    part_c <- big_c[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_c <- big_c[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
-    # lav_matrix_commutation_pre((tcrossprod(fi) - MTM) %x% MTM) -- part m_d
-    long_d <- diag(p) %x% lav_matrix_vec(mtm %x% fi)
-    block_d <- (fi %x% lav_matrix_vec(mtm)) %x% diag(p)
+    # lav_mat_com_pre((tcrossprod(fi) - MTM) %x% MTM) -- part m_d
+    long_d <- diag(p) %x% lav_mat_vec(mtm %x% fi)
+    block_d <- (fi %x% lav_mat_vec(mtm)) %x% diag(p)
     big_d <- block_d + long_d
-    part_d <- big_d[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_d <- big_d[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
     # t1 (tcrossprod(fi2[keep.idx] - FS.mean) only) -- part E
     idx1 <- rep(seq_len(p), each = p)
@@ -980,7 +980,7 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
     fi <- as.matrix(fi)
     tt <- ((fi %x% diag(p))[keep_idx, ] + (diag(p) %x% fi)[keep_idx, ])
     tmp <- ((fik - fs_mean) %x% tt) + (tt %x% (fik - fs_mean))
-    part_e <- tmp[lav_matrix_vech_idx(length(fik)), ]
+    part_e <- tmp[lav_mat_vech_idx(length(fik)), ]
 
     final <- part_e - lambda_star * (part_a + part_b + part_c + part_d)
     final
@@ -995,7 +995,7 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
     x <- x[-seq_len(nvar)]
     # this_m  <- matrix(x[seq_len(nvar * nfac)], nrow = nfac, ncol = nvar)
     x <- x[-seq_len(nvar * nfac)]
-    mtm <- lav_matrix_vech_reverse(x)
+    mtm <- lav_mat_vech_rev(x)
     fi <- as.matrix(fi)
     p <- nrow(fi)
 
@@ -1008,7 +1008,7 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
                         })) %x% diag(p)
     big_a_vec <- long_a + block_a
     big_a <- big_a_vec %*% m_d
-    part_a <- big_a[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_a <- big_a[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
     # part b: (MTM %x% (tcrossprod(fi) - MTM))
     block_b <- do.call("rbind",
@@ -1019,9 +1019,9 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
                         }))
     big_b_vec <- block_b + long_b
     big_b <- big_b_vec %*% m_d
-    part_b <- big_b[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_b <- big_b[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
-    # part c: lav_matrix_commutation_post((tcrossprod(fi) - MTM) %x% MTM)
+    # part c: lav_mat_com_post((tcrossprod(fi) - MTM) %x% MTM)
     block_c <- diag(p) %x% do.call("rbind",
            lapply(seq_len(p),
                        function(i) ((tcrossprod(fi) - mtm)[, i]) %x% diag(p)))
@@ -1029,9 +1029,9 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
            lapply(seq_len(p), function(i) diag(p * p) %x% (-mtm[, i])))
     big_c_vec <- block_c + long_c
     big_c <- big_c_vec %*% m_d
-    part_c <- big_c[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_c <- big_c[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
-    # part d: lav_matrix_commutation_pre((tcrossprod(fi) - MTM) %x% MTM)
+    # part d: lav_mat_com_pre((tcrossprod(fi) - MTM) %x% MTM)
     block_d <- diag(p) %x% do.call("rbind",
                   lapply(seq_len(p), function(i) -mtm[, i] %x% diag(p)))
     long_d <- do.call("rbind",
@@ -1039,10 +1039,10 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
                      function(i) diag(p * p) %x% ((tcrossprod(fi) - mtm)[, i])))
     big_d_vec <- block_d + long_d
     big_d <- big_d_vec %*% m_d
-    part_d <- big_d[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_d <- big_d[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
     # part e: (IK %*% (MTM %x% MTM))
-    m_k <- lav_matrix_commutation(p, p)
+    m_k <- lav_mat_com(p, p)
     e1 <- diag(p) %x% do.call("rbind",
             lapply(seq_len(p), function(i) diag(p) %x% mtm[, i]))
     e2 <- do.call("rbind",
@@ -1053,14 +1053,14 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
             lapply(seq_len(p), function(i) m_k %*% (diag(p) %x% mtm[, i])))
     big_e_vec <- e1 + e2 + e3 + e4
     big_e <- big_e_vec %*% m_d
-    part_e <-  big_e[lav_matrix_vech(index[keep_idx, keep_idx]), ]
+    part_e <-  big_e[lav_mat_vech(index[keep_idx, keep_idx]), ]
 
     final <- -1 * lambda_star * (part_a + part_b + part_c + part_d + part_e)
     final
                 }
 
   n_eeta_veta <- length(step1$EETA[[1]]) +
-                 length(lav_matrix_vech(step1$VETA[[1]]))
+                 length(lav_mat_vech(step1$VETA[[1]]))
   cveta <- matrix(0, nrow = n_eeta_veta, ncol = length(x_step1))
   for (i in 1:n) {
     # experimental: remove fs outliers
@@ -1076,7 +1076,7 @@ lav_sam_gamma_add <- function(step1 = NULL, fit = NULL, group = 1L) {
                            t(as.matrix(y[i, ] - drop(this_nu))) %x%
                                                          diag(nrow(this_m)),
                            matrix(0, nrow = nrow(this_m),
-                                  ncol = length(lav_matrix_vech(this_mtm)))))
+                                  ncol = length(lav_mat_vech(this_mtm)))))
 
     jac_eeta2_fi_i <- ((fi %x% diag(nfac)) + (diag(nfac) %x% fi))[keep_idx, ]
     eeta2 <- ((jac_eeta2_fi_i %*% jac_this2fi_i) +

--- a/R/lav_sam_step2.R
+++ b/R/lav_sam_step2.R
@@ -61,7 +61,7 @@ lav_sam_step2 <- function(step1 = NULL, fit = NULL,
   # construct PTS
   if (sam_method %in% c("local", "fsr", "cfsr")) {
     # extract structural part
-    pts <- lav_partable_subset_structural_model(pt_1,
+    pts <- lav_pt_subset_structural_model(pt_1,
       add_idx = TRUE,
       add_exo_cov = TRUE,
       fixed_x = lavoptions_pa$fixed.x,
@@ -115,7 +115,7 @@ lav_sam_step2 <- function(step1 = NULL, fit = NULL,
     # the measurement model parameters now become fixed ustart values
     pt_1$ustart[pt_1$free > 0] <- pt_1$est[pt_1$free > 0]
 
-    reg_idx <- lav_partable_subset_structural_model(
+    reg_idx <- lav_pt_subset_structural_model(
       pt_1 = pt_1,
       idx_only = TRUE
     )
@@ -164,7 +164,7 @@ lav_sam_step2 <- function(step1 = NULL, fit = NULL,
     # set 'ustart' values for free FIT.PA parameter to NA
     pts$ustart[pts$free > 0L] <- as.numeric(NA)
 
-    pts <- lav_partable_complete(pts)
+    pts <- lav_pt_complete(pts)
 
     extra_id <- integer(0L)
   } # global
@@ -211,7 +211,7 @@ lav_sam_step2 <- function(step1 = NULL, fit = NULL,
 
   # find corresponding rows in PT
   pts2 <- as.data.frame(pts, stringsAsFactors = FALSE)
-  pt_idx <- lav_partable_map_id_p1_in_p2(pts2[pts_idx, ], pt_1,
+  pt_idx <- lav_pt_map_id_p1_in_p2(pts2[pts_idx, ], pt_1,
     exclude_nonpar = FALSE
   )
   # fill in

--- a/R/lav_sam_step2_se.R
+++ b/R/lav_sam_step2_se.R
@@ -85,7 +85,7 @@ lav_sam_step2_se <- function(fit = NULL, joint = NULL,
   # Fix for EFA/ESEM: when rotation is used, FIT.PA@Model@con.jac includes
   # columns for rotation identification constraints that are not part of
   # step2.free.idx. These extra columns cause dimension mismatch in
-  # lav_model_information_augment_invert(). Remove them via rm.idx.
+  # lav_model_info_augment_invert(). Remove them via rm.idx.
   if (nrow(fit_pa@Model@con.jac) > 0L) {
     n_jac_cols <- ncol(fit_pa@Model@con.jac)
     n_step2 <- length(step2_free_idx)
@@ -98,7 +98,7 @@ lav_sam_step2_se <- function(fit = NULL, joint = NULL,
   # new in 0.6-16 (otherwise, eq constraints in struc part are ignored)
   if (lavoptions$se %in% c("standard", "twostep", "twostep.robust")) {
     i_22_inv <-
-      lav_model_information_augment_invert(
+      lav_model_info_augment_invert(
         lavmodel = fit_pa@Model,
         information = i_22,
         inverted = TRUE,

--- a/R/lav_sam_utils.R
+++ b/R/lav_sam_utils.R
@@ -5,7 +5,7 @@
 # optionally return MTM (for ML)
 #
 # by construction, M %*% LAMBDA = I (the identity matrix)
-lav_sam_mapping_matrix <- function(mm_lambda = NULL, mm_theta = NULL,
+lav_sam_mapping_mat <- function(mm_lambda = NULL, mm_theta = NULL,
                                    s = NULL, s_inv = NULL,
                                    method = "ML") {
 
@@ -42,7 +42,7 @@ lav_sam_mapping_matrix <- function(mm_lambda = NULL, mm_theta = NULL,
     }
     if (inherits(s_inv, "try-error")) {
       lav_msg_warn(gettext("S is not invertible; switching to ULS method"))
-      m <- lav_sam_mapping_matrix(mm_lambda = mm_lambda, method = "ULS")
+      m <- lav_sam_mapping_mat(mm_lambda = mm_lambda, method = "ULS")
     } else {
       t_lsinv <- t(mm_lambda) %*% s_inv
       t_lsinv_l <- t_lsinv %*% mm_lambda
@@ -77,7 +77,7 @@ lav_sam_mapping_matrix <- function(mm_lambda = NULL, mm_theta = NULL,
     zero_theta_idx <- which(abs(diag(mm_theta)) < 1e-4) # be conservative
     if (length(zero_theta_idx) == 0L) {
       # ok, no zero diagonal elements: try to invert THETA
-      if (lav_matrix_is_diagonal(mm_theta)) {
+      if (lav_mat_is_diagonal(mm_theta)) {
         theta_inv <- diag(1 / diag(mm_theta), nrow = nrow(mm_theta))
       } else {
         theta_inv <- try(solve(mm_theta), silent = TRUE)
@@ -89,7 +89,7 @@ lav_sam_mapping_matrix <- function(mm_lambda = NULL, mm_theta = NULL,
       # see if we can use marker method
       marker_idx <- lav_utils_get_marker(mm_lambda = mm_lambda, std_lv = TRUE)
       if (any(is.na(marker_idx))) {
-        theta_inv <- try(lav_matrix_symmetric_inverse(mm_theta), silent = TRUE)
+        theta_inv <- try(lav_mat_sym_inverse(mm_theta), silent = TRUE)
         if (inherits(theta_inv, "try-error")) {
           theta_inv <- NULL
         } else {
@@ -110,18 +110,18 @@ lav_sam_mapping_matrix <- function(mm_lambda = NULL, mm_theta = NULL,
       if (inherits(m, "try-error")) {
         lav_msg_warn(gettext(
           "problem constructing ML mapping matrix; switching to ULS"))
-        m <- lav_sam_mapping_matrix(mm_lambda = mm_lambda, method = "ULS")
+        m <- lav_sam_mapping_mat(mm_lambda = mm_lambda, method = "ULS")
       }
     } else {
       # use W&A2000's method using the 'T' transformation
-      m <- try(lav_sam_mapping_matrix_tmat(
+      m <- try(lav_sam_mapping_mat_tmat(
         mm_lambda = mm_lambda,
         mm_theta = mm_theta
       ), silent = TRUE)
       if (inherits(m, "try-error")) {
         lav_msg_warn(gettext(
           "problem constructing ML mapping matrix; switching to ULS"))
-        m <- lav_sam_mapping_matrix(mm_lambda = mm_lambda, method = "ULS")
+        m <- lav_sam_mapping_mat(mm_lambda = mm_lambda, method = "ULS")
       }
     }
   } # ML
@@ -148,7 +148,7 @@ lav_sam_mapping_matrix <- function(mm_lambda = NULL, mm_theta = NULL,
 # - if std.lv = TRUE, we first rescale to 'create' marker indicators
 #   and then rescale back at the end
 #
-lav_sam_mapping_matrix_tmat <- function(mm_lambda = NULL,
+lav_sam_mapping_mat_tmat <- function(mm_lambda = NULL,
                                         mm_theta = NULL,
                                         marker_idx = NULL,
                                         std_lv = NULL) {
@@ -293,7 +293,7 @@ lav_sam_veta <- function(m = NULL, s = NULL, mm_theta = NULL,
   empty_theta_idx <- which(diag(mtm) == 0)
 
   # new in 0.6-16: make sure MTM is pd
-  # (otherwise lav_matrix_symmetric_diff_smallest_root will fail)
+  # (otherwise lav_mat_sym_diff_smallest_root will fail)
   theta_rm_idx <- unique(c(dummy_lv_idx, empty_theta_idx))
   if (length(theta_rm_idx) == nrow(mtm)) {
     # all zero?
@@ -302,13 +302,13 @@ lav_sam_veta <- function(m = NULL, s = NULL, mm_theta = NULL,
     lambda_correction <- FALSE
   } else if (length(theta_rm_idx) > 0L) {
     mtm_small <- mtm[-theta_rm_idx, -theta_rm_idx, drop = FALSE]
-    mtm_small <- zapsmall(lav_matrix_symmetric_force_pd(
+    mtm_small <- zapsmall(lav_mat_sym_force_pd(
       mtm_small,
       tol = 1e-04
     ))
     mtm[-theta_rm_idx, -theta_rm_idx] <- mtm_small
   } else {
-    mtm <- zapsmall(lav_matrix_symmetric_force_pd(mtm, tol = 1e-04))
+    mtm <- zapsmall(lav_mat_sym_force_pd(mtm, tol = 1e-04))
   }
 
   # apply small sample correction (if requested)
@@ -328,7 +328,7 @@ lav_sam_veta <- function(m = NULL, s = NULL, mm_theta = NULL,
   lambda <- lambda_star <- +Inf
   if (lambda_correction) {
     # use Fuller (1987) approach to ensure VETA is positive
-    lambda <- try(lav_matrix_symmetric_diff_smallest_root(msm, mtm),
+    lambda <- try(lav_mat_sym_diff_smallest_root(msm, mtm),
       silent = TRUE
     )
     if (inherits(lambda, "try-error")) {
@@ -409,24 +409,24 @@ lav_sam_veta2 <- function(fs = NULL, m = NULL,
   mtm <- m %*% mm_theta %*% t(m)
 
   # new in 0.6-16: make sure MTM is pd
-  # (otherwise lav_matrix_symmetric_diff_smallest_root will fail)
+  # (otherwise lav_mat_sym_diff_smallest_root will fail)
   dummy_lv_idx <- which(lv_names %in% dummy_lv_names)
   if (length(dummy_lv_idx) > 0L) {
     mtm_nodummy <- mtm[-dummy_lv_idx, -dummy_lv_idx, drop = FALSE]
-    mtm_nodummy <- zapsmall(lav_matrix_symmetric_force_pd(
+    mtm_nodummy <- zapsmall(lav_mat_sym_force_pd(
       mtm_nodummy,
       tol = 1e-04
     ))
     mtm[-dummy_lv_idx, -dummy_lv_idx] <- mtm_nodummy
   } else {
-    mtm <- zapsmall(lav_matrix_symmetric_force_pd(mtm, tol = 1e-04))
+    mtm <- zapsmall(lav_mat_sym_force_pd(mtm, tol = 1e-04))
   }
 
   # augment to include intercept
   fs <- cbind(1, fs)
   n <- nrow(fs)
-  mtm <- lav_matrix_bdiag(0, mtm)
-  veta <- lav_matrix_bdiag(0, veta)
+  mtm <- lav_mat_bdiag(0, mtm)
+  veta <- lav_mat_bdiag(0, veta)
   eeta <- c(1, eeta)
   lv_names <- c("..int..", lv_names)
   nfac <- ncol(fs)
@@ -439,7 +439,7 @@ lav_sam_veta2 <- function(fs = NULL, m = NULL,
 
   fs2 <- fs[, idx1] * fs[, idx2]
 
-  k_nfac <- lav_matrix_commutation(nfac, nfac)
+  k_nfac <- lav_mat_com(nfac, nfac)
   ik <- diag(nfac * nfac) + k_nfac
 
   eeta <- as.matrix(drop(eeta))
@@ -451,10 +451,10 @@ lav_sam_veta2 <- function(fs = NULL, m = NULL,
   # ingredients (normal ME case)
   var_fs2 <- varn(fs2, n)
   var_etak_me <- (tcrossprod(eeta) %x% mtm + vetak_mtm)
-  var_mek_eta <- lav_matrix_commutation_pre_post(var_etak_me)
+  var_mek_eta <- lav_mat_com_pre_post(var_etak_me)
   var_me2 <- gamma_me22
 
-  cov_etak_me_mek_eta <- lav_matrix_commutation_post(var_etak_me)
+  cov_etak_me_mek_eta <- lav_mat_com_post(var_etak_me)
   cov_mek_eta_etak_me <- t(cov_etak_me_mek_eta)
 
   var_error <- (var_etak_me + var_mek_eta + cov_etak_me_mek_eta
@@ -473,7 +473,7 @@ lav_sam_veta2 <- function(fs = NULL, m = NULL,
   fs_mean <- fs_mean[lv_keep]
 
   # compute Gamma for FS2[,lv.keep]
-  #FS.gamma <- lav_samplestats_gamma(FS2[,lv.keep, drop  = FALSE],
+  #FS.gamma <- lav_samp_gamma(FS2[,lv.keep, drop  = FALSE],
   #                                  meanstructure = TRUE)
 
   # apply small sample correction (if requested)
@@ -494,7 +494,7 @@ lav_sam_veta2 <- function(fs = NULL, m = NULL,
   lambda_star <- 1
   if (lambda_correction) {
     # use Fuller (1987) approach to ensure VETA2 is positive
-    lambda <- try(lav_matrix_symmetric_diff_smallest_root(
+    lambda <- try(lav_mat_sym_diff_smallest_root(
       var_fs2,
       var_error
     ), silent = TRUE)
@@ -519,26 +519,26 @@ lav_sam_veta2 <- function(fs = NULL, m = NULL,
   # new in 0.6-20: to compute Gamma.eta
   if (return_cov_iveta2) {
     iveta2_1 <- matrix(0, n,
-                ncol = length(lav_matrix_vech(veta2)) + ncol(veta2))
+                ncol = length(lav_mat_vech(veta2)) + ncol(veta2))
     ef <- colMeans(fs)
     for (i in 1:n) {
       fi <- as.matrix(fs2[i, seq_len(nfac)])
       tmp <- (((tcrossprod(fi) - mtm) %x% mtm) +
            (mtm %x% (tcrossprod(fi) - mtm)) +
-           lav_matrix_commutation_post((tcrossprod(fi) - mtm) %x% mtm) +
-           lav_matrix_commutation_pre((tcrossprod(fi) - mtm) %x% mtm) +
+           lav_mat_com_post((tcrossprod(fi) - mtm) %x% mtm) +
+           lav_mat_com_pre((tcrossprod(fi) - mtm) %x% mtm) +
            (ik %*% (mtm %x% mtm)))
       iveta2 <- tcrossprod(fs2[i, ] - fs2_mean) - lambda_star * tmp
       colnames(iveta2) <- rownames(iveta2) <- names_1
 
-      ieeta2 <- (lav_matrix_vec(tcrossprod(fi)) -
-                 lav_matrix_vec(tcrossprod(ef)) +
+      ieeta2 <- (lav_mat_vec(tcrossprod(fi)) -
+                 lav_mat_vec(tcrossprod(ef)) +
                  (ef %x% ef) -
-                 lambda_star * lav_matrix_vec(mtm))
+                 lambda_star * lav_mat_vec(mtm))
       names(ieeta2) <- names_1
 
       iveta2_1[i, ] <- c(ieeta2[lv_keep],
-                      lav_matrix_vech(iveta2[lv_keep, lv_keep]))
+                      lav_mat_vech(iveta2[lv_keep, lv_keep]))
     } # N
     # experimental:
     # remove outliers in FS?
@@ -586,7 +586,7 @@ lav_sam_eeta2 <- function(eeta = NULL, veta = NULL, lv_names = NULL,
   names_1 <- c(lv_names, paste(lv_names[idx1], lv_names[idx2], sep = ":"))
 
   # E(\eta %x% \eta)
-  eeta2 <- lav_matrix_vec(veta) + eeta %x% eeta
+  eeta2 <- lav_mat_vec(veta) + eeta %x% eeta
 
   # add 1st order
   eeta2_aug <- c(eeta, eeta2)
@@ -931,7 +931,7 @@ lav_sam_get_mmlist <- function(lavobject) {
   mm_list
 }
 
-lav_sam_veta_partable <- function(lavobject, block = 1L) {
+lav_sam_veta_pt <- function(lavobject, block = 1L) {
 
   lavmodel <- lavobject@Model
   lavpta   <- lavobject@pta
@@ -948,7 +948,7 @@ lav_sam_veta_partable <- function(lavobject, block = 1L) {
   if (!is.null(mlist$beta)) {
     mm_beta <- (mlist$beta != 0) + 0L
     tmp <- -mm_beta
-    tmp[lav_matrix_diag_idx(nr)] <- 1
+    tmp[lav_mat_diag_idx(nr)] <- 1
     ib_inv <- solve(tmp)
   } else {
     ib_inv <- diag(nr)
@@ -977,7 +977,7 @@ lav_sam_veta_con <- function(s = NULL, mm_lambda = NULL, mm_theta = NULL,
   t_lw  <- t(wl)
   t_lwl <- t_lw %*% mm_lambda
   tmp1 <- t(l_veta) %*% (t_lwl %x% t_lwl) %*% l_veta
-  tmp2 <- t(l_veta) %*% lav_matrix_vec(t_lw %*% (s - mm_theta) %*% wl)
+  tmp2 <- t(l_veta) %*% lav_mat_vec(t_lw %*% (s - mm_theta) %*% wl)
   out <- solve(tmp1, tmp2)
   veta_init <- matrix(l_veta %*% out, m, m)
 
@@ -994,7 +994,7 @@ lav_sam_veta_con <- function(s = NULL, mm_lambda = NULL, mm_theta = NULL,
     t_lw  <- t(wl)
     t_lwl <- t_lw %*% mm_lambda
     tmp1 <- t(l_veta) %*% (t_lwl %x% t_lwl) %*% l_veta
-    tmp2 <- t(l_veta) %*% lav_matrix_vec(t_lw %*% (s - mm_theta) %*% wl)
+    tmp2 <- t(l_veta) %*% lav_mat_vec(t_lw %*% (s - mm_theta) %*% wl)
     out <- solve(tmp1, tmp2)
     veta_ml <- matrix(l_veta %*% out, m, m)
     rmsea <- sqrt(sum((veta_new - veta_ml)^2))

--- a/R/lav_samplestats.R
+++ b/R/lav_samplestats.R
@@ -6,14 +6,12 @@
 
 # YR 18 Jan 2021: use lavoptions
 
-lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
+lav_samp_from_data <- function(lavdata = NULL,        # nolint start
                                       lavoptions = NULL,
-                                      WLS.V = NULL,
-                                      NACOV = NULL) {        # nolint end
+                                      wls_v = NULL,
+                                      nacov = NULL) {        # nolint end
   # extra info from lavoptions
   stopifnot(!is.null(lavoptions))
-  wls_v <- WLS.V
-  nacov <- NACOV
   missing <- lavoptions$missing
   rescale <- lavoptions$sample.cov.rescale
   estimator <- lavoptions$estimator
@@ -137,13 +135,13 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         wls_v <- list(wls_v)
       } else {
         lav_msg_stop(gettextf(
-          "WLS.V argument should be a list of length %s", ngroups)
+          "wls_v argument should be a list of length %s", ngroups)
         )
       }
     } else {
       if (length(wls_v) != ngroups) {
         lav_msg_stop(gettextf(
-          "WLS.V assumes %1$s groups; data contains %2$s groups",
+          "wls_v assumes %1$s groups; data contains %2$s groups",
           length(wls_v), ngroups))
       }
     }
@@ -403,12 +401,12 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
 
       # only for catML
       if (estimator == "catML") {
-        cov_1 <- cov2cor(lav_matrix_symmetric_force_pd(cov[[g]],
+        cov_1 <- cov2cor(lav_mat_sym_force_pd(cov[[g]],
           tol = 1e-04
         ))
         # overwrite
         cov[[g]] <- cov_1
-        out <- lav_samplestats_icov(
+        out <- lav_samp_icov(
           cov_1 = cov_1,
           x_idx = x_idx[[g]],
           ngroups = ngroups, g = g
@@ -419,12 +417,12 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         # the same for res.cov if conditional.x = TRUE
         if (conditional_x) {
           res_cov_1 <-
-            cov2cor(lav_matrix_symmetric_force_pd(res_cov[[g]],
+            cov2cor(lav_mat_sym_force_pd(res_cov[[g]],
               tol = 1e-04
             ))
           # overwrite
           res_cov[[g]] <- res_cov_1
-          out <- lav_samplestats_icov(
+          out <- lav_samp_icov(
             cov_1 = res_cov_1,
             ridge = 1e-05,
             x_idx = x_idx[[g]],
@@ -439,7 +437,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
     # continuous -- multilevel
     } else if (nlevels > 1L) {
       # level-based sample statistics
-      ylp[[g]] <- lav_samplestats_cluster_patterns(
+      ylp[[g]] <- lav_samp_cl_patterns(
         y = x[[g]],
         lp = lavdata@Lp[[g]],
         conditional_x = lavoptions$conditional.x
@@ -521,7 +519,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         if (missing %in% c("ml", "ml.x")) {
           missing_flag <- TRUE
           missing_1[[g]] <-
-            lav_samplestats_missing_patterns(
+            lav_samp_mi_patterns(
               y = x[[g]],
               mp = mp[[g]],
               wt = wt[[g]],
@@ -596,7 +594,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         missing == "robust.two.stage") {
         missing_flag <- FALSE # !!! just use sample statistics
         missing_1[[g]] <-
-          lav_samplestats_missing_patterns(
+          lav_samp_mi_patterns(
             y = x[[g]],
             mp = mp[[g]],
             wt = wt[[g]]
@@ -604,7 +602,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         current_warn <- lav_warn()
         if (lav_warn(lavoptions$em.h1.warn))
           on.exit(lav_warn(current_warn), TRUE)
-        out <- lav_mvnorm_missing_h1_estimate_moments(
+        out <- lav_mvn_mi_h1_est_moments(
           y = x[[g]],
           wt = wt[[g]],
           mp = mp[[g]], yp = missing_1[[g]],
@@ -626,7 +624,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
       } else if (missing %in% c("ml", "ml.x")) {
         missing_flag <- TRUE
         missing_1[[g]] <-
-          lav_samplestats_missing_patterns(
+          lav_samp_mi_patterns(
             y = x[[g]],
             mp = mp[[g]],
             wt = wt[[g]]
@@ -638,14 +636,14 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
           if (lav_warn(lavoptions$em.h1.warn))
             on.exit(lav_warn(current_warn), TRUE)
           # zero coverage?
-          if (any(lav_matrix_vech(mp[[g]]$coverage, diagonal = FALSE) == 0)) {
-            #out <- lav_mvnorm_missing_h1_estimate_moments_chol(
+          if (any(lav_mat_vech(mp[[g]]$coverage, diagonal = FALSE) == 0)) {
+            #out <- lav_mvn_mi_h1_est_moments_chol(
             #         lavdata = lavdata, lavoptions = lavoptions, group = g)
             #missing.h1.[[g]]$sigma <- out$Sigma
             #missing.h1.[[g]]$mu <- out$Mu
             #missing.h1.[[g]]$h1 <- out$fx
           } else if (!allow_empty_cell) {
-            out <- lav_mvnorm_missing_h1_estimate_moments(
+            out <- lav_mvn_mi_h1_est_moments(
               y = x[[g]],
               wt = wt[[g]],
               mp = mp[[g]], yp = missing_1[[g]],
@@ -743,7 +741,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
 
       # icov and cov.log.det (but not if missing)
       if (sample_icov && !missing %in% c("ml", "ml.x")) {
-        out <- lav_samplestats_icov(
+        out <- lav_samp_icov(
           cov_1 = cov[[g]], ridge = 1e-05,
           x_idx = x_idx[[g]],
           ngroups = ngroups, g = g
@@ -753,7 +751,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
 
         # the same for res.cov if conditional.x = TRUE
         if (conditional_x) {
-          out <- lav_samplestats_icov(
+          out <- lav_samp_icov(
             cov_1 = res_cov[[g]],
             ridge = 1e-05,
             x_idx = x_idx[[g]],
@@ -776,7 +774,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         tmp_categorical <- categorical
         tmp_meanstructure <- meanstructure
       }
-      wls_obs[[g]] <- lav_samplestats_wls_obs(
+      wls_obs[[g]] <- lav_samp_wls_obs(
         mean_g = mean[[g]],
         cov_g = cov[[g]], var_g = var[[g]], th_g = th[[g]],
         th_idx_g = th_idx[[g]], res_int_g = res_int[[g]],
@@ -834,13 +832,13 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         }
 
         if (correlation) {
-      nacov[[g]] <- lav_samplestats_cor_gamma(
+      nacov[[g]] <- lav_samp_cor_gamma(
         m_y = y,
         meanstructure = meanstructure
       )
     } else {
           nacov[[g]] <-
-            lav_samplestats_gamma(
+            lav_samp_gamma(
               m_y = y,
               x_idx = x_idx[[g]],
               cluster_idx = cluster_idx,
@@ -889,7 +887,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
             cluster_idx <- NULL
           }
       if (correlation) {
-            nacov[[g]] <- lav_samplestats_cor_gamma(
+            nacov[[g]] <- lav_samp_cor_gamma(
               m_y = y,
               meanstructure = meanstructure
             )
@@ -897,7 +895,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
             if ("robust.sem.nt" %in% lavoptions$se ||
                 "browne.residual.nt" %in% lavoptions$test) {
               nacov[[g]] <-
-                lav_samplestats_gamma_nt(
+                lav_samp_gamma_nt(
                   m_y = y,
                   m_cov = cov[[g]],
                   m_mean = mean[[g]],
@@ -910,7 +908,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
                 )
             } else {
               nacov[[g]] <-
-                lav_samplestats_gamma(
+                lav_samp_gamma(
                   m_y = y,
                   x_idx = x_idx[[g]],
                   cluster_idx = cluster_idx,
@@ -955,7 +953,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         # unweight!!
         a <- group_w[[g]] * sum(unlist(nobs)) / nobs[[g]]
         # always 1!!!
-        nacov[[g]] <- lav_matrix_bdiag(matrix(a, 1, 1), nacov[[g]])
+        nacov[[g]] <- lav_mat_bdiag(matrix(a, 1, 1), nacov[[g]])
       }
     }
 
@@ -964,7 +962,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
       if (estimator == "DLS" && dls_gamma_nt == "sample" && dls_a < 1.0) {
         # compute GammaNT here
         if (correlation) {
-          gamma_nt <- lav_samplestats_cor_gamma_nt(
+          gamma_nt <- lav_samp_cor_gamma_nt(
             m_cov          = cov[[g]],
             m_mean         = mean[[g]],
             rescale        = FALSE,
@@ -975,7 +973,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
             slopestructure = conditional_x   # not used yet
           )
         } else {
-          gamma_nt <- lav_samplestats_gamma_nt(
+          gamma_nt <- lav_samp_gamma_nt(
             m_cov          = cov[[g]],
             m_mean         = mean[[g]],
             rescale        = FALSE,
@@ -994,7 +992,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
         # Note: we need the 'original' COV/MEAN/ICOV
         #        sample statistics; not the 'residual' version
         if (correlation) {
-          gamma_nt <- lav_samplestats_cor_gamma_nt(
+          gamma_nt <- lav_samp_cor_gamma_nt(
             m_cov          = cov[[g]],
             m_mean         = mean[[g]],
             #rescale        = FALSE,
@@ -1004,9 +1002,9 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
             meanstructure  = meanstructure,  # not used yet
             slopestructure = conditional_x   # not used yet
           )
-          wls_v[[g]] <- lav_matrix_symmetric_inverse(gamma_nt)
+          wls_v[[g]] <- lav_mat_sym_inverse(gamma_nt)
         } else {
-          wls_v[[g]] <- lav_samplestats_gamma_inverse_nt(
+          wls_v[[g]] <- lav_samp_gamma_inverse_nt(
             m_icov         = icov[[g]],
             m_cov          = cov[[g]],
             m_mean         = mean[[g]],
@@ -1053,11 +1051,11 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
                   w_dls <-
                     (1 - dls_a) * nacov[[g]] + dls_a * gamma_nt
                   wls_v[[g]] <-
-                    lav_matrix_symmetric_inverse(w_dls)
+                    lav_mat_sym_inverse(w_dls)
                 }
               } else { # WLS
                 wls_v[[g]] <-
-                  lav_matrix_symmetric_inverse(nacov[[g]])
+                  lav_mat_sym_inverse(nacov[[g]])
               }
             } else {
               # fixed.x: we have zero cols/rows
@@ -1068,10 +1066,10 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
               if (estimator == "DLS" && dls_gamma_nt == "sample") {
                 w_dls <- (1 - dls_a) * nacov[[g]] + dls_a * gamma_nt
                 wls_v[[g]] <-
-                  lav_matrix_symmetric_inverse(w_dls)
+                  lav_mat_sym_inverse(w_dls)
               } else { # WLS
                 wls_v[[g]] <-
-                  lav_matrix_symmetric_inverse(nacov[[g]])
+                  lav_mat_sym_inverse(nacov[[g]])
               }
             }
           } else if (estimator == "DWLS") {
@@ -1127,7 +1125,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
           # always 1!!!
           # invert
           a <- 1 / a
-          wls_v[[g]] <- lav_matrix_bdiag(matrix(a, 1, 1), wls_v[[g]])
+          wls_v[[g]] <- lav_mat_bdiag(matrix(a, 1, 1), wls_v[[g]])
         }
         if (!is.null(wls_vd[[g]])) {
           # unweight!!
@@ -1211,7 +1209,7 @@ lav_samplestats_from_data <- function(lavdata = NULL,        # nolint start
 }
 
 
-lav_samplestats_from_moments <- function(sample_cov = NULL,
+lav_samp_from_moments <- function(sample_cov = NULL,
                                          sample_mean = NULL,
                                          sample_th = NULL,
                                          sample_nobs = NULL,
@@ -1396,20 +1394,20 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
       if (ngroups == 1L) {
         wls_v <- list(unclass(wls_v))
       } else {
-        lav_msg_stop(gettextf("WLS.V argument should be a list of length %s",
+        lav_msg_stop(gettextf("wls_v argument should be a list of length %s",
           ngroups)
         )
       }
     } else {
       if (length(wls_v) != ngroups) {
         lav_msg_stop(gettextf(
-          "WLS.V assumes %1$s groups; data contains %2$s groups",
+          "wls_v assumes %1$s groups; data contains %2$s groups",
           length(wls_v), ngroups))
       }
       wls_v <- lapply(wls_v, unclass)
     }
 
-    # is WLS.V full? check first
+    # is wls_v full? check first
     if (is.null(dim(wls_v[[1]]))) {
       # we will assume it is the diagonal only
       wls_vd <- wls_v
@@ -1421,7 +1419,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
     }
 
     wls_v_user <- TRUE
-    # FIXME: check dimension of WLS.V!!
+    # FIXME: check dimension of wls_v!!
   }
 
   if (is.null(nacov)) {
@@ -1605,7 +1603,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
 
         # icov and cov.log.det
         # if(lavoptions$sample.icov) {
-        out <- lav_samplestats_icov(
+        out <- lav_samp_icov(
           cov_1 = res_cov[[g]],
           ridge = 1e-05,
           x_idx = x_idx[[g]],
@@ -1633,7 +1631,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
 
         # icov and cov.log.det
         # if(lavoptions$sample.icov) {
-        out <- lav_samplestats_icov(
+        out <- lav_samp_icov(
           cov_1 = cov[[g]],
           ridge = 1e-05,
           x_idx = x_idx[[g]],
@@ -1675,7 +1673,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
     }
 
     # WLS.obs
-    wls_obs[[g]] <- lav_samplestats_wls_obs(
+    wls_obs[[g]] <- lav_samp_wls_obs(
       mean_g = mean[[g]],
       cov_g = cov[[g]], var_g = var[[g]], th_g = th[[g]],
       th_idx_g = th_idx[[g]], res_int_g = res_int[[g]],
@@ -1688,7 +1686,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
       group_w_free = group_w_free
     )
 
-    # WLS.V
+    # wls_v
     if (!wls_v_user) {
       if (estimator == "GLS") {
         # FIXME: in <0.5-21, we had
@@ -1697,7 +1695,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
         #        V11 <- V11 * nobs[[g]]/(nobs[[g]]-1)
         #    }
         if (correlation) {
-          gamma_nt <- lav_samplestats_cor_gamma_nt(
+          gamma_nt <- lav_samp_cor_gamma_nt(
             m_cov          = cov[[g]],
             m_mean         = mean[[g]],
             #rescale        = FALSE,
@@ -1707,9 +1705,9 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
             meanstructure  = meanstructure,  # not used yet
             slopestructure = conditional_x   # not used yet
           )
-          wls_v[[g]] <- lav_matrix_symmetric_inverse(gamma_nt)
+          wls_v[[g]] <- lav_mat_sym_inverse(gamma_nt)
         } else {
-          wls_v[[g]] <- lav_samplestats_gamma_inverse_nt(
+          wls_v[[g]] <- lav_samp_gamma_inverse_nt(
             m_icov = icov[[g]],
             m_cov = cov[[g]],
             m_mean = mean[[g]],
@@ -1728,14 +1726,14 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
         if (is.null(wls_v[[g]])) {
           lav_msg_stop(gettext(
             "the (D)WLS estimator is only available with full data
-            or with a user-provided WLS.V"))
+            or with a user-provided wls_v"))
         }
       }
 
       # group.w.free
       if (!is.null(wls_v[[g]]) && group_w_free) {
         # FIXME!!!
-        wls_v[[g]] <- lav_matrix_bdiag(matrix(1, 1, 1), wls_v[[g]])
+        wls_v[[g]] <- lav_mat_bdiag(matrix(1, 1, 1), wls_v[[g]])
       }
     }
   } # ngroups
@@ -1798,7 +1796,7 @@ lav_samplestats_from_moments <- function(sample_cov = NULL,
 }
 
 # compute sample statistics, per missing pattern
-lav_samplestats_missing_patterns <- function(     # nolint
+lav_samp_mi_patterns <- function(
   y = NULL, mp = NULL, wt = NULL,lp = NULL) {
   # coerce Y to matrix
   y <- as.matrix(y)
@@ -1815,7 +1813,7 @@ lav_samplestats_missing_patterns <- function(     # nolint
   }
 
   if (is.null(mp)) {
-    mp <- lav_data_missing_patterns(y,
+    mp <- lav_data_mi_patterns(y,
       sort_freq = FALSE, coverage = FALSE,
       lp = lp
     )
@@ -1841,7 +1839,7 @@ lav_samplestats_missing_patterns <- function(     # nolint
         my <- base::.colMeans(raw_1, m = NROW(raw_1), n = NCOL(raw_1))
         # SY <- crossprod(RAW)/Mp$freq[p] - tcrossprod(MY)
         # bad practice, better like this:
-        sy <- lav_matrix_cov(raw_1)
+        sy <- lav_mat_cov(raw_1)
       }
     # only a single observation (no need to weight!)
     } else {
@@ -1870,7 +1868,7 @@ lav_samplestats_missing_patterns <- function(     # nolint
 
   # add Zp as an attribute
   # if(!is.null(Lp)) {
-  #    Zp <- lav_samplestats_missing_patterns(Y = Z, Mp = Mp$Zp)
+  #    Zp <- lav_samp_mi_patterns(Y = Z, Mp = Mp$Zp)
   #    for(p in Mp$Zp$npatterns) {
   #        this.z <- Z[Mp$Zp$case.idx[[p]], drop = FALSE]
   #        Zp[[p]]$ROWSUM <- t(this.z)
@@ -1883,7 +1881,7 @@ lav_samplestats_missing_patterns <- function(     # nolint
 }
 
 # compute sample statistics, per cluster
-lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
+lav_samp_cl_patterns <- function(y = NULL, lp = NULL,
                                              conditional_x = FALSE) {
   # coerce Y to matrix
   y1 <- as.matrix(y)
@@ -1917,7 +1915,7 @@ lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
     # size even in the balanced case
 
     y1_means <- colMeans(y1, na.rm = TRUE)
-    y1y1 <- lav_matrix_crossprod(y1)
+    y1y1 <- lav_mat_crossprod(y1)
     both_idx <- all_idx <- seq_len(p)
 
     if (length(within_idx) > 0L ||
@@ -1945,13 +1943,13 @@ lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
     #    }
     # }
     y1a <- y1 - y2a[cluster_idx, , drop = FALSE]
-    s_w <- lav_matrix_crossprod(y1a) / (n - nclusters)
+    s_w <- lav_mat_crossprod(y1a) / (n - nclusters)
 
     # S.b
     # three parts: within/within, between/between, between/within
     # standard definition of the between variance matrix
     # divides by (nclusters - 1)
-    s_b <- lav_matrix_crossprod(y2c * cluster_size, y2c) / (nclusters - 1)
+    s_b <- lav_mat_crossprod(y2c * cluster_size, y2c) / (nclusters - 1)
 
     # check for zero variances
     if (length(both_idx) > 0L) {
@@ -1972,7 +1970,7 @@ lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
     # extract 'fixed' level-1 loglik from here
     wx_idx <- lp$ov.x.idx[[1]]
     if (length(wx_idx) > 0L) {
-      loglik_x_w <- lav_mvnorm_h1_loglik_samplestats(
+      loglik_x_w <- lav_mvn_h1_loglik_samp(
         sample_nobs = lp$nclusters[[1]],
         sample_cov  = s_1[wx_idx, wx_idx, drop = FALSE]
       )
@@ -1983,7 +1981,7 @@ lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
     bx_idx <- lp$ov.x.idx[[2]]
     if (length(bx_idx) > 0L) {
       covb <- cov(y2[, bx_idx, drop = FALSE]) * (nclusters - 1) / nclusters
-      loglik_x_b <- lav_mvnorm_h1_loglik_samplestats(
+      loglik_x_b <- lav_mvn_h1_loglik_samp(
         sample_nobs = lp$nclusters[[2]],
         sample_cov  = covb
       )
@@ -2013,7 +2011,7 @@ lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
       s_b[between_idx, ] <-
         (s * nclusters / n) * s_b[between_idx, , drop = FALSE]
       s_b[between_idx, between_idx] <-
-        (s * lav_matrix_crossprod(
+        (s * lav_mat_crossprod(
           y2c[, between_idx, drop = FALSE],
           y2c[, between_idx, drop = FALSE]
         ) / nclusters)
@@ -2082,7 +2080,7 @@ lav_samplestats_cluster_patterns <- function(y = NULL, lp = NULL,     # nolint
         if (any(is.na(tmp2))) {
           # if full column has NA, this will fail...
           # not needed anyway
-          # out <- lav_mvnorm_missing_h1_estimate_moments(Y = tmp2,
+          # out <- lav_mvn_mi_h1_est_moments(Y = tmp2,
           #          max.iter = 10L)
           # cov.d[[clz]] <- out$Sigma
           cov_d[[clz]] <- 0

--- a/R/lav_samplestats_gamma.R
+++ b/R/lav_samplestats_gamma.R
@@ -81,7 +81,7 @@ lav_object_gamma <- function(lavobject = NULL,
       } else {
         cluster_idx <- NULL
       }
-      out[[g]] <- lav_samplestats_gamma(
+      out[[g]] <- lav_samp_gamma(
         m_y = y,
         m_mu = mean_1,
         m_sigma = cov_1,
@@ -96,7 +96,7 @@ lav_object_gamma <- function(lavobject = NULL,
         mplus_wls = mplus_wls
       )
     } else {
-      out[[g]] <- lav_samplestats_gamma_nt(
+      out[[g]] <- lav_samp_gamma_nt(
         m_cov = cov_1, # joint!
         m_mean = mean_1, # joint!
         x_idx = x_idx,
@@ -110,7 +110,7 @@ lav_object_gamma <- function(lavobject = NULL,
     # group.w.free
     if (lavoptions$group.w.free) {
       # checkme!
-      out[[g]] <- lav_matrix_bdiag(matrix(1, 1, 1), out[[g]])
+      out[[g]] <- lav_mat_bdiag(matrix(1, 1, 1), out[[g]])
     }
 
   } # g
@@ -130,7 +130,7 @@ lav_object_gamma <- function(lavobject = NULL,
 #  - if conditional.x = TRUE, we ignore fixed.x (can be TRUE or FALSE)
 
 # NORMAL-THEORY
-lav_samplestats_gamma_nt <- function(m_y = NULL, # should include
+lav_samp_gamma_nt <- function(m_y = NULL, # should include
                                      # eXo if
                                      # conditional.x=TRUE
                                      wt = NULL,
@@ -196,10 +196,10 @@ lav_samplestats_gamma_nt <- function(m_y = NULL, # should include
       #   m_gamma <- lavaanC::m_kronecker_dup_ginv_pre_post(m_s,
       #                                              multiplicator = 2.0)
       # } else {
-        m_gamma <- 2 * lav_matrix_duplication_ginv_pre_post(m_s %x% m_s)
+        m_gamma <- 2 * lav_mat_dup_ginv_pre_post(m_s %x% m_s)
       # }
       if (meanstructure) {
-        m_gamma <- lav_matrix_bdiag(m_s, m_gamma)
+        m_gamma <- lav_mat_bdiag(m_s, m_gamma)
       }
 
       # unconditional - fixed x
@@ -226,13 +226,13 @@ lav_samplestats_gamma_nt <- function(m_y = NULL, # should include
       #   gamma_r <- lavaanC::m_kronecker_dup_ginv_pre_post(m_r,
       #                                               multiplicator = 2.0)
       # } else {
-        gamma_s <- 2 * lav_matrix_duplication_ginv_pre_post(m_s %x% m_s)
-        gamma_r <- 2 * lav_matrix_duplication_ginv_pre_post(m_r %x% m_r)
+        gamma_s <- 2 * lav_mat_dup_ginv_pre_post(m_s %x% m_s)
+        gamma_r <- 2 * lav_mat_dup_ginv_pre_post(m_r %x% m_r)
       # }
       m_gamma <- gamma_s - gamma_r
 
       if (meanstructure) {
-        m_gamma <- lav_matrix_bdiag(ybarx_aug, m_gamma)
+        m_gamma <- lav_mat_bdiag(ybarx_aug, m_gamma)
       }
     }
   } else {
@@ -254,7 +254,7 @@ lav_samplestats_gamma_nt <- function(m_y = NULL, # should include
     #                                                  multiplicator = 2.0)
     # } else {
       m_gamma <- 2 *
-               lav_matrix_duplication_ginv_pre_post(cov_ybarx %x% cov_ybarx)
+               lav_mat_dup_ginv_pre_post(cov_ybarx %x% cov_ybarx)
     # }
 
     if (meanstructure || slopestructure) {
@@ -283,7 +283,7 @@ lav_samplestats_gamma_nt <- function(m_y = NULL, # should include
       }
     }
 
-    m_gamma <- lav_matrix_bdiag(a11, m_gamma)
+    m_gamma <- lav_mat_bdiag(a11, m_gamma)
   }
 
   m_gamma
@@ -302,7 +302,7 @@ lav_samplestats_gamma_nt <- function(m_y = NULL, # should include
 #  - new in 0.6-13: add unbiased = TRUE (for the 'plain' setting only)
 
 # ADF THEORY
-lav_samplestats_gamma <- function(m_y, # Y+X if cond!
+lav_samp_gamma <- function(m_y, # Y+X if cond!
                                   m_mu = NULL,
                                   m_sigma = NULL,
                                   x_idx = integer(0L),
@@ -330,7 +330,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     # data really should be complete
       m_cov <- stats::cov(m_y, use = "pairwise.complete.obs")
       m_cov <- m_cov * (n - 1) / n
-      cov_vech <- lav_matrix_vech(m_cov)
+      cov_vech <- lav_mat_vech(m_cov)
     }
   }
 
@@ -340,10 +340,10 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     model_based <- TRUE
     if (meanstructure) {
       stopifnot(!is.null(m_mu))
-      sigma <- c(as.numeric(m_mu), lav_matrix_vech(m_sigma))
+      sigma <- c(as.numeric(m_mu), lav_mat_vech(m_sigma))
     } else {
       m_mu <- colMeans(m_y, na.rm = TRUE) # for centering!
-      sigma <- lav_matrix_vech(m_sigma)
+      sigma <- lav_mat_vech(m_sigma)
     }
   } else {
     model_based <- FALSE
@@ -374,8 +374,8 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     # create z where the rows_i contain the following elements:
     #  - Y_i (if meanstructure is TRUE)
     #  - vech(Yc_i' %*% Yc_i) where Yc_i are the residuals
-    idx1 <- lav_matrix_vech_col_idx(p)
-    idx2 <- lav_matrix_vech_row_idx(p)
+    idx1 <- lav_mat_vech_col_idx(p)
+    idx2 <- lav_mat_vech_row_idx(p)
     if (meanstructure) {
       z <- cbind(m_y, m_yc[, idx1, drop = FALSE] *
         m_yc[, idx2, drop = FALSE])
@@ -387,9 +387,9 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     if (model_based) {
       if (meanstructure) {
         stopifnot(!is.null(m_mu))
-        sigma <- c(as.numeric(m_mu), lav_matrix_vech(m_sigma))
+        sigma <- c(as.numeric(m_mu), lav_mat_vech(m_sigma))
       } else {
-        sigma <- lav_matrix_vech(m_sigma)
+        sigma <- lav_mat_vech(m_sigma)
       }
       zc <- t(t(z) - sigma)
     } else {
@@ -402,7 +402,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     }
 
     if (anyNA(zc)) {
-      m_gamma <- lav_matrix_crossprod(zc) / n
+      m_gamma <- lav_mat_crossprod(zc) / n
     } else {
       m_gamma <- base::crossprod(zc) / n
     }
@@ -434,22 +434,22 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
       y_hat[, -x_idx] <- yhat
       # y_hat <- cbind(yhat, m_y[,x_idx])
       y_hatc <- t(t(y_hat) - yhat_bar)
-      idx1 <- lav_matrix_vech_col_idx(p)
-      idx2 <- lav_matrix_vech_row_idx(p)
+      idx1 <- lav_mat_vech_col_idx(p)
+      idx2 <- lav_mat_vech_row_idx(p)
       if (meanstructure) {
         z <- (cbind(m_y, m_yc[, idx1, drop = FALSE] *
           m_yc[, idx2, drop = FALSE]) -
           cbind(y_hat, y_hatc[, idx1, drop = FALSE] *
             y_hatc[, idx2, drop = FALSE]))
-        sigma1 <- c(m_mu, lav_matrix_vech(m_sigma))
-        sigma2 <- c(yhat_bar, lav_matrix_vech(yhat_cov))
+        sigma1 <- c(m_mu, lav_mat_vech(m_sigma))
+        sigma2 <- c(yhat_bar, lav_mat_vech(yhat_cov))
       } else {
         z <- (m_yc[, idx1, drop = FALSE] *
           m_yc[, idx2, drop = FALSE] -
           y_hatc[, idx1, drop = FALSE] *
             y_hatc[, idx2, drop = FALSE])
-        sigma1 <- lav_matrix_vech(m_sigma)
-        sigma2 <- lav_matrix_vech(yhat_cov)
+        sigma1 <- lav_mat_vech(m_sigma)
+        sigma2 <- lav_mat_vech(yhat_cov)
       }
       zc <- t(t(z) - (sigma1 - sigma2))
     } else {
@@ -461,8 +461,8 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
 
       m_yc <- t(t(m_y) - colMeans(m_y, na.rm = TRUE))
       y_hatc <- t(t(y_hat) - colMeans(y_hat, na.rm = TRUE))
-      idx1 <- lav_matrix_vech_col_idx(p)
-      idx2 <- lav_matrix_vech_row_idx(p)
+      idx1 <- lav_mat_vech_col_idx(p)
+      idx2 <- lav_mat_vech_row_idx(p)
       if (meanstructure) {
         z <- (cbind(m_y, m_yc[, idx1, drop = FALSE] *
           m_yc[, idx2, drop = FALSE]) -
@@ -483,7 +483,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     }
 
     if (anyNA(zc)) {
-      m_gamma <- lav_matrix_crossprod(zc) / n
+      m_gamma <- lav_mat_crossprod(zc) / n
     } else {
       m_gamma <- base::crossprod(zc) / n
     }
@@ -502,8 +502,8 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     m_res <- qr.resid(m_qr, m_y[, -x_idx, drop = FALSE])
     p <- ncol(m_res)
 
-    idx1 <- lav_matrix_vech_col_idx(p)
-    idx2 <- lav_matrix_vech_row_idx(p)
+    idx1 <- lav_mat_vech_col_idx(p)
+    idx2 <- lav_mat_vech_row_idx(p)
 
     if (meanstructure || slopestructure) {
       xtx_inv <- unname(solve(crossprod(m_x)))
@@ -563,7 +563,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     }
 
     if (anyNA(zc)) {
-      m_gamma <- lav_matrix_crossprod(zc) / n
+      m_gamma <- lav_mat_crossprod(zc) / n
     } else {
       m_gamma <- base::crossprod(zc) / n
     }
@@ -574,7 +574,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
   if (mplus_wls && !fixed_x && !conditional_x) {
     # adjust G_22 (the varcov part)
     m_s <- cov(m_y, use = "pairwise")
-    w <- lav_matrix_vech(m_s)
+    w <- lav_mat_vech(m_s)
     w_biased <- (n - 1) / n * w
     diff <- outer(w, w) - outer(w_biased, w_biased)
     if (meanstructure) {
@@ -606,7 +606,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
     #   gammant_cov <- lavaanC::m_kronecker_dup_ginv_pre_post(m_cov,
     #                                               multiplicator = 2.0)
     # } else {
-      gammant_cov <- 2 * lav_matrix_duplication_ginv_pre_post(m_cov %x% m_cov)
+      gammant_cov <- 2 * lav_mat_dup_ginv_pre_post(m_cov %x% m_cov)
     # }
 
     if (meanstructure) {
@@ -621,7 +621,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
       n / (n - 2) / (n - 3) * (gammant_cov -
         2 / (n - 1) * tcrossprod(cov_vech)))
     if (meanstructure) {
-      m_gamma <- lav_matrix_bdiag(m_cov, gamma_u)
+      m_gamma <- lav_mat_bdiag(m_cov, gamma_u)
 
       # 3-rd order:
       m_gamma[1:p, (p + 1):ncol(m_gamma)] <- gamma_mean_cov * n / (n - 2)
@@ -637,7 +637,7 @@ lav_samplestats_gamma <- function(m_y, # Y+X if cond!
 # ADF Gamma for correlations
 #
 # 30 May 2024: basic version: fixed_x=FALSE, conditional_x=FALSE, ...
-lav_samplestats_cor_gamma <- function(m_y, meanstructure = FALSE) {
+lav_samp_cor_gamma <- function(m_y, meanstructure = FALSE) {
 
   # coerce to matrix
   m_y <- unname(as.matrix(m_y))
@@ -657,12 +657,12 @@ lav_samplestats_cor_gamma <- function(m_y, meanstructure = FALSE) {
 
   # find indices so we avoid 1) double subscripts (diagonal!), and
   #                          2) duplicated subscripts (symmetric!)
-  idx1 <- lav_matrix_vech_col_idx(p, diagonal = FALSE)
-  idx2 <- lav_matrix_vech_row_idx(p, diagonal = FALSE)
+  idx1 <- lav_mat_vech_col_idx(p, diagonal = FALSE)
+  idx2 <- lav_mat_vech_row_idx(p, diagonal = FALSE)
 
   zr1 <- (yz[, idx1, drop = FALSE] * yz[, idx2, drop = FALSE])
   zr2 <- (yz2[, idx1, drop = FALSE] + yz2[, idx2, drop = FALSE])
-  zr2 <- t(t(zr2) * lav_matrix_vech(m_r, diagonal = FALSE))
+  zr2 <- t(t(zr2) * lav_mat_vech(m_r, diagonal = FALSE))
   zrr <- zr1 - 0.5 * zr2
   if (meanstructure) {
       zrr <- cbind(yz, zrr)
@@ -674,7 +674,7 @@ lav_samplestats_cor_gamma <- function(m_y, meanstructure = FALSE) {
 
 # normal theory version
 # 30 May 2024: basic version: fixed_x=FALSE, conditional_x=FALSE, ...
-lav_samplestats_cor_gamma_nt <- function(m_y = NULL,
+lav_samp_cor_gamma_nt <- function(m_y = NULL,
                                          wt = NULL,
                                          m_cov = NULL, # joint!
                                          m_mean = NULL, # joint!
@@ -744,18 +744,18 @@ lav_samplestats_cor_gamma_nt <- function(m_y = NULL,
     if (!fixed_x) {
       m_ip <- diag(s_p) %x% m_r
       m_rr <- m_r %x% m_r
-      gamma_z_nt <- m_rr + lav_matrix_commutation_pre(m_rr)
-      tmp <- (m_ip + lav_matrix_commutation_pre(m_ip)) / 2
-      zero_idx <- seq_len(s_p * s_p)[-lav_matrix_diag_idx(s_p)]
+      gamma_z_nt <- m_rr + lav_mat_com_pre(m_rr)
+      tmp <- (m_ip + lav_mat_com_pre(m_ip)) / 2
+      zero_idx <- seq_len(s_p * s_p)[-lav_mat_diag_idx(s_p)]
       tmp[, zero_idx] <- 0
       m_a <- -tmp
       diag(m_a) <- 1 - diag(tmp)
       gamma_nt_big <- m_a %*% gamma_z_nt %*% t(m_a)
-      r_idx <- lav_matrix_vech_idx(s_p, diagonal = FALSE)
+      r_idx <- lav_mat_vech_idx(s_p, diagonal = FALSE)
       v_gamma <- gamma_nt_big[r_idx, r_idx]
 
       if (meanstructure) {
-        v_gamma <- lav_matrix_bdiag(m_r, v_gamma)
+        v_gamma <- lav_mat_bdiag(m_r, v_gamma)
       }
 
       # unconditional - fixed x

--- a/R/lav_samplestats_icov.R
+++ b/R/lav_samplestats_icov.R
@@ -1,4 +1,4 @@
-lav_samplestats_icov <- function(cov_1 = NULL, ridge = 0.0, x_idx = integer(0L),
+lav_samp_icov <- function(cov_1 = NULL, ridge = 0.0, x_idx = integer(0L),
                                  ngroups = 1L, g = 1L) {
 
   c_s <- tryCatch(chol(cov_1), error = function(e) NULL)

--- a/R/lav_samplestats_igamma.R
+++ b/R/lav_samplestats_igamma.R
@@ -12,7 +12,7 @@
 #  - if conditional_x = TRUE, we ignore fixed_x (can be TRUE or FALSE)
 
 # NORMAL-THEORY
-lav_samplestats_gamma_inverse_nt <- function(m_y = NULL,
+lav_samp_gamma_inverse_nt <- function(m_y = NULL,
                                              m_cov = NULL,
                                              m_icov = NULL,
                                              m_mean = NULL,
@@ -79,10 +79,10 @@ lav_samplestats_gamma_inverse_nt <- function(m_y = NULL,
       #   gamma_inv <- lavaanC::m_kronecker_dup_pre_post(s_inv,
       #                                                multiplicator = 0.5)
       # } else {
-        gamma_inv <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+        gamma_inv <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
       # }
       if (meanstructure) {
-        gamma_inv <- lav_matrix_bdiag(s_inv, gamma_inv)
+        gamma_inv <- lav_mat_bdiag(s_inv, gamma_inv)
       }
 
       # unconditional - fixed x
@@ -92,15 +92,15 @@ lav_samplestats_gamma_inverse_nt <- function(m_y = NULL,
       #   gamma_inv <- lavaanC::m_kronecker_dup_pre_post(s_inv,
       #                                                multiplicator = 0.5)
       # } else {
-        gamma_inv <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+        gamma_inv <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
       # }
 
       # zero rows/cols corresponding with x/x combinations
       nvar <- NROW(m_icov)
       pstar <- nvar * (nvar + 1) / 2
       m_m <- matrix(0, nvar, nvar)
-      m_m[lav_matrix_vech_idx(nvar)] <- seq_len(pstar)
-      zero_idx <- lav_matrix_vech(m_m[x_idx, x_idx, drop = FALSE])
+      m_m[lav_mat_vech_idx(nvar)] <- seq_len(pstar)
+      zero_idx <- lav_mat_vech(m_m[x_idx, x_idx, drop = FALSE])
       gamma_inv[zero_idx, ] <- 0
       gamma_inv[, zero_idx] <- 0
 
@@ -108,7 +108,7 @@ lav_samplestats_gamma_inverse_nt <- function(m_y = NULL,
         s_inv_nox <- s_inv
         s_inv_nox[x_idx, ] <- 0
         s_inv_nox[, x_idx] <- 0
-        gamma_inv <- lav_matrix_bdiag(s_inv_nox, gamma_inv)
+        gamma_inv <- lav_mat_bdiag(s_inv_nox, gamma_inv)
       }
     }
   } else {
@@ -125,7 +125,7 @@ lav_samplestats_gamma_inverse_nt <- function(m_y = NULL,
     # if (lav_use_lavaanC()) {
     #   gamma_inv <- lavaanC::m_kronecker_dup_pre_post(s11, multiplicator = 0.5)
     # } else {
-      gamma_inv <- 0.5 * lav_matrix_duplication_pre_post(s11 %x% s11)
+      gamma_inv <- 0.5 * lav_mat_dup_pre_post(s11 %x% s11)
     # }
 
     if (meanstructure || slopestructure) {
@@ -153,7 +153,7 @@ lav_samplestats_gamma_inverse_nt <- function(m_y = NULL,
     }
 
     if (meanstructure || slopestructure) {
-      gamma_inv <- lav_matrix_bdiag(a11, gamma_inv)
+      gamma_inv <- lav_mat_bdiag(a11, gamma_inv)
     }
   }
 

--- a/R/lav_samplestats_step1.R
+++ b/R/lav_samplestats_step1.R
@@ -1,4 +1,4 @@
-lav_samplestats_step1 <- function(y,
+lav_samp_step1 <- function(y,
                                   wt = NULL, # new in 0.6-6
                                   ov_names = NULL,
                                   ov_types = NULL,
@@ -60,7 +60,7 @@ lav_samplestats_step1 <- function(y,
       th_names[[i]] <- ov_names[i]
       th_idx_1[[i]] <- 0L
       if (scores_flag) {
-        scores <- lav_uvreg_scores(y = y[, i], x = exo, wt = wt)
+        scores <- lav_uvreg_sc(y = y[, i], x = exo, wt = wt)
         sc_th[, th_idx] <- scores[, 1L]
         sc_var[, i] <- scores[, fit$var_idx]
       }
@@ -98,7 +98,7 @@ lav_samplestats_step1 <- function(y,
       fit_nox <- lav_uvord_th(y = y[, i], wt = wt)
       th_nox[[i]] <- fit_nox
       if (scores_flag) {
-        scores <- lav_uvord_scores(y = y[, i], x = exo, wt = wt)
+        scores <- lav_uvord_sc(y = y[, i], x = exo, wt = wt)
       }
 
       if (allow_empty_cell) {

--- a/R/lav_samplestats_step2.R
+++ b/R/lav_samplestats_step2.R
@@ -1,4 +1,4 @@
-lav_samplestats_step2 <- function(uni = NULL,
+lav_samp_step2 <- function(uni = NULL,
                                   wt = NULL,
                                   ov_names = NULL, # error message only
                                   # polychoric and empty cells

--- a/R/lav_samplestats_wls_obs.R
+++ b/R/lav_samplestats_wls_obs.R
@@ -1,4 +1,4 @@
-lav_samplestats_wls_obs <- function(mean_g, cov_g, var_g,
+lav_samp_wls_obs <- function(mean_g, cov_g, var_g,
                                     th_g, th_idx_g,
                                     res_int_g, res_cov_g, res_var_g, res_th_g,
                                     res_slopes_g,
@@ -30,9 +30,9 @@ lav_samplestats_wls_obs <- function(mean_g, cov_g, var_g,
 
       wls_obs <- c(
         th,
-        lav_matrix_vec(res_slopes_g),
+        lav_mat_vec(res_slopes_g),
         res_var_g[num_idx],
-        lav_matrix_vech(res_cov_g, diagonal = FALSE)
+        lav_mat_vech(res_cov_g, diagonal = FALSE)
       )
     } else {
       th <- th_g
@@ -44,7 +44,7 @@ lav_samplestats_wls_obs <- function(mean_g, cov_g, var_g,
       wls_obs <- c(
         th,
         var_g[num_idx],
-        lav_matrix_vech(cov_g, diagonal = FALSE)
+        lav_mat_vech(cov_g, diagonal = FALSE)
       )
     }
   } else {
@@ -60,36 +60,36 @@ lav_samplestats_wls_obs <- function(mean_g, cov_g, var_g,
           # cbind(res.int, res.slopes) is t(Beta)
           # so we need vecr
           wls_obs <- c(
-            lav_matrix_vecr(cbind(
+            lav_mat_vecr(cbind(
               res_int_g,
               res_slopes_g
             )),
-            lav_matrix_vech(res_cov_g, diagonal = diag_1)
+            lav_mat_vech(res_cov_g, diagonal = diag_1)
           )
         } else {
           wls_obs <- c(
             res_int_g,
-            lav_matrix_vech(res_cov_g, diagonal = diag_1)
+            lav_mat_vech(res_cov_g, diagonal = diag_1)
           )
         }
       } else {
         if (slopestructure) {
           wls_obs <- c(
-            lav_matrix_vecr(res_slopes_g),
-            lav_matrix_vech(res_cov_g, diagonal = diag_1)
+            lav_mat_vecr(res_slopes_g),
+            lav_mat_vech(res_cov_g, diagonal = diag_1)
           )
         } else {
-          wls_obs <- lav_matrix_vech(res_cov_g, diagonal = diag_1)
+          wls_obs <- lav_mat_vech(res_cov_g, diagonal = diag_1)
         }
       }
     } else {
       if (meanstructure) {
         wls_obs <- c(
           mean_g,
-          lav_matrix_vech(cov_g, diagonal = diag_1)
+          lav_mat_vech(cov_g, diagonal = diag_1)
         )
       } else {
-        wls_obs <- lav_matrix_vech(cov_g, diagonal = diag_1)
+        wls_obs <- lav_mat_vech(cov_g, diagonal = diag_1)
       }
     }
   }

--- a/R/lav_scores.R
+++ b/R/lav_scores.R
@@ -16,13 +16,13 @@
 # YR 16 Feb 2016: adapt to changed @Mp slot elements; add remove.empty.cases=
 #                 argument
 # YR 12 Mar 2024: make lintr (more) happy; include WLS code from Franz Classe
-#                 move ML-specific code to lav_scores_ml() function
+#                 move ML-specific code to lav_sc_ml() function
 # YR 26 Apr 2025: add lav_scores_gls()
 
-lav_scores <- function(object, scaling = FALSE,                    # nolint start
-                                       ignore.constraints = FALSE,
-                                       remove.duplicated = TRUE,
-                                       remove.empty.cases = TRUE) { # nolint end
+lav_sc <- function(object, scaling = FALSE,
+                           ignore_constraints = FALSE,
+                           remove_duplicated = TRUE,
+                           remove_empty_cases = TRUE) {
   stopifnot(inherits(object, "lavaan"))
 
   # check object
@@ -54,11 +54,11 @@ lav_scores <- function(object, scaling = FALSE,                    # nolint star
   # ntot <- max( object@Data@case.idx[[ object@Data@ngroups ]] )
   ntab <- unlist(lavdata@norig)
   ntot <- sum(ntab)
-  npar <- lav_object_inspect_npar(object, ceq = FALSE)
+  npar <- lav_inspect_npar(object, ceq = FALSE)
 
   if (object@Options$estimator == "ML") {
     moments <- fitted(object)
-    score_matrix <- lav_scores_ml(
+    score_matrix <- lav_sc_ml(
       ntab = ntab, ntot = ntot, npar = npar,
       moments = moments, lavdata = lavdata, lavsamplestats = lavsamplestats,
       lavmodel = lavmodel, lavoptions = lavoptions, scaling = scaling
@@ -73,7 +73,7 @@ lav_scores <- function(object, scaling = FALSE,                    # nolint star
     }
 
     # compute WLS scores
-    score_matrix <- lav_scores_wls(
+    score_matrix <- lav_sc_wls(
       ntab = ntab, ntot = ntot, npar = npar,
       lavdata = lavdata, lavsamplestats = lavsamplestats,
       lavmodel = lavmodel, lavoptions = lavoptions
@@ -81,7 +81,7 @@ lav_scores <- function(object, scaling = FALSE,                    # nolint star
   } else if (!lavmodel@categorical &&
              object@Options$estimator %in% c("GLS", "ULS", "WLS")) {
     # compute WLS/GLS/ULS `scores'
-    score_matrix <- lav_scores_ls(
+    score_matrix <- lav_sc_ls(
       ntab = ntab, ntot = ntot, npar = npar,
       lavdata = lavdata, lavsamplestats = lavsamplestats,
       lavmodel = lavmodel, lavoptions = lavoptions
@@ -92,7 +92,7 @@ lav_scores <- function(object, scaling = FALSE,                    # nolint star
   }
 
   # handle empty rows
-  if (remove.empty.cases) {
+  if (remove_empty_cases) {
     # empty.idx <- which( apply(score_matrix, 1L,
     #                        function(x) sum(is.na(x))) == ncol(score_matrix) )
     empty_idx <- unlist(lapply(lavdata@Mp, "[[", "empty.idx"))
@@ -102,28 +102,28 @@ lav_scores <- function(object, scaling = FALSE,                    # nolint star
   }
 
   # provide column names
-  colnames(score_matrix) <- names(lav_object_inspect_coef(object,
+  colnames(score_matrix) <- names(lav_inspect_coef(object,
     type = "free", add_labels = TRUE
   ))
 
   # handle general constraints, so that the sum of the columns equals zero
-  if (!ignore.constraints &&
+  if (!ignore_constraints &&
     sum(
       lavmodel@ceq.linear.idx, lavmodel@ceq.nonlinear.idx,
       lavmodel@cin.linear.idx, lavmodel@cin.nonlinear.idx
     ) > 0) {
     r_matrix <- object@Model@con.jac[, ]
-    pre <- lav_constraints_lambda_pre(object)
+    pre <- lav_con_lambda_pre(object)
     # LAMBDA <- -1 * t(pre %*% t(score_matrix))
     # RLAMBDA <- t(t(r_matrix) %*% t(LAMBDA))
     score_matrix <- score_matrix - t(t(r_matrix) %*% pre %*% t(score_matrix))
   }
 
   # handle simple equality constraints
-  if (remove.duplicated && lavmodel@eq.constraints) {
-    simple_flag <- lav_constraints_check_simple(lavmodel)
+  if (remove_duplicated && lavmodel@eq.constraints) {
+    simple_flag <- lav_con_check_simple(lavmodel)
     if (simple_flag) {
-      k_matrix <- lav_constraints_r2k(lavmodel)
+      k_matrix <- lav_con_r2k(lavmodel)
       score_matrix <- score_matrix %*% k_matrix
     } else {
       lav_msg_warn(gettext(
@@ -134,10 +134,20 @@ lav_scores <- function(object, scaling = FALSE,                    # nolint star
 
   score_matrix
 }
-lavScores <- lav_scores       # synonym #nolint
-estfun.lavaan <- lav_scores   # synonym
 
-lav_scores_ml <- function(ntab = 0L,
+lavScores <- estfun.lavaan <- function(               # nolint start
+                       object,
+                       scaling = FALSE,
+                       ignore.constraints = FALSE,
+                       remove.duplicated = TRUE,
+                       remove.empty.cases = TRUE) {   # nolint end
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan:::lav_sc)
+  eval(sc, parent.frame())
+}       
+
+lav_sc_ml <- function(ntab = 0L,
                           ntot = 0L,
                           npar = 0L,
                           moments = NULL,
@@ -185,7 +195,7 @@ lav_scores_ml <- function(ntab = 0L,
         dx_sigma <- t(matrix(apply(
           mean_diff, 1L,
           function(x) {
-            lav_matrix_vech(-j2 *
+            lav_mat_vech(-j2 *
               (sigma_inv %*% (tcrossprod(x) * nobs1 - sigma_hat) %*% sigma_inv))
           }
         ), ncol = nrow(mean_diff)))
@@ -196,7 +206,7 @@ lav_scores_ml <- function(ntab = 0L,
         dx_sigma <- t(matrix(apply(
           mean_diff, 1L,
           function(x) {
-            lav_matrix_vech(-j2 *
+            lav_mat_vech(-j2 *
               (sigma_inv %*% (tcrossprod(x) * nobs1 - sigma_hat) %*% sigma_inv))
           }
         ), ncol = nrow(mean_diff)))
@@ -250,7 +260,7 @@ lav_scores_ml <- function(ntab = 0L,
         score_sigma[case_idx, sigma_idx] <- t(matrix(apply(
           mean_diff, 1L,
           function(x) {
-            lav_matrix_vech(-j2 *
+            lav_mat_vech(-j2 *
               (sigma_inv %*% (tcrossprod(x) -
                 sigma_hat[var_idx, var_idx, drop = FALSE]) %*% sigma_inv))
           }
@@ -280,7 +290,7 @@ lav_scores_ml <- function(ntab = 0L,
 
 # this function is based on code originally written by Franz Classe (Munich)
 # for categorical data only!
-lav_scores_wls <- function(ntab = 0L,
+lav_sc_wls <- function(ntab = 0L,
                            ntot = 0L,
                            npar = 0L,
                            lavdata = NULL,
@@ -334,7 +344,7 @@ lav_scores_wls <- function(ntab = 0L,
     mus <- colMeans(x_1)
     y_minus_mu <- t(apply(x_1, 1L, function(x) x - mus))
     s_vech <- t(apply(y_minus_mu, 1L, function(i) {
-      lavaan::lav_matrix_vech(tcrossprod(i), diagonal = FALSE)
+      lavaan::lav_mat_vech(tcrossprod(i), diagonal = FALSE)
     })) # s=c( (y1-mu1)(y2-mu2)....
     sigma <- colMeans(s_vech)
     e2 <- t(apply(s_vech, 1L, function(x) x - sigma))
@@ -355,7 +365,7 @@ lav_scores_wls <- function(ntab = 0L,
 
 
 # wls/gls/uls (continuous data only)
-lav_scores_ls <- function(ntab = 0L,
+lav_sc_ls <- function(ntab = 0L,
                           ntot = 0L,
                           npar = 0L,
                           lavdata = NULL,
@@ -386,8 +396,8 @@ lav_scores_ls <- function(ntab = 0L,
     # create Z where the rows_i contain the following elements:
     #  - Y_i (if meanstructure is TRUE)
     #  - vech(Yc_i' %*% Yc_i) where Yc_i are the residuals
-    idx1 <- lav_matrix_vech_col_idx(nvar)
-    idx2 <- lav_matrix_vech_row_idx(nvar)
+    idx1 <- lav_mat_vech_col_idx(nvar)
+    idx2 <- lav_mat_vech_row_idx(nvar)
     if (lavmodel@meanstructure) {
       z <- cbind(y, yc[, idx1, drop = FALSE] * yc[, idx2, drop = FALSE])
     } else {
@@ -397,9 +407,9 @@ lav_scores_ls <- function(ntab = 0L,
     # model-based sample statistics
     if (lavmodel@meanstructure) {
       sigma <- c(as.numeric(implied$mean[[g]]),
-                 lav_matrix_vech(implied$cov[[g]]))
+                 lav_mat_vech(implied$cov[[g]]))
     } else {
-      sigma <- lav_matrix_vech(implied$cov[[g]])
+      sigma <- lav_mat_vech(implied$cov[[g]])
     }
 
     # adjust sigma for N-1, so that colMeans(scores) == gradient

--- a/R/lav_sem_miiv.R
+++ b/R/lav_sem_miiv.R
@@ -25,7 +25,7 @@ lav_sem_miiv_internal <- function(lavmodel = NULL, lavh1 = NULL,
   stopifnot(iv_varcov_method %in% c("ULS", "GLS", "2RLS", "RLS", "NONE"))
 
   # get lavpta
-  # lavpta <- lav_partable_attributes(lavpartable)
+  # lavpta <- lav_pt_attributes(lavpartable)
 
   # we assume the blocks are independent groups for now
   stopifnot(lavdata@nlevels == 1L)
@@ -52,7 +52,7 @@ lav_sem_miiv_internal <- function(lavmodel = NULL, lavh1 = NULL,
   theta1 <- numeric(0L)
   if (length(free_directed_idx) > 0L) {
     if (iv_samplestats) {
-      theta1 <- lav_sem_miiv_2sls_samplestats(
+      theta1 <- lav_sem_miiv_2sls_samp(
         x = NULL, samplestats = FALSE, eqs = eqs,
         lavmodel = lavmodel, lavpartable = lavpartable,
         lavdata = lavdata, lavsamplestats = lavsamplestats,
@@ -115,7 +115,7 @@ lav_sem_miiv_2sls <- function(eqs = NULL, lavmodel = NULL, lavpartable = NULL,
   stopifnot(iv_vcov_stage1 %in% c("lm.vcov.dfres", "lm.vcov", "none"))
 
   # get lavpta
-  lavpta <- lav_partable_attributes(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
 
   if (is.null(eqs)) {
     # find ALL model-implied instrumental variables (miivs) per equation
@@ -323,7 +323,7 @@ lav_sem_miiv_2sls <- function(eqs = NULL, lavmodel = NULL, lavpartable = NULL,
 #          directed effects in the model -- samplestats version
 # if samplestats = TRUE, x should contain the sample statistics
 # (taken from lavh1$implied)
-lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
+lav_sem_miiv_2sls_samp <- function(x = NULL, samplestats = FALSE,
                                           eqs = NULL, lavmodel = NULL,
                                           lavpartable = NULL, lavdata = NULL,
                                           lavsamplestats = NULL, lavh1 = NULL,
@@ -338,7 +338,7 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
     c("lm.vcov.dfres", "lm.vcov", "gamma", "none"))
 
   # get lavpta
-  lavpta <- lav_partable_attributes(lavpartable)
+  lavpta <- lav_pt_attributes(lavpartable)
 
   if (is.null(eqs)) {
     # find ALL model-implied instrumental variables (miivs) per equation
@@ -436,18 +436,18 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
       fit_y_on_xhat <- list()
       if (iv_flag) {
         # Step 1: compute S_ZZ^{-1} S_ZX and S_ZZ^{-1} S_Zy
-        m_w <- lav_matrix_symmetric_solve_spd(s_zz, s_zx)
-        v <- lav_matrix_symmetric_solve_spd(s_zz, s_zy)
+        m_w <- lav_mat_sym_solve_spd(s_zz, s_zx)
+        v <- lav_mat_sym_solve_spd(s_zz, s_zy)
         # Step 2: build reduced system
         amat <- s_xz %*% m_w
         bvec <- s_xz %*% v
-        beta_slopes <- drop(lav_matrix_symmetric_solve_spd(amat, bvec))
+        beta_slopes <- drop(lav_mat_sym_solve_spd(amat, bvec))
         beta0 <- as.vector(y_bar - t(x_bar) %*% beta_slopes)
       } else {
         if (nx > 0L) {
           amat <- s_xx
           bvec <- s_xy
-          beta_slopes <- drop(lav_matrix_symmetric_solve_spd(amat, bvec))
+          beta_slopes <- drop(lav_mat_sym_solve_spd(amat, bvec))
           beta0 <- as.vector(y_bar - t(x_bar) %*% beta_slopes)
         } else {
           beta_slopes <- numeric(0L)
@@ -468,8 +468,8 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
           ex[cbind(seq_len(nx), x_idx)] <- 1.0
         }
         # ---- Jacobian of beta_slopes w.r.t. vech(S) --------------
-        a_vec <- lav_matrix_vech_row_idx(nvar)
-        b_vec <- lav_matrix_vech_col_idx(nvar)
+        a_vec <- lav_mat_vech_row_idx(nvar)
+        b_vec <- lav_mat_vech_col_idx(nvar)
         offdiag <- (a_vec > b_vec) # logical: strictly off-diagonal elements
 
         if (!iv_flag && nx == 0L) {
@@ -480,10 +480,10 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
           # build M (p x m) column-by-column in vectorised form
           m <- sweep(ex[, b_vec, drop = FALSE], 2L, g[a_vec], `*`) +
             sweep(ex[, a_vec, drop = FALSE], 2L, g[b_vec] * offdiag, `*`)
-          j_slopes_s <- lav_matrix_symmetric_solve_spd(s_xx, m)
+          j_slopes_s <- lav_mat_sym_solve_spd(s_xx, m)
         } else {
           r_z <- drop(s_zy) - s_zx %*% beta_slopes
-          u <- drop(lav_matrix_symmetric_solve_spd(s_zz, r_z))
+          u <- drop(lav_mat_sym_solve_spd(s_zz, r_z))
           ez <- matrix(0.0, nz, nvar)
           ez[cbind(seq_len(nz), i_idx)] <- 1.0
           ew <- crossprod(m_w, ez)
@@ -518,7 +518,7 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
         } else if (lavmodel@categorical) {
           # split: var_num, off
           # FIXME: all ordinal for now (ie no variances)
-          tmp <- j_slopes_s[, -lav_matrix_diagh_idx(nvar), drop = FALSE]
+          tmp <- j_slopes_s[, -lav_mat_diagh_idx(nvar), drop = FALSE]
           nth <- nrow(lavsamplestats@NACOV[[b]]) - ncol(tmp)
           k_mat_int <- numeric(nth + ncol(tmp))
           k_mat <- matrix(0.0, nx, nth + ncol(tmp))
@@ -580,7 +580,7 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
         }
         if (nx > 0L) {
           ainv <-
-            lav_matrix_symmetric_solve_spd(amat, diag(x = 1, nrow = nrow(amat)))
+            lav_mat_sym_solve_spd(amat, diag(x = 1, nrow = nrow(amat)))
           vcov_slopes <- (this_resvar / nobs) * ainv
           vcov_beta0 <-
             (this_resvar / nobs) + t(x_bar) %*% vcov_slopes %*% x_bar
@@ -601,7 +601,7 @@ lav_sem_miiv_2sls_samplestats <- function(x = NULL, samplestats = FALSE,
         sargan["df"] <- nz - nx
         if (sargan["df"] > 0L) {
           g <- s_zy - s_zx %*% beta_slopes
-          w <- lav_matrix_symmetric_solve_spd(s_zz, g)
+          w <- lav_mat_sym_solve_spd(s_zz, g)
           sargan["stat"] <- as.numeric(nobs * t(g) %*% w / resvar_df_res)
           if (!lavmodel@categorical) {
             sargan["pvalue"] <- pchisq(sargan["stat"], sargan["df"],
@@ -696,11 +696,11 @@ lav_sem_miiv_varcov <- function(x = NULL, samplestats = FALSE,
   sample_mean <- implied$mean[[b]]
   if (lavmodel@categorical) {
     sample_th <- implied$th[[b]]
-    svec <- c(sample_th, lav_matrix_vech(sample_cov, diagonal = FALSE))
+    svec <- c(sample_th, lav_mat_vech(sample_cov, diagonal = FALSE))
   } else if (!lavmodel@categorical && lavmodel@meanstructure) {
-    svec <- c(sample_mean, lav_matrix_vech(sample_cov))
+    svec <- c(sample_mean, lav_mat_vech(sample_cov))
   } else {
-    svec <- lav_matrix_vech(sample_cov)
+    svec <- lav_mat_vech(sample_cov)
   }
 
   # initial estimate for theta.2
@@ -836,7 +836,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
           cov_g <- lavh1$implied$cov[[g]]
         }
 #         # NT version (for now), model-based
-#         gamma_g[[g]] <- lav_samplestats_gamma_nt(
+#         gamma_g[[g]] <- lav_samp_gamma_nt(
 #           m_cov = cov_g,
 #           m_mean = mean_g,
 #           x_idx = lavsamplestats@x.idx[[g]],
@@ -849,7 +849,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
       }
     }
     if (!is.null(lavsamplestats@NACOV[[g]])) {
-      gamma_big <- lav_matrix_bdiag(gamma_g)
+      gamma_big <- lav_mat_bdiag(gamma_g)
     }
   }
 
@@ -863,7 +863,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
         drop_list = TRUE
       )
       jac_k <- numDeriv::jacobian(
-        lav_sem_miiv_2sls_samplestats,
+        lav_sem_miiv_2sls_samp,
         x = vec, samplestats = TRUE, eqs = eqs,
         lavmodel = lavmodel, lavpartable = lavpartable,
         lavsamplestats = lavsamplestats,
@@ -892,7 +892,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
         # k_gammant_kt <- jac_k %*% gamma_big %*% t(jac_k)
         x_idx <-
           if (lavmodel@fixed.x) lavsamplestats@x.idx[[1]] else integer(0L)
-        k_gammant_kt <- lav_matrix_k_gammant_kt(m_k = jac_k, s = cov_g,
+        k_gammant_kt <- lav_mat_k_gammant_kt(m_k = jac_k, s = cov_g,
           meanstructure = lavmodel@meanstructure, x_idx = x_idx)
         vcov[free_directed_idx, free_directed_idx] <-
           k_gammant_kt / lavsamplestats@ntotal
@@ -968,16 +968,16 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
       #   } else {
       #     s.inv <- lavimplied$cov[[b]]
       #   }
-      #   w2_22 <- 0.5 * lav_matrix_duplication_pre_post(s.inv %x% s.inv)
+      #   w2_22 <- 0.5 * lav_mat_dup_pre_post(s.inv %x% s.inv)
       #   if (lavmodel@meanstructure) {
-      #     w2_block[[b]] <- lav_matrix_bdiag(s.inv, w2_22)
+      #     w2_block[[b]] <- lav_mat_bdiag(s.inv, w2_22)
       #   } else {
       #     w2_block[[b]] <- w2_22
       #   }
       # } # blocks
       # delta1 <- do.call("rbind", delta1_block)
       # delta2 <- do.call("rbind", delta2_block)
-      # w2 <- lav_matrix_bdiag(w2_block)
+      # w2 <- lav_mat_bdiag(w2_block)
       # h2 <- solve(t(delta2) %*% w2 %*% delta2, t(delta2) %*% w2)
 
       # tmp <- lav_sem_miiv_varcov(
@@ -1037,7 +1037,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
       } else {
         x_idx <-
           if (lavmodel@fixed.x) lavsamplestats@x.idx[[1]] else integer(0L)
-        tmp_gammant_tmpt <- lav_matrix_k_gammant_kt(m_k = tmp, s = cov_g,
+        tmp_gammant_tmpt <- lav_mat_k_gammant_kt(m_k = tmp, s = cov_g,
           meanstructure = lavmodel@meanstructure, x_idx = x_idx)
         #tmp_gammant_tmpt_bis <- tmp %*% gamma_big %*% t(tmp)
         vcov[free_undirected_idx, free_undirected_idx] <-
@@ -1126,7 +1126,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
                                           theta2 = theta2)
           }
         } # blocks
-        jac_b <- lav_matrix_bdiag(jac_b_block)
+        jac_b <- lav_mat_bdiag(jac_b_block)
 
       # for checking only: numerical approximation (very slow!)
       } else {
@@ -1154,7 +1154,7 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
         # )
       }
       x_idx <- if (lavmodel@fixed.x) lavsamplestats@x.idx[[1]] else integer(0L)
-      jacb_gammant_jacbt <- lav_matrix_k_gammant_kt(m_k = jac_b, s = cov_g,
+      jacb_gammant_jacbt <- lav_mat_k_gammant_kt(m_k = jac_b, s = cov_g,
         meanstructure = lavmodel@meanstructure, x_idx = x_idx)
       #jacb_gammant_jacbt_bis <- jac_b %*% gamma_big %*% t(jac_b)
       vcov_b <- jacb_gammant_jacbt / lavsamplestats@ntotal

--- a/R/lav_sem_miiv_utils.R
+++ b/R/lav_sem_miiv_utils.R
@@ -30,7 +30,7 @@ lav_sem_miiv_utils_jacb_uls <- function(sample_cov = NULL, delta2 = NULL) {
 
   # vech
   w <- rep(1.0, pstar)
-  w[lav_matrix_diagh_idx(nvar)] <- 0.5
+  w[lav_mat_diagh_idx(nvar)] <- 0.5
 
   q_cov <- w * jac_cov
   a <- crossprod(jac_cov, q_cov)
@@ -54,11 +54,11 @@ lav_sem_miiv_utils_jacb_gls <- function(sample_cov = NULL, delta2 = NULL,
                                         theta2 = NULL) {
   nvar  <- nrow(sample_cov)
   pstar <- nvar * (nvar + 1L) / 2L
-  s_vech <- lav_matrix_vech(sample_cov)
+  s_vech <- lav_mat_vech(sample_cov)
 
   # vech weights
   w <- rep(1.0, pstar)
-  w[lav_matrix_diagh_idx(nvar)] <- 0.5
+  w[lav_mat_diagh_idx(nvar)] <- 0.5
 
   # only covariance block
   meanstructure_flag <- FALSE
@@ -75,9 +75,9 @@ lav_sem_miiv_utils_jacb_gls <- function(sample_cov = NULL, delta2 = NULL,
   # equivalent to (1/2) W2 %*% delta2
   q_cov <- matrix(0.0, pstar, nc)
   for (j in seq_len(nc)) {
-    v_j <- lav_matrix_vech_reverse(delta2[, j])
+    v_j <- lav_mat_vech_rev(delta2[, j])
     si_vj <- si %*% v_j
-    q_cov[, j] <- w * lav_matrix_vech(si_vj %*% si)
+    q_cov[, j] <- w * lav_mat_vech(si_vj %*% si)
   }
 
   # M_half = (1/2) M = t(delta2) %*% q_cov
@@ -92,16 +92,16 @@ lav_sem_miiv_utils_jacb_gls <- function(sample_cov = NULL, delta2 = NULL,
   }
 
   # error term and GLS correction q_mat = Si %*% e_mat %*% Si
-  e_mat <- lav_matrix_vech_reverse(s_vech - delta2 %*% theta2)
+  e_mat <- lav_mat_vech_rev(s_vech - delta2 %*% theta2)
   q_mat <- si %*% e_mat %*% si
 
   # correction_cov[,j] = w * vech(Tj + t(Tj)),  Tj = Si %*% Vj %*% q_mat
   # equivalent to (1/2) correction %*% delta2
   correction_cov <- matrix(0.0, pstar, nc)
   for (j in seq_len(nc)) {
-    v_j              <- lav_matrix_vech_reverse(delta2[, j])
+    v_j              <- lav_mat_vech_rev(delta2[, j])
     t_j              <- si %*% v_j %*% q_mat
-    correction_cov[, j] <- w * lav_matrix_vech(t_j + t(t_j))
+    correction_cov[, j] <- w * lav_mat_vech(t_j + t(t_j))
   }
 
   # out = M^{-1} %*% t(delta2) %*% (W2 - correction)
@@ -124,11 +124,11 @@ lav_sem_miiv_utils_jacb_2rls <- function(sample_cov = NULL, delta2 = NULL,
 
   nvar  <- nrow(sample_cov)
   pstar <- nvar * (nvar + 1L) / 2L
-  s_vech <- lav_matrix_vech(sample_cov)
+  s_vech <- lav_mat_vech(sample_cov)
 
   # vech weights: 1 for off-diagonal positions, 0.5 for diagonal positions
   w <- rep(1.0, pstar)
-  w[lav_matrix_diagh_idx(nvar)] <- 0.5
+  w[lav_mat_diagh_idx(nvar)] <- 0.5
 
   # only covariance block
   meanstructure_flag <- FALSE
@@ -146,7 +146,7 @@ lav_sem_miiv_utils_jacb_2rls <- function(sample_cov = NULL, delta2 = NULL,
     backsolve(r_uls, forwardsolve(t(r_uls), drop(crossprod(q_uls, s_vech))))
 
   # sigma to be used for GLS estimate
-  sigma <- lav_matrix_vech_reverse(delta2 %*% theta_uls)
+  sigma <- lav_mat_vech_rev(delta2 %*% theta_uls)
   c_si <- chol(sigma)
   sigma_inv <- chol2inv(c_si)
 
@@ -154,8 +154,8 @@ lav_sem_miiv_utils_jacb_2rls <- function(sample_cov = NULL, delta2 = NULL,
   # q_cov[,j] = w * vech(Si Vj Si)  =  (1/2) w2 delta2[,j]
   q_cov <- matrix(0.0, pstar, nc)
   for (j in seq_len(nc)) {
-    v_j <- lav_matrix_vech_reverse(delta2[, j])
-    q_cov[, j] <- w * lav_matrix_vech(sigma_inv %*% v_j %*% sigma_inv)
+    v_j <- lav_mat_vech_rev(delta2[, j])
+    q_cov[, j] <- w * lav_mat_vech(sigma_inv %*% v_j %*% sigma_inv)
   }
   m_sigma_half <- crossprod(delta2, q_cov)
   r_sigma <- chol(m_sigma_half)
@@ -167,14 +167,14 @@ lav_sem_miiv_utils_jacb_2rls <- function(sample_cov = NULL, delta2 = NULL,
   # step 3: correction matrix (as column operations, no c_mat formed)
   # c_cov[,j] = w * vech(Tj + t(Tj)),  Tj = Si Vj q_mat
   #           = (1/2) c_mat delta2[,j]
-  e_mat <- lav_matrix_vech_reverse(s_vech - delta2 %*% theta2)
+  e_mat <- lav_mat_vech_rev(s_vech - delta2 %*% theta2)
   q_mat <- sigma_inv %*% e_mat %*% sigma_inv
 
   c_cov <- matrix(0.0, pstar, nc)
   for (j in seq_len(nc)) {
-    v_j <- lav_matrix_vech_reverse(delta2[, j])
+    v_j <- lav_mat_vech_rev(delta2[, j])
     t_j <- sigma_inv %*% v_j %*% q_mat
-    c_cov[, j] <- w * lav_matrix_vech(t_j + t(t_j))
+    c_cov[, j] <- w * lav_mat_vech(t_j + t(t_j))
   }
 
   # step 4: Jacobian
@@ -201,11 +201,11 @@ lav_sem_miiv_utils_jacb_rls <- function(sample_cov = NULL, delta2 = NULL,
                                         theta2 = NULL) {
   nvar  <- nrow(sample_cov)
   pstar <- nvar * (nvar + 1L) / 2L
-  s_vech <- lav_matrix_vech(sample_cov)
+  s_vech <- lav_mat_vech(sample_cov)
 
   # vech weights: 0.5 for diagonal positions, 1 for off-diagonal positions
   w <- rep(1.0, pstar)
-  w[lav_matrix_diagh_idx(nvar)] <- 0.5
+  w[lav_mat_diagh_idx(nvar)] <- 0.5
 
   # only covariance block
   meanstructure_flag <- FALSE
@@ -219,16 +219,16 @@ lav_sem_miiv_utils_jacb_rls <- function(sample_cov = NULL, delta2 = NULL,
   # Pre-compute vech_reverse of each column of delta2 once; used in the
   # final block (and in the loop when theta2 is not supplied).
   v_list <- vector("list", nc)
-  for (j in seq_len(nc)) v_list[[j]] <- lav_matrix_vech_reverse(delta2[, j])
+  for (j in seq_len(nc)) v_list[[j]] <- lav_mat_vech_rev(delta2[, j])
 
   q_cov <- matrix(0.0, pstar, nc)
 
   # using final theta2 estimate
-  new_sigma <- lav_matrix_vech_reverse(delta2 %*% theta2)
+  new_sigma <- lav_mat_vech_rev(delta2 %*% theta2)
   c_si       <- chol(new_sigma)
   sigma_inv <- chol2inv(c_si)
   for (j in seq_len(nc)) {
-    q_cov[, j] <- w * lav_matrix_vech(sigma_inv %*% v_list[[j]] %*% sigma_inv)
+    q_cov[, j] <- w * lav_mat_vech(sigma_inv %*% v_list[[j]] %*% sigma_inv)
   }
   m_mat <- crossprod(delta2, q_cov)
   r_mat <- chol(m_mat)
@@ -236,12 +236,12 @@ lav_sem_miiv_utils_jacb_rls <- function(sample_cov = NULL, delta2 = NULL,
   # correction columns: c_cov[,j] = w * vech(Tj + t(Tj)),  Tj = Si Vj q_mat
   # where q_mat = Si e_mat Si.
   # JW_theta2 = -c_cov  (dW_e2_from_v(delta2[,j]) = -c_cov[,j], derived above)
-  e_mat <- lav_matrix_vech_reverse(s_vech - delta2 %*% theta2)
+  e_mat <- lav_mat_vech_rev(s_vech - delta2 %*% theta2)
   q_mat <- sigma_inv %*% e_mat %*% sigma_inv
   c_cov <- matrix(0.0, pstar, nc)
   for (j in seq_len(nc)) {
     t_j <- sigma_inv %*% v_list[[j]] %*% q_mat
-    c_cov[, j] <- w * lav_matrix_vech(t_j + t(t_j))
+    c_cov[, j] <- w * lav_mat_vech(t_j + t(t_j))
   }
 
   # Jacobian:
@@ -292,7 +292,7 @@ lav_sem_miiv_utils_jaca_uls_gls <- function(lavmodel = NULL,  # nolint
     # s_vech
     sample_cov <- lavh1$implied$cov[[b]]
     nvar <- nrow(sample_cov)
-    s_vech <- lav_matrix_vech(sample_cov)
+    s_vech <- lav_mat_vech(sample_cov)
 
     # delta2
     delta2 <- delta_block[[b]][, free_undirected_idx, drop = FALSE]
@@ -306,7 +306,7 @@ lav_sem_miiv_utils_jaca_uls_gls <- function(lavmodel = NULL,  # nolint
     } else {
       s_inv <- diag(1, nrow = nrow(sample_cov))
     }
-    w2_22 <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+    w2_22 <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
     w2 <- w2_22
 
     # MLIST
@@ -355,7 +355,7 @@ lav_sem_miiv_utils_jaca_uls_gls <- function(lavmodel = NULL,  # nolint
             i = d_row, j = d_col, k = un_row, l = un_col
           )
         }
-        d_deltak[, i] <- lav_matrix_vech(tmp)
+        d_deltak[, i] <- lav_mat_vech(tmp)
       }
       jac_a[, k] <-
         m_inv %*% (t(d_deltak) %*% w2e - delta2tw2 %*% d_deltak %*% theta2)
@@ -393,7 +393,7 @@ lav_sem_miiv_utils_jaca_2rls <- function(lavmodel = NULL,
     # s_vech
     sample_cov <- lavh1$implied$cov[[b]]
     nvar <- nrow(sample_cov)
-    s_vech <- lav_matrix_vech(sample_cov)
+    s_vech <- lav_mat_vech(sample_cov)
 
     # delta2
     delta2 <- delta_block[[b]][, free_undirected_idx, drop = FALSE]
@@ -402,7 +402,7 @@ lav_sem_miiv_utils_jaca_2rls <- function(lavmodel = NULL,
     }
     # w2
     s_inv <- diag(1, nrow = nrow(sample_cov))
-    w2_uls <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+    w2_uls <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
 
     # MLIST
     mm_in_group <- seq_len(lavmodel@nmat[b]) + cumsum(c(0, lavmodel@nmat))[b]
@@ -417,14 +417,14 @@ lav_sem_miiv_utils_jaca_2rls <- function(lavmodel = NULL,
     theta_uls <- drop(m_uls_inv %*% t(delta2) %*% w2_uls %*% s_vech)
 
     # step 2
-    new_sigma <- lav_matrix_vech_reverse(delta2 %*% theta_uls)
+    new_sigma <- lav_mat_vech_rev(delta2 %*% theta_uls)
     sigma_inv <- solve(new_sigma)
-    w2 <- 0.5 * lav_matrix_duplication_pre_post(sigma_inv %x% sigma_inv)
+    w2 <- 0.5 * lav_mat_dup_pre_post(sigma_inv %x% sigma_inv)
     m_mat <- t(delta2) %*% w2 %*% delta2
     m_mat_inv <- solve(m_mat)
     theta2 <- drop(m_mat_inv %*% t(delta2) %*% w2 %*% s_vech)
     e2 <- s_vech - delta2 %*% theta2
-    e_mat <- lav_matrix_vech_reverse(e2)
+    e_mat <- lav_mat_vech_rev(e2)
 
     # pre-compute
     minv_delta2t <- m_mat_inv %*% t(delta2)
@@ -464,12 +464,12 @@ lav_sem_miiv_utils_jaca_2rls <- function(lavmodel = NULL,
             i = d_row, j = d_col, k = un_row, l = un_col
           )
         }
-        d_deltak[, i] <- lav_matrix_vech(tmp)
+        d_deltak[, i] <- lav_mat_vech(tmp)
       }
 
       # d vech(Sigma)/d theta1[k]: product rule on unvech(Delta2 theta_uls)
       v_k <- d_deltak %*% theta_uls + delta2 %*% jac_uls[, k]
-      d_sigma_k <- lav_matrix_vech_reverse(v_k)
+      d_sigma_k <- lav_mat_vech_rev(v_k)
 
       # d_sigma_inv = -sigma.inv dSigma_k sigma.inv
       d_sigma_inv <- -sigma_inv %*% d_sigma_k %*% sigma_inv
@@ -479,7 +479,7 @@ lav_sem_miiv_utils_jaca_2rls <- function(lavmodel = NULL,
       # D^T vec(sigma_inv e_mat dsigma_inv_k + dsigma_invk e_mat sigma_inv)
       sym_part <- sigma_inv_e %*% d_sigma_inv + d_sigma_inv %*% t(sigma_inv_e)
       dw2_e2 <-
-        0.5 * drop(lav_matrix_duplication_pre(as.matrix(as.vector(sym_part))))
+        0.5 * drop(lav_mat_dup_pre(as.matrix(as.vector(sym_part))))
 
       # term 1: direct delta2 variation in final WLS
       term1 <-
@@ -516,7 +516,7 @@ lav_sem_miiv_utils_jaca_rls <- function(lavmodel = NULL,
     # s_vech
     sample_cov <- lavh1$implied$cov[[b]]
     nvar <- nrow(sample_cov)
-    s_vech <- lav_matrix_vech(sample_cov)
+    s_vech <- lav_mat_vech(sample_cov)
 
     # delta2
     delta2 <- delta_block[[b]][, free_undirected_idx, drop = FALSE]
@@ -526,7 +526,7 @@ lav_sem_miiv_utils_jaca_rls <- function(lavmodel = NULL,
 
     # w2
     s_inv <- diag(1, nrow = nrow(sample_cov))
-    w2_uls <- 0.5 * lav_matrix_duplication_pre_post(s_inv %x% s_inv)
+    w2_uls <- 0.5 * lav_mat_dup_pre_post(s_inv %x% s_inv)
 
     # MLIST
     mm_in_group <- seq_len(lavmodel@nmat[b]) + cumsum(c(0, lavmodel@nmat))[b]
@@ -544,22 +544,22 @@ lav_sem_miiv_utils_jaca_rls <- function(lavmodel = NULL,
     theta2 <- theta_uls
     for (i in seq_len(200)) {
       old_x <- theta2
-      new_sigma <- lav_matrix_vech_reverse(delta2 %*% theta2)
+      new_sigma <- lav_mat_vech_rev(delta2 %*% theta2)
       sigma_inv <- solve(new_sigma)
-      w2 <- 0.5 * lav_matrix_duplication_pre_post(sigma_inv %x% sigma_inv)
+      w2 <- 0.5 * lav_mat_dup_pre_post(sigma_inv %x% sigma_inv)
       m_mat <- t(delta2) %*% w2 %*% delta2
       theta2 <- drop(solve(m_mat, t(delta2) %*% w2 %*% s_vech))
       if (sum((old_x - theta2)^2) < 1e-12 * (1 + sum(theta2^2))) break
     }
 
     # final quantities
-    new_sigma <- lav_matrix_vech_reverse(delta2 %*% theta2)
+    new_sigma <- lav_mat_vech_rev(delta2 %*% theta2)
     sigma_inv <- solve(new_sigma)
-    w2 <- 0.5 * lav_matrix_duplication_pre_post(sigma_inv %x% sigma_inv)
+    w2 <- 0.5 * lav_mat_dup_pre_post(sigma_inv %x% sigma_inv)
     m_mat <- t(delta2) %*% w2 %*% delta2
     m_mat_inv <- solve(m_mat)
     e2 <- s_vech - delta2 %*% theta2
-    e_mat <- lav_matrix_vech_reverse(e2)
+    e_mat <- lav_mat_vech_rev(e2)
     sigma_inv_e <- sigma_inv %*% e_mat
 
     minv_delta2t <- m_mat_inv %*% t(delta2)
@@ -568,11 +568,11 @@ lav_sem_miiv_utils_jaca_rls <- function(lavmodel = NULL,
 
     # helper: compute (dW)e2 given d vech(Sigma) as a vector v
     d_w_e2_from_v <- function(v) {
-      d_sigma <- lav_matrix_vech_reverse(v)
+      d_sigma <- lav_mat_vech_rev(v)
       d_sigma_inv <- -sigma_inv %*% d_sigma %*% sigma_inv
       sym_part <- sigma_inv_e %*% d_sigma_inv + d_sigma_inv %*% t(sigma_inv_e)
       dw2_e2 <-
-        0.5 * drop(lav_matrix_duplication_pre(as.matrix(as.vector(sym_part))))
+        0.5 * drop(lav_mat_dup_pre(as.matrix(as.vector(sym_part))))
       dw2_e2
     }
 
@@ -617,7 +617,7 @@ lav_sem_miiv_utils_jaca_rls <- function(lavmodel = NULL,
             i = d_row, j = d_col, k = un_row, l = un_col
           )
         }
-        d_deltak[, i] <- lav_matrix_vech(tmp)
+        d_deltak[, i] <- lav_mat_vech(tmp)
       }
 
       # term 1: direct delta2 variation in final WLS

--- a/R/lav_simulate_old.R
+++ b/R/lav_simulate_old.R
@@ -67,27 +67,27 @@ lav_data_simulate_old <- function( # user-specified model    # nolint start
       lav_msg_stop(gettext("model is a list, but not a parameterTable?"))
     }
   } else {
-    lav <- lav_model_partable(
+    lav <- lav_model_pt(
       model = model,
       meanstructure = meanstructure,
-      int.ov.free = int.ov.free,
-      int.lv.free = int.lv.free,
-      marker.int.zero = marker.int.zero,
+      int_ov_free = int.ov.free,
+      int_lv_free = int.lv.free,
+      marker_int_zero = marker.int.zero,
       composites = composites,
-      conditional.x = conditional.x,
-      fixed.x = fixed.x,
+      conditional_x = conditional.x,
+      fixed_x = fixed.x,
       orthogonal = orthogonal,
-      std.lv = std.lv,
-      auto.fix.first = auto.fix.first,
-      auto.fix.single = auto.fix.single,
-      auto.var = auto.var,
-      auto.cov.lv.x = auto.cov.lv.x,
-      auto.cov.y = auto.cov.y,
+      std_lv = std.lv,
+      auto_fix_first = auto.fix.first,
+      auto_fix_single = auto.fix.single,
+      auto_var = auto.var,
+      auto_cov_lv_x = auto.cov.lv.x,
+      auto_cov_y = auto.cov.y,
       ngroups = length(sample.nobs)
     )
   }
 
-  group_values <- lav_partable_group_values(lav)
+  group_values <- lav_pt_group_values(lav)
   if (lav_debug()) {
     cat("initial lav\n")
     print(as.data.frame(lav))
@@ -141,12 +141,12 @@ lav_data_simulate_old <- function( # user-specified model    # nolint start
     # for ordered observed variables, we will get '0.0', but that is ok
     # so there is no need to make a distinction between numeric/ordered
     # here??
-    ngroups <- lav_partable_ngroups(lav)
-    ov_names <- lav_partable_vnames(lav, "ov")
-    ov_nox <- lav_partable_vnames(lav, "ov.nox")
-    # lv_names <- lav_partable_vnames(lav, "lv")
-    # lv_y <- lav_partable_vnames(lav, "lv.y")
-    lv_nox <- lav_partable_vnames(lav, "lv.nox")
+    ngroups <- lav_pt_ngroups(lav)
+    ov_names <- lav_pt_vnames(lav, "ov")
+    ov_nox <- lav_pt_vnames(lav, "ov.nox")
+    # lv_names <- lav_pt_vnames(lav, "lv")
+    # lv_y <- lav_pt_vnames(lav, "lv.y")
+    lv_nox <- lav_pt_vnames(lav, "lv.nox")
     ov_var_idx <- which(lav$op == "~~" & lav$lhs %in% ov_nox &
       lav$rhs == lav$lhs)
     lv_var_idx <- which(lav$op == "~~" & lav$lhs %in% lv_nox &
@@ -321,9 +321,9 @@ lav_data_simulate_old <- function( # user-specified model    # nolint start
     }
 
     # any categorical variables?
-    ov_ord <- lav_partable_vnames(lav, type = "ov.ord", group = group_values[g])
+    ov_ord <- lav_pt_vnames(lav, type = "ov.ord", group = group_values[g])
     if (length(ov_ord) > 0L) {
-      ov_names <- lav_partable_vnames(lav, type = "ov", group = group_values[g])
+      ov_names <- lav_pt_vnames(lav, type = "ov", group = group_values[g])
       # use thresholds to cut
       for (o in ov_ord) {
         o_idx <- which(o == ov_names)
@@ -353,7 +353,7 @@ lav_data_simulate_old <- function( # user-specified model    # nolint start
       }
       data_1$group <- rep(1:ngroups, times = sample.nobs)
     }
-    var_names <- lav_partable_vnames(fit@ParTable, type = "ov", group = 1L)
+    var_names <- lav_pt_vnames(fit@ParTable, type = "ov", group = 1L)
     if (ngroups > 1L) var_names <- c(var_names, "group")
     names(data_1) <- var_names
     if (return.fit) {

--- a/R/lav_standardize.R
+++ b/R/lav_standardize.R
@@ -120,7 +120,7 @@ lav_standardize_lv <- function(lavobject = NULL,
     lavmodel <- lavobject@Model
     lavpartable <- lavobject@ParTable
     if (is.null(est)) {
-      est <- lav_object_inspect_est(lavobject)
+      est <- lav_inspect_est(lavobject)
     }
   }
 
@@ -152,9 +152,9 @@ lav_standardize_lv <- function(lavobject = NULL,
   }
 
   for (g in 1:lavmodel@nblocks) {
-    ov_names <- lav_partable_vnames(lavpartable, "ov", block = g) # not user,
+    ov_names <- lav_pt_vnames(lavpartable, "ov", block = g) # not user,
     # which may be incomplete
-    lv_names <- lav_partable_vnames(lavpartable, "lv", block = g)
+    lv_names <- lav_pt_vnames(lavpartable, "lv", block = g)
 
     # shortcut: no latents in this block, nothing to do
     if (length(lv_names) == 0L) {
@@ -179,7 +179,7 @@ lav_standardize_lv <- function(lavobject = NULL,
     # (based on Kelava & Brandt, 2022; Brandt et al., 2015)
     # For interaction terms A:B, the standardized coefficient should use
     # SD(A)*SD(B) instead of SD(A:B) (Eq. 13 in Brandt et al., 2015).
-    lv_int_names <- lav_partable_vnames(lavpartable, "lv.interaction",
+    lv_int_names <- lav_pt_vnames(lavpartable, "lv.interaction",
       block = g
     )
 
@@ -422,7 +422,7 @@ lav_standardize_all <- function(lavobject = NULL,
     lavmodel <- lavobject@Model
     lavpartable <- lavobject@ParTable
     if (is.null(est)) {
-      est <- lav_object_inspect_est(lavobject)
+      est <- lav_inspect_est(lavobject)
     }
     if (lavmodel@conditional.x) {
       if (is.null(cov_x)) {
@@ -474,8 +474,8 @@ lav_standardize_all <- function(lavobject = NULL,
 
 
   for (g in 1:lavmodel@nblocks) {
-    ov_names <- lav_partable_vnames(lavpartable, "ov", block = g) # not user
-    lv_names <- lav_partable_vnames(lavpartable, "lv", block = g)
+    ov_names <- lav_pt_vnames(lavpartable, "ov", block = g) # not user
+    lv_names <- lav_pt_vnames(lavpartable, "lv", block = g)
 
     if (is.null(ov_var)) {
       ov2 <- vy[[g]]
@@ -499,8 +499,8 @@ lav_standardize_all <- function(lavobject = NULL,
 
     if (lavmodel@conditional.x) {
       # extend OV with ov.names.x
-      ov_names_x <- lav_partable_vnames(lavpartable, "ov.x", block = g)
-      ov_names_nox <- lav_partable_vnames(lavpartable, "ov.nox", block = g)
+      ov_names_x <- lav_pt_vnames(lavpartable, "ov.x", block = g)
+      ov_names_nox <- lav_pt_vnames(lavpartable, "ov.nox", block = g)
       ov_names <- c(ov_names_nox, ov_names_x)
       ov2 <- c(ov2, diag(cov_x[[g]]))
       ov <- c(ov, sqrt(diag(cov_x[[g]])))
@@ -660,7 +660,7 @@ lav_standardize_all_nox <- function(lavobject = NULL,
     lavmodel <- lavobject@Model
     lavpartable <- lavobject@ParTable
     if (is.null(est)) {
-      est <- lav_object_inspect_est(lavobject)
+      est <- lav_inspect_est(lavobject)
     }
     if (lavmodel@conditional.x) {
       if (is.null(cov_x)) {
@@ -713,10 +713,10 @@ lav_standardize_all_nox <- function(lavobject = NULL,
 
 
   for (g in 1:lavmodel@nblocks) {
-    ov_names <- lav_partable_vnames(lavpartable, "ov", block = g)
-    ov_names_x <- lav_partable_vnames(lavpartable, "ov.x", block = g)
-    ov_names_nox <- lav_partable_vnames(lavpartable, "ov.nox", block = g)
-    lv_names <- lav_partable_vnames(lavpartable, "lv", block = g)
+    ov_names <- lav_pt_vnames(lavpartable, "ov", block = g)
+    ov_names_x <- lav_pt_vnames(lavpartable, "ov.x", block = g)
+    ov_names_nox <- lav_pt_vnames(lavpartable, "ov.nox", block = g)
+    lv_names <- lav_pt_vnames(lavpartable, "lv", block = g)
 
     if (is.null(ov_var)) {
       ov2 <- vy[[g]]
@@ -741,7 +741,7 @@ lav_standardize_all_nox <- function(lavobject = NULL,
 
     if (lavmodel@conditional.x) {
       # extend OV with ov.names.x
-      ov_names_x <- lav_partable_vnames(lavpartable, "ov.x", block = g)
+      ov_names_x <- lav_pt_vnames(lavpartable, "ov.x", block = g)
       ov_names <- c(ov_names_nox, ov_names_x)
       ov2 <- c(ov2, diag(cov_x[[g]]))
       ov <- c(ov, sqrt(diag(cov_x[[g]])))
@@ -899,7 +899,7 @@ lav_unstandardize_ov <- function(partable, ov_var = NULL, cov_std = TRUE) {
   # n <- length(est)
 
   # nblocks
-  nblocks <- lav_partable_nblocks(partable)
+  nblocks <- lav_pt_nblocks(partable)
 
   # if ov.var is NOT a list, make a list
   if (!is.list(ov_var)) {
@@ -909,8 +909,8 @@ lav_unstandardize_ov <- function(partable, ov_var = NULL, cov_std = TRUE) {
   }
 
   for (g in 1:nblocks) {
-    ov_names <- lav_partable_vnames(partable, "ov", block = g) # not user
-    lv_names <- lav_partable_vnames(partable, "lv", block = g)
+    ov_names <- lav_pt_vnames(partable, "ov", block = g) # not user
+    lv_names <- lav_pt_vnames(partable, "lv", block = g)
 
     ov <- sqrt(ov_var[[g]])
 

--- a/R/lav_start.R
+++ b/R/lav_start.R
@@ -34,7 +34,7 @@ lav_start <- function(start_method = "default",
   # ord.names <- unique(lavpartable$lhs[ lavpartable$op == "|" ])
 
   # nlevels?
-  nlevels <- lav_partable_nlevels(lavpartable)
+  nlevels <- lav_pt_nlevels(lavpartable)
 
   # reflect/order.lv.by
   if (is.null(reflect)) {
@@ -72,7 +72,7 @@ lav_start <- function(start_method = "default",
       #    start[ which(lavpartable$op == "=~") ] <- 1.0
       # }
       start[which(lavpartable$op == "~*~")] <- 1.0
-      ov_names_ord <- lav_partable_vnames(lavpartable, "ov.ord")
+      ov_names_ord <- lav_pt_vnames(lavpartable, "ov.ord")
       var_idx <- which(lavpartable$op == "~~" &
         lavpartable$lhs == lavpartable$rhs &
         !(lavpartable$lhs %in% ov_names_ord))
@@ -139,7 +139,7 @@ lav_start <- function(start_method = "default",
   }
 
   # 2. (residual) lv variances for latent variables
-  lv_names <- lav_partable_vnames(lavpartable, "lv") # all groups
+  lv_names <- lav_pt_vnames(lavpartable, "lv") # all groups
   lv_var_idx <- which(lavpartable$op == "~~" &
     lavpartable$lhs %in% lv_names &
     lavpartable$lhs == lavpartable$rhs)
@@ -152,7 +152,7 @@ lav_start <- function(start_method = "default",
 
 
   # group-specific settings
-  ngroups <- lav_partable_ngroups(lavpartable)
+  ngroups <- lav_pt_ngroups(lavpartable)
 
   # for now, if no group column, add one (again), until we rewrite
   # this function to handle block/group hybrid settings
@@ -162,35 +162,35 @@ lav_start <- function(start_method = "default",
   }
 
   # group values
-  group_values <- lav_partable_group_values(lavpartable)
+  group_values <- lav_pt_group_values(lavpartable)
 
   for (g in 1:ngroups) {
 
     # info from user model for this group
     if (conditional_x) {
-      ov_names <- lav_partable_vnames(lavpartable, "ov.nox",
+      ov_names <- lav_pt_vnames(lavpartable, "ov.nox",
                                                 group = group_values[g])
     } else {
-      ov_names <- lav_partable_vnames(lavpartable, "ov",
+      ov_names <- lav_pt_vnames(lavpartable, "ov",
                                                 group = group_values[g])
     }
     if (categorical) {
-      ov_names_num <- lav_partable_vnames(lavpartable, "ov.num",
+      ov_names_num <- lav_pt_vnames(lavpartable, "ov.num",
                                                 group = group_values[g])
-      ov_names_ord <- lav_partable_vnames(lavpartable, "ov.ord",
+      ov_names_ord <- lav_pt_vnames(lavpartable, "ov.ord",
                                                 group = group_values[g])
     } else {
       ov_names_num <- ov_names
     }
-    lv_names <- lav_partable_vnames(lavpartable, "lv",
+    lv_names <- lav_pt_vnames(lavpartable, "lv",
                                                  group = group_values[g])
-    lv_names_efa <- lav_partable_vnames(lavpartable, "lv.efa",
+    lv_names_efa <- lav_pt_vnames(lavpartable, "lv.efa",
                                                  group = group_values[g])
-    ov_names_x <- lav_partable_vnames(lavpartable, "ov.x",
+    ov_names_x <- lav_pt_vnames(lavpartable, "ov.x",
                                                  group = group_values[g])
-    ov_ind_c <- lav_partable_vnames(lavpartable, "ov.cind",
+    ov_ind_c <- lav_pt_vnames(lavpartable, "ov.cind",
                                                  group = group_values[g])
-    lv_names_c <- lav_partable_vnames(lavpartable, "lv.composite",
+    lv_names_c <- lav_pt_vnames(lavpartable, "lv.composite",
                                                  group = group_values[g])
 
     # just for the nlevels >1 case
@@ -360,9 +360,9 @@ lav_start <- function(start_method = "default",
       } # fabin3
 
       # efa?
-      nefa <- lav_partable_nefa(lavpartable)
+      nefa <- lav_pt_nefa(lavpartable)
       if (nefa > 0L) {
-        efa_values <- lav_partable_efa_values(lavpartable)
+        efa_values <- lav_pt_efa_values(lavpartable)
 
         for (set in seq_len(nefa)) {
           # determine ov idx for this set
@@ -541,7 +541,7 @@ lav_start <- function(start_method = "default",
       th_names_sample <-
         lavsamplestats@th.names[[g]][lavsamplestats@th.idx[[g]] > 0L]
       # th.names.sample should identical to
-      # lav_partable_vnames(lavpartable, "th", group = group.values[g])
+      # lav_pt_vnames(lavpartable, "th", group = group.values[g])
       if (conditional_x && nlevels == 1L) {
         th_values <-
           lavsamplestats@res.th[[g]][lavsamplestats@th.idx[[g]] > 0L]
@@ -601,7 +601,7 @@ lav_start <- function(start_method = "default",
     }
 
     # 6b. exogenous lv variances if single indicator -- new in 0.5-21
-    lv_x <- lav_partable_vnames(lavpartable, "lv.x", group = group_values[g])
+    lv_x <- lav_pt_vnames(lavpartable, "lv.x", group = group_values[g])
     # FIXME: also for multilevel?
     lv_x <- unique(unlist(lv_x))
     if (length(lv_x) > 0L) {
@@ -699,9 +699,9 @@ lav_start <- function(start_method = "default",
     }
 
     #  # 8 latent variances (new in 0.6-2)
-    #  lv.names.y <- lav_partable_vnames(lavpartable,
+    #  lv.names.y <- lav_pt_vnames(lavpartable,
     #                               "lv.y", group = group.values[g])
-    #  lv.names.x <- lav_partable_vnames(lavpartable,
+    #  lv.names.x <- lav_pt_vnames(lavpartable,
     #                               "lv.x", group = group.values[g])
     #  # multilevel? take first level only
     #  if(is.list(lv.names.y)) {
@@ -770,17 +770,17 @@ lav_start <- function(start_method = "default",
 
     # nlevels > 1L
     if (nlevels > 1L) {
-      level_values <- lav_partable_level_values(lavpartable)
+      level_values <- lav_pt_level_values(lavpartable)
       # Note: ov.names.x contains all levels within a group!
       if (length(ov_names_x) > 0) {
         for (l in 1:nlevels) {
           # block number
           block <- (g - 1L) * nlevels + l
 
-          this_block_x <- lav_partable_vnames(lavpartable, "ov.x",
+          this_block_x <- lav_pt_vnames(lavpartable, "ov.x",
             block = block
           )
-          this_block_ov <- lav_partable_vnames(lavpartable, "ov",
+          this_block_ov <- lav_pt_vnames(lavpartable, "ov",
             block = block
           )
           if (length(this_block_x) == 0L) {
@@ -847,7 +847,7 @@ lav_start <- function(start_method = "default",
                "lavh1 information is needed; please rerun with h1 = TRUE"))
             }
             blocks_within_group <- (g - 1L) * nlevels + seq_len(nlevels)
-            other_block_names <- lav_partable_vnames(lavpartable, "ov",
+            other_block_names <- lav_pt_vnames(lavpartable, "ov",
                                     block = blocks_within_group[-block])
             ov_names_x_block <- this_block_x
             idx <- which(ov_names_x_block %in% other_block_names)
@@ -1046,12 +1046,12 @@ lav_start <- function(start_method = "default",
 # sanity check: (user-specified) variances smaller than covariances
 # but not for composites, as we have not 'set' their variances yet
 lav_start_check_cov <- function(lavpartable = NULL, start = lavpartable$start) {
-  nblocks <- lav_partable_nblocks(lavpartable)
-  block_values <- lav_partable_block_values(lavpartable)
+  nblocks <- lav_pt_nblocks(lavpartable)
+  block_values <- lav_pt_block_values(lavpartable)
 
   for (g in 1:nblocks) {
 
-    lv_names_c <- lav_partable_vnames(lavpartable, "lv.composite", block = g)
+    lv_names_c <- lav_pt_vnames(lavpartable, "lv.composite", block = g)
 
     # collect all non-zero covariances
     cov_idx <- which(lavpartable$op == "~~" &

--- a/R/lav_syntax.R
+++ b/R/lav_syntax.R
@@ -567,7 +567,7 @@ other (observed) variable in the model syntax. Problematic term is: "),
   }
 
   # new in 0.6, reorder covariances here!
-  flat <- lav_partable_covariance_reorder(flat)
+  flat <- lav_pt_covariance_reorder(flat)
 
   if (as_data_frame) {
     flat <- as.data.frame(flat, stringsAsFactors = FALSE)

--- a/R/lav_syntax_parser.R
+++ b/R/lav_syntax_parser.R
@@ -1081,7 +1081,7 @@ assign("equal", function(...) {
     }
   }
   # new in 0.6, reorder covariances here!
-  flat <- lav_partable_covariance_reorder(flat)
+  flat <- lav_pt_covariance_reorder(flat)
   if (as_data_frame) {
     flat <- as.data.frame(flat, stringsAsFactors = FALSE)
   }

--- a/R/lav_tables.R
+++ b/R/lav_tables.R
@@ -904,7 +904,7 @@ lav_tables_pairwise_freq_cell <- function(lavdata = NULL,
           nobs = rep.int(sum(freq), ncell),
           row = rep.int(seq_len(nrow), times = ncol),
           col = rep(seq_len(ncol), each = nrow),
-          obs.freq = lav_matrix_vec(freq) # col by col!
+          obs.freq = lav_mat_vec(freq) # col by col!
         )
       }
     )
@@ -976,7 +976,7 @@ lav_tables_pairwise_model_pi <- function(lavobject = NULL) {
       )
     } else {
       pi_group <- integer(0)
-      # order! first i, then j, lav_matrix_vec(table)!
+      # order! first i, then j, lav_mat_vec(table)!
       for (i in seq_len(nvar - 1L)) {
         for (j in (i + 1L):nvar) {
           if (ov_types[i] == "ordered" && ov_types[j] == "ordered") {
@@ -985,7 +985,7 @@ lav_tables_pairwise_model_pi <- function(lavobject = NULL) {
               th_y1 = th[[g]][th_idx[[g]] == i],
               th_y2 = th[[g]][th_idx[[g]] == j]
             )
-            pi_group <- c(pi_group, lav_matrix_vec(pi_table))
+            pi_group <- c(pi_group, lav_mat_vec(pi_table))
           }
         }
       }
@@ -1058,7 +1058,7 @@ lav_tables_pairwise_sample_pi_cor <- function(cor_1 = NULL, th = NULL, # nolint
     ov_types[ord_idx] <- "ordered"
 
     pi_group <- integer(0)
-    # order! first i, then j, lav_matrix_vec(table)!
+    # order! first i, then j, lav_mat_vec(table)!
     for (i in seq_len(nvar - 1L)) {
       for (j in (i + 1L):nvar) {
         if (ov_types[i] == "ordered" && ov_types[j] == "ordered") {
@@ -1067,7 +1067,7 @@ lav_tables_pairwise_sample_pi_cor <- function(cor_1 = NULL, th = NULL, # nolint
             th_y1 = th[[g]][th_idx_1 == i],
             th_y2 = th[[g]][th_idx_1 == j]
           )
-          pi_group <- c(pi_group, lav_matrix_vec(pi_table))
+          pi_group <- c(pi_group, lav_mat_vec(pi_table))
         }
       }
     }
@@ -1327,7 +1327,7 @@ lav_tables_cells_format <- function(out, lavdata = lavdata,
 
 
 
-# The function lav_tables_univariate_freq_cell computes the univariate (one-way)
+# The function lav_tables_uni_freq_cell computes the univariate (one-way)
 # frequency tables.
 # The function closely follows the "logic" of the lavaan function
 # lav_tables_pairwise_freq_cell.
@@ -1351,7 +1351,7 @@ lav_tables_cells_format <- function(out, lavdata = lavdata,
 #    second group and so on. The last table has the index equal to
 #                                   (no of groups) * (no of variables).
 
-lav_tables_univariate_freq_cell <- function(lavdata = NULL,   # nolint
+lav_tables_uni_freq_cell <- function(lavdata = NULL,
                                             as_data_frame = TRUE) {
   # shortcuts
   vartable <- as.data.frame(lavdata@ov, stringsAsFactors = FALSE)

--- a/R/lav_test.R
+++ b/R/lav_test.R
@@ -2,7 +2,7 @@
 # comparing the current model versus the saturated/unrestricted model
 # TDJ 9 April 2024: Add a (hidden) function to update the @test slot
 #                   when the user provides a custom h1 model.  Called by
-#                   lav_object_summary and lav_fit_measures(_check_baseline)
+#                   lav_object_summary and lav_fit(_check_baseline)
 
 lavTest <- function(lavobject, test = "standard",               # nolint start
                     scaled.test = "standard",
@@ -279,7 +279,7 @@ lav_model_test <- function(lavobject = NULL,
   # lavobject?
   if (!is.null(lavobject)) {
     lavmodel <- lavobject@Model
-    lavpartable <- lav_partable_set_cache(lavobject@ParTable, lavobject@pta)
+    lavpartable <- lav_pt_set_cache(lavobject@ParTable, lavobject@pta)
     lavsamplestats <- lavobject@SampleStats
     lavimplied <- lavobject@implied
     lavh1 <- lavobject@h1
@@ -305,7 +305,7 @@ lav_model_test <- function(lavobject = NULL,
   test_1 <- list()
 
   # degrees of freedom (ignoring constraints)
-  df <- lav_partable_df(lavpartable)
+  df <- lav_pt_df(lavpartable)
 
   # handle equality constraints (note: we ignore inequality constraints,
   # active or not!)
@@ -318,7 +318,7 @@ lav_model_test <- function(lavobject = NULL,
     }
   } else if (lavmodel@ceq.simple.only) {
     # needed??
-    ndat <- lav_partable_ndat(lavpartable)
+    ndat <- lav_pt_ndat(lavpartable)
     npar <- max(lavpartable$free)
     df <- ndat - npar
   }
@@ -646,7 +646,7 @@ lav_model_test <- function(lavobject = NULL,
         }
       }
 
-      out <- lav_test_satorra_bentler(
+      out <- lav_test_sb(
         lavobject = NULL,
         lavsamplestats = lavsamplestats,
         lavmodel = lavmodel,
@@ -681,7 +681,7 @@ lav_model_test <- function(lavobject = NULL,
           }
       }
 
-      out <- lav_test_yuan_bentler(
+      out <- lav_test_yb(
         lavobject = NULL,
         lavsamplestats = lavsamplestats,
         lavmodel = lavmodel,

--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -342,7 +342,7 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
     if (method == "satorra.bentler.2001") {
       # use formula from Satorra & Bentler 2001
       for (m in seq_len(length(mods) - 1L)) {
-        out <- lav_test_diff_SatorraBentler2001(mods[[m]], mods[[m + 1]],
+        out <- lav_test_diff_sb2001(mods[[m]], mods[[m + 1]],
                                                 # in case not @test[[2]]:
                                                 test = test_1)
         stat_delta[m + 1] <- out$T.delta
@@ -357,7 +357,7 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
       }
     } else if (method == "satorra.bentler.2010") {
       for (m in seq_len(length(mods) - 1L)) {
-        out <- lav_test_diff_SatorraBentler2010(mods[[m]], mods[[m + 1]],
+        out <- lav_test_diff_sb2010(mods[[m]], mods[[m + 1]],
           test = test_1, # in case not @test[[2]]
           h1 = FALSE
         ) # must be F
@@ -635,7 +635,7 @@ lav_test_lrt_fmg <- function(mods, test = "pall_ug_ml", method = "default",
     mods,
     function(x) {
       lav_test_fmg_check_estimator(x@Options, context = "FMG nested tests")
-      lav_test_fmg_check_missing(x@Options, context = "FMG nested tests")
+      lav_test_fmg_check_mi(x@Options, context = "FMG nested tests")
     }
   ))
   estimators <- vapply(mods, function(x) x@Options$estimator.orig,

--- a/R/lav_test_Wald.R
+++ b/R/lav_test_Wald.R
@@ -52,7 +52,7 @@ lavTestWald <- function(object, constraints = NULL, verbose = FALSE) { # nolint
   theta <- lav_model_get_parameters(lavmodel)
 
   # build constraint function
-  ceq_function <- lav_partable_constraints_ceq(
+  ceq_function <- lav_pt_con_ceq(
     partable = partable,
     con = list_1, debug = FALSE
   )
@@ -65,7 +65,7 @@ lavTestWald <- function(object, constraints = NULL, verbose = FALSE) { # nolint
   }
 
   # check for linear redundant rows in JAC
-  out <- lav_matrix_rref(t(jac))
+  out <- lav_mat_rref(t(jac))
   ran_k <- length(out$pivot)
   if (ran_k < nrow(jac)) {
     lav_msg_warn(gettext(
@@ -93,7 +93,7 @@ lavTestWald <- function(object, constraints = NULL, verbose = FALSE) { # nolint
   # get VCOV
   # VCOV <- vcov(object, labels = FALSE)
   # avoid S4 dispatch
-  vcov_1 <- lav_object_inspect_vcov(object,
+  vcov_1 <- lav_inspect_vcov(object,
     standardized = FALSE,
     free_only = TRUE,
     add_labels = FALSE,

--- a/R/lav_test_browne.R
+++ b/R/lav_test_browne.R
@@ -194,10 +194,10 @@ lav_test_browne <- function(lavobject = NULL,
         )
       } else {
         # naive formula base computation (slow!)
-        delta_c <- lav_matrix_orthogonal_complement(delta_g)
+        delta_c <- lav_mat_ortho_complement(delta_g)
         t_dgd <- crossprod(delta_c, gamma_1[[g]]) %*% delta_c
         # if fixed.x = TRUE, gamma_1[[g]] may contain zero col/rows
-        t_dgd_inv <- lav_matrix_symmetric_inverse(t_dgd)
+        t_dgd_inv <- lav_mat_sym_inverse(t_dgd)
         t_res_delta_c <- crossprod(res, delta_c)
         stat_group[g] <-
           ng * drop(t_res_delta_c %*% t_dgd_inv %*% t(t_res_delta_c))
@@ -232,7 +232,7 @@ lav_test_browne <- function(lavobject = NULL,
       }
       gamma_inv_weighted[[g]] <- gamma_inv_temp * ng / ntotal
     }
-    gi <- lav_matrix_bdiag(gamma_inv_weighted)
+    gi <- lav_mat_bdiag(gamma_inv_weighted)
     t_dgi_d <- t(delta_g) %*% gi %*% delta_g
     t_dgi_d_inv <- MASS::ginv(t_dgi_d) # GI may be rank-deficient
     q1 <- drop(t(res_all) %*% gi %*% res_all)
@@ -253,7 +253,7 @@ lav_test_browne <- function(lavobject = NULL,
     df_1 <- lavobject@test[[1]]$df
   } else {
     # same approach as in lav_test.R
-    df <- lav_partable_df(lavpartable)
+    df <- lav_pt_df(lavpartable)
     if (nrow(lavmodel@con.jac) > 0L) {
       ceq_idx <- attr(lavmodel@con.jac, "ceq.idx")
       if (length(ceq_idx) > 0L) {
@@ -262,7 +262,7 @@ lav_test_browne <- function(lavobject = NULL,
       }
     } else if (lavmodel@ceq.simple.only) {
       # needed??
-      ndat <- lav_partable_ndat(lavpartable)
+      ndat <- lav_pt_ndat(lavpartable)
       npar <- max(lavpartable$free)
       df <- ndat - npar
     }
@@ -325,7 +325,7 @@ lav_test_browne_nt_fast <- function(res = NULL, delta = NULL,
   }
 
   # vech
-  diag_idx <- lav_matrix_diagh_idx(nvar)
+  diag_idx <- lav_mat_diagh_idx(nvar)
 
   # applies gamma_cov_inv = 0.5 * t(D) %*% (S.inv %x% S.inv) %*% D
   # to a pstar-vector 'x'
@@ -337,9 +337,9 @@ lav_test_browne_nt_fast <- function(res = NULL, delta = NULL,
       out_mean <- drop(s_inv %*% x_mean)
     }
 
-    m_w <- lav_matrix_vech_reverse(x_cov)
+    m_w <- lav_mat_vech_rev(x_cov)
     z <- s_inv %*% m_w %*% s_inv
-    out_cov <- lav_matrix_vech(z)
+    out_cov <- lav_mat_vech(z)
     out_cov[diag_idx] <- out_cov[diag_idx] / 2.0
     out <- out_cov
     if (meanstructure) {

--- a/R/lav_test_diff.R
+++ b/R/lav_test_diff.R
@@ -61,7 +61,7 @@ lav_test_diff_satorra2000 <- function(m1, m0, h1 = TRUE, a_method = "delta",
     m_pi <- lav_model_delta(m1@Model)
     p <- lavTech(m1, "information")
     # needed? (yes, if h1 already has eq constraints)
-    p_inv <- lav_model_information_augment_invert(m1@Model,
+    p_inv <- lav_model_info_augment_invert(m1@Model,
       information = p,
       inverted = TRUE
     )
@@ -87,7 +87,7 @@ lav_test_diff_satorra2000 <- function(m1, m0, h1 = TRUE, a_method = "delta",
     m_pi <- lav_model_delta(m0@Model)
     p <- lavTech(m0, "information")
     # needed?
-    p_inv <- lav_model_information_augment_invert(m0@Model,
+    p_inv <- lav_model_info_augment_invert(m0@Model,
       information = p,
       inverted = TRUE
     )
@@ -175,8 +175,8 @@ lav_test_diff_satorra2000 <- function(m1, m0, h1 = TRUE, a_method = "delta",
       for (g in seq_along(m_gamma)) {
         gamma_f[[g]] <- fg[g] * m_gamma[[g]]
       }
-      gamma_all <- lav_matrix_bdiag(gamma_f)
-      v_all <- lav_matrix_bdiag(wls_v)
+      gamma_all <- lav_mat_bdiag(gamma_f)
+      v_all <- lav_mat_bdiag(wls_v)
       pi_all <- do.call(rbind, m_pi)
       u_all <- v_all %*% pi_all %*% paapaap %*% t(pi_all) %*% v_all
       ug_all <- u_all %*% gamma_all
@@ -213,7 +213,7 @@ lav_test_diff_satorra2000 <- function(m1, m0, h1 = TRUE, a_method = "delta",
   )
 }
 
-lav_test_diff_SatorraBentler2001 <- function(m1, m0, test = 2) {
+lav_test_diff_sb2001 <- function(m1, m0, test = 2) {
   # extract information from m1 and m2
   t1 <- m1@test[[1]]$stat
   r1 <- m1@test[[1]]$df
@@ -259,7 +259,7 @@ lav_test_diff_SatorraBentler2001 <- function(m1, m0, test = 2) {
   list(T.delta = t_delta, scaling.factor = cd, df.delta = m)
 }
 
-lav_test_diff_SatorraBentler2010 <- function(m1, m0, test = 2,
+lav_test_diff_sb2010 <- function(m1, m0, test = 2,
                                              h1 = FALSE) {
   ### FIXME: check if models are nested at the parameter level!!!
 
@@ -356,16 +356,16 @@ lav_test_diff_m10 <- function(m1, m0, test = FALSE) {
     options_1$test <- "none"
   }
 
-  pt_m0 <- lav_partable_set_cache(m0@ParTable, m0@pta)
-  pt_m1 <- lav_partable_set_cache(m1@ParTable, m1@pta)
+  pt_m0 <- lav_pt_set_cache(m0@ParTable, m0@pta)
+  pt_m1 <- lav_pt_set_cache(m1@ParTable, m1@pta)
 
   # `extend' PT.M1 partable to include all `fixed-to-zero parameters'
-  pt_m1_full <- lav_partable_full(
+  pt_m1_full <- lav_pt_full(
     partable = pt_m1,
     free = TRUE, start = TRUE
   )
-  pt_m1_extended <- lav_partable_merge(pt_m1, pt_m1_full,
-    remove.duplicated = TRUE, warn = FALSE
+  pt_m1_extended <- lav_pt_merge(pt_m1, pt_m1_full,
+    remove_duplicated = TRUE, warn = FALSE
   )
 
   # remove most columns
@@ -378,12 +378,12 @@ lav_test_diff_m10 <- function(m1, m0, test = FALSE) {
   pt_m1_extended$ustart[free_par_idx] <- as.numeric(NA)
 
   # `extend' PT.M0 partable to include all `fixed-to-zero parameters'
-  pt_m0_full <- lav_partable_full(
+  pt_m0_full <- lav_pt_full(
     partable = pt_m0,
     free = TRUE, start = TRUE
   )
-  pt_m0_extended <- lav_partable_merge(pt_m0, pt_m0_full,
-    remove.duplicated = TRUE, warn = FALSE
+  pt_m0_extended <- lav_pt_merge(pt_m0, pt_m0_full,
+    remove_duplicated = TRUE, warn = FALSE
   )
   # remove most columns, but not 'est'
   pt_m0_extended$ustart <- NULL
@@ -455,7 +455,7 @@ lav_test_diff_a <- function(m1, m0, method = "delta", reference = "H1") {
 
     # H <- solve(t(Delta1) %*% Delta1) %*% t(Delta1) %*% Delta0
     h <- MASS::ginv(delta1) %*% delta0
-    m_a <- t(lav_matrix_orthogonal_complement(h))
+    m_a <- t(lav_mat_ortho_complement(h))
   }
 
   m_a
@@ -475,8 +475,8 @@ lav_test_diff_a <- function(m1, m0, method = "delta", reference = "H1") {
 #   - the plabels used in "==" constraints must be renamed, if necessary
 #
 lav_test_diff_af_h1 <- function(m1, m0) {
-  pt_m0 <- lav_partable_set_cache(parTable(m0), m0@pta)
-  pt_m1 <- lav_partable_set_cache(parTable(m1), m1@pta)
+  pt_m0 <- lav_pt_set_cache(parTable(m0), m0@pta)
+  pt_m1 <- lav_pt_set_cache(parTable(m1), m1@pta)
 
   # select .p*. parameters only
   m0_p_idx <- which(grepl("\\.p", pt_m0$plabel))
@@ -498,7 +498,7 @@ lav_test_diff_af_h1 <- function(m1, m0) {
   pt_m1_part2 <- pt_m1[-m1_p_idx, ]
 
   # figure out relationship between m0 and m1
-  p1_id <- lav_partable_map_id_p1_in_p2(pt_m0_part1, pt_m1_part1)
+  p1_id <- lav_pt_map_id_p1_in_p2(pt_m0_part1, pt_m1_part1)
   p0_free_idx <- which(pt_m0_part1$free > 0)
 
   # change 'free' order in m0
@@ -512,21 +512,21 @@ lav_test_diff_af_h1 <- function(m1, m0) {
   pt_m1 <- rbind(pt_m1_part1, pt_m1_part2)
 
   # `extend' PT.M1 partable to include all `fixed-to-zero parameters'
-  pt_m1_full <- lav_partable_full(
+  pt_m1_full <- lav_pt_full(
     partable = pt_m1,
     free = TRUE, start = TRUE
   )
-  pt_m1_extended <- lav_partable_merge(pt_m1, pt_m1_full,
-    remove.duplicated = TRUE, warn = FALSE
+  pt_m1_extended <- lav_pt_merge(pt_m1, pt_m1_full,
+    remove_duplicated = TRUE, warn = FALSE
   )
 
   # `extend' PT.M0 partable to include all `fixed-to-zero parameters'
-  pt_m0_full <- lav_partable_full(
+  pt_m0_full <- lav_pt_full(
     partable = pt_m0,
     free = TRUE, start = TRUE
   )
-  pt_m0_extended <- lav_partable_merge(pt_m0, pt_m0_full,
-    remove.duplicated = TRUE, warn = FALSE
+  pt_m0_extended <- lav_pt_merge(pt_m0, pt_m0_full,
+    remove_duplicated = TRUE, warn = FALSE
   )
 
   p1 <- pt_m1_extended
@@ -581,7 +581,7 @@ lav_test_diff_af_h1 <- function(m1, m0) {
   }
 
   # only for the UNIQUE equality constraints in H0, generate syntax
-  defcon_txt <- lav_partable_constraints_ceq(p0_1, txtOnly = TRUE)
+  defcon_txt <- lav_pt_con_ceq(p0_1, txt_only = TRUE)
   body_txt <- paste(body_txt, defcon_txt, "\n", sep = "")
 
 

--- a/R/lav_test_fmg.R
+++ b/R/lav_test_fmg.R
@@ -179,7 +179,7 @@ lav_test_fmg_resolve_chisq <- function(parsed, lavoptions = NULL) {
   ))
 }
 
-lav_test_fmg_check_missing <- function(lavoptions = NULL,
+lav_test_fmg_check_mi <- function(lavoptions = NULL,
                                        context = "FMG tests") {
   if (is.null(lavoptions) || is.null(lavoptions$missing)) {
     return(invisible(TRUE))
@@ -351,9 +351,9 @@ lav_test_fmg_browne_nt_model <- function(lavobject = NULL,
   if (!lineq.flag) {
     for (g in seq_len(ngroups)) {
       RES <- WLS.obs[[g]] - WLS.est[[g]]
-      Delta.c <- lav_matrix_orthogonal_complement(Delta[[g]])
+      Delta.c <- lav_mat_ortho_complement(Delta[[g]])
       t_dgd <- crossprod(Delta.c, Gamma[[g]]) %*% Delta.c
-      t_dgd_inv <- lav_matrix_symmetric_inverse(t_dgd)
+      t_dgd_inv <- lav_mat_sym_inverse(t_dgd)
       Ng <- if (n.minus.one) nobs[[g]] - 1L else nobs[[g]]
       t_res_delta_c <- crossprod(RES, Delta.c)
       stat.group[g] <-
@@ -377,7 +377,7 @@ lav_test_fmg_browne_nt_model <- function(lavobject = NULL,
       }
       Gamma.inv.weighted[[g]] <- Gamma.inv.temp * Ng / ntotal
     }
-    GI <- lav_matrix_bdiag(Gamma.inv.weighted)
+    GI <- lav_mat_bdiag(Gamma.inv.weighted)
     t_dgid <- t(Delta.g) %*% GI %*% Delta.g
     t_dgid_inv <- MASS::ginv(t_dgid)
     q1 <- drop(t(RES.all) %*% GI %*% RES.all)
@@ -391,14 +391,14 @@ lav_test_fmg_browne_nt_model <- function(lavobject = NULL,
   if (!is.null(lavobject)) {
     DF <- lavobject@test[[1]]$df
   } else {
-    DF <- lav_partable_df(lavpartable)
+    DF <- lav_pt_df(lavpartable)
     if (!lavmodel@cin.simple.only && nrow(lavmodel@con.jac) > 0L) {
       ceq.idx <- attr(lavmodel@con.jac, "ceq.idx")
       if (length(ceq.idx) > 0L) {
         DF <- DF + qr(lavmodel@con.jac[ceq.idx, , drop = FALSE])$rank
       }
     } else if (lavmodel@ceq.simple.only) {
-      DF <- lav_partable_ndat(lavpartable) - max(lavpartable$free)
+      DF <- lav_pt_ndat(lavpartable) - max(lavpartable$free)
     }
   }
 
@@ -453,7 +453,7 @@ lav_test_fmg <- function(lavobject = NULL,
   }
 
   lav_test_fmg_check_estimator(lavoptions, context = "FMG tests")
-  lav_test_fmg_check_missing(lavoptions, context = "FMG tests")
+  lav_test_fmg_check_mi(lavoptions, context = "FMG tests")
 
   # Parse test string
   parsed <- lav_test_fmg_parse(test)
@@ -612,7 +612,7 @@ lav_test_fmg_ugamma <- function(lavobject = NULL,
     # Recompute Gamma with unbiased = TRUE
     Gamma <- vector("list", ngroups)
     for (g in seq_len(ngroups)) {
-      Gamma[[g]] <- lav_samplestats_gamma(
+      Gamma[[g]] <- lav_samp_gamma(
         m_y = lavdata@X[[g]],
         meanstructure = lavoptions$meanstructure,
         unbiased = TRUE
@@ -644,7 +644,7 @@ lav_test_fmg_ugamma <- function(lavobject = NULL,
   }
 
   # Get U matrix and UGamma using existing infrastructure
-  out <- lav_test_satorra_bentler(
+  out <- lav_test_sb(
     lavobject = lavobject,
     lavsamplestats = lavsamplestats,
     lavmodel = lavmodel,
@@ -678,7 +678,7 @@ lav_test_fmg_ugamma <- function(lavobject = NULL,
     for (g in seq_along(Gamma)) {
       Gamma_scaled[[g]] <- Gamma[[g]] / fg[g]
     }
-    Gamma_all <- lav_matrix_bdiag(Gamma_scaled)
+    Gamma_all <- lav_mat_bdiag(Gamma_scaled)
     UGamma <- U %*% Gamma_all
   } else {
     UGamma <- out$UGamma
@@ -945,8 +945,8 @@ lav_test_fmg_nested <- function(m0, m1, test = "pall") {
       dQuote(m1@Options$estimator.orig)
     ))
   }
-  lav_test_fmg_check_missing(m0@Options, context = "FMG nested tests")
-  lav_test_fmg_check_missing(m1@Options, context = "FMG nested tests")
+  lav_test_fmg_check_mi(m0@Options, context = "FMG nested tests")
+  lav_test_fmg_check_mi(m1@Options, context = "FMG nested tests")
 
   # Parse test string
   parsed <- lav_test_fmg_parse(test)
@@ -1040,7 +1040,7 @@ lav_test_fmg_ugamma_nested <- function(m0, m1, unbiased = FALSE) {
   if (unbiased) {
     Gamma <- vector("list", ngroups)
     for (g in seq_len(ngroups)) {
-      Gamma[[g]] <- lav_samplestats_gamma(
+      Gamma[[g]] <- lav_samp_gamma(
         m_y = lavdata@X[[g]],
         meanstructure = m1@Options$meanstructure,
         unbiased = TRUE
@@ -1104,13 +1104,13 @@ lav_test_fmg_ugamma_nested <- function(m0, m1, unbiased = FALSE) {
   for (g in seq_along(Gamma)) {
     Gamma_f[[g]] <- Gamma[[g]] / fg[g]
   }
-  Gamma_all <- lav_matrix_bdiag(Gamma_f)
+  Gamma_all <- lav_mat_bdiag(Gamma_f)
 
   V_f <- WLS.V
   for (g in seq_along(WLS.V)) {
     V_f[[g]] <- fg[g] * WLS.V[[g]]
   }
-  V_all <- lav_matrix_bdiag(V_f)
+  V_all <- lav_mat_bdiag(V_f)
 
   PI_all <- do.call(rbind, PI)
 

--- a/R/lav_test_satorra_bentler.R
+++ b/R/lav_test_satorra_bentler.R
@@ -2,7 +2,7 @@
 #           Moss) when Satterthwaite = TRUE, ngroups > 1, and eq constraints.
 #           Use ug2.old.approach = TRUE to get the old result
 
-lav_test_satorra_bentler <- function(lavobject = NULL,
+lav_test_sb <- function(lavobject = NULL,
                                      lavsamplestats = NULL,
                                      lavmodel = NULL,
                                      lavimplied = NULL,
@@ -91,20 +91,20 @@ lav_test_satorra_bentler <- function(lavobject = NULL,
   if (npar > 0L &&
     (is.null(e_inv) || is.null(delta) || is.null(wls_v) || e_inv_recompute)) {
     if (lavoptions$information.expected.mplus && lavoptions$estimator == "ML") {
-      m_e <- lav_model_information_expected_mlm(
+      m_e <- lav_model_info_expected_mlm(
         lavmodel = lavmodel,
         augmented = FALSE, inverted = FALSE,
         lavsamplestats = lavsamplestats, extra = TRUE
       )
     } else {
-      m_e <- lav_model_information(
+      m_e <- lav_model_info(
         lavmodel = lavmodel,
         lavimplied = lavimplied,
         lavsamplestats = lavsamplestats, lavdata = lavdata,
         lavoptions = lavoptions, extra = TRUE
       )
     }
-    e_inv <- try(lav_model_information_augment_invert(lavmodel,
+    e_inv <- try(lav_model_info_augment_invert(lavmodel,
       information = m_e, inverted = TRUE
     ), silent = TRUE)
     if (inherits(e_inv, "try-error")) {
@@ -194,7 +194,7 @@ lav_test_satorra_bentler <- function(lavobject = NULL,
     for (g in 1:ngroups) {
       gamma_f[[g]] <- 1 / fg[g] * m_gamma[[g]]
     }
-    gamma_all <- lav_matrix_bdiag(gamma_f)
+    gamma_all <- lav_mat_bdiag(gamma_f)
     ug <- gamma_all
     trace_ugamma <- sum(diag(gamma_all))
     trace_ugamma2 <- sum(ug * t(ug))
@@ -203,7 +203,7 @@ lav_test_satorra_bentler <- function(lavobject = NULL,
       UGamma = ug, UfromUGamma = u_all
     )
   } else if (method == "original") {
-    out <- lav_test_satorra_bentler_trace_original(
+    out <- lav_test_sb_trace_original(
       m_gamma = m_gamma,
       delta = delta, wls_v = wls_v, e_inv = e_inv,
       ngroups = ngroups, nobs = lavsamplestats@nobs,
@@ -213,7 +213,7 @@ lav_test_satorra_bentler <- function(lavobject = NULL,
       satterthwaite = satterthwaite
     )
   } else if (method == "orthogonal.complement") {
-    out <- lav_test_satorra_bentler_trace_complement(
+    out <- lav_test_sb_trace_complement(
       m_gamma = m_gamma,
       delta = delta, wls_v = wls_v, lavmodel = lavmodel,
       ngroups = ngroups, nobs = lavsamplestats@nobs,
@@ -223,7 +223,7 @@ lav_test_satorra_bentler <- function(lavobject = NULL,
       satterthwaite = satterthwaite
     )
   } else if (method == "ABA") {
-    out <- lav_test_satorra_bentler_trace_aba(
+    out <- lav_test_sb_trace_aba(
       m_gamma = m_gamma,
       m_delta = delta, wls_v = wls_v, e_inv = e_inv,
       ngroups = ngroups, nobs = lavsamplestats@nobs,
@@ -415,7 +415,7 @@ lav_test_satorra_bentler <- function(lavobject = NULL,
 
 # using the `classical' formula
 # UG = Gamma * [V - V Delta E.inv Delta' V']
-lav_test_satorra_bentler_trace_original <- function(m_gamma = NULL,  # nolint
+lav_test_sb_trace_original <- function(m_gamma = NULL,
                                                     delta = NULL,
                                                     wls_v = NULL,
                                                     e_inv = NULL,
@@ -472,12 +472,12 @@ lav_test_satorra_bentler_trace_original <- function(m_gamma = NULL,  # nolint
           v_g[[g]] <- fg[g] * diag(wls_v[[g]])
         }
       }
-      v_all <- lav_matrix_bdiag(v_g)
+      v_all <- lav_mat_bdiag(v_g)
       gamma_f <- m_gamma
       for (g in 1:ngroups) {
         gamma_f[[g]] <- 1 / fg[g] * m_gamma[[g]]
       }
-      gamma_all <- lav_matrix_bdiag(gamma_f)
+      gamma_all <- lav_mat_bdiag(gamma_f)
       delta_all <- do.call("rbind", delta)
       u_all <- v_all - v_all %*% delta_all %*% e_inv %*% t(delta_all) %*% v_all
       ug <- u_all %*% gamma_all
@@ -512,7 +512,7 @@ lav_test_satorra_bentler_trace_original <- function(m_gamma = NULL,  # nolint
 
 # using the orthogonal complement of Delta: Delta.c
 # UG = [ (Delta.c' W Delta.c)^{-1} (Delta.c' Gamma Delta.c)
-lav_test_satorra_bentler_trace_complement <- function(m_gamma = NULL,  # nolint
+lav_test_sb_trace_complement <- function(m_gamma = NULL,
                                                       delta = NULL,
                                                       wls_v = NULL,
                                                       lavmodel = NULL,
@@ -546,7 +546,7 @@ lav_test_satorra_bentler_trace_complement <- function(m_gamma = NULL,  # nolint
       }
 
       # orthogonal complement of Delta.g
-      delta_c <- lav_matrix_orthogonal_complement(delta_g)
+      delta_c <- lav_mat_ortho_complement(delta_g)
 
       ### FIXME: compute WLS.W directly, instead of using solve(WLS.V)
 
@@ -576,12 +576,12 @@ lav_test_satorra_bentler_trace_complement <- function(m_gamma = NULL,  # nolint
         v_g[[g]] <- fg[g] * diag(wls_v[[g]])
       }
     }
-    v_all <- lav_matrix_bdiag(v_g)
+    v_all <- lav_mat_bdiag(v_g)
     gamma_f <- m_gamma
     for (g in 1:ngroups) {
       gamma_f[[g]] <- 1 / fg[g] * m_gamma[[g]]
     }
-    gamma_all <- lav_matrix_bdiag(gamma_f)
+    gamma_all <- lav_mat_bdiag(gamma_f)
     delta_all <- do.call("rbind", delta)
 
     # handle equality constraints
@@ -593,7 +593,7 @@ lav_test_satorra_bentler_trace_complement <- function(m_gamma = NULL,  # nolint
     }
 
     # orthogonal complement of Delta.g
-    delta_c <- lav_matrix_orthogonal_complement(delta_all)
+    delta_c <- lav_mat_ortho_complement(delta_all)
 
     tmp1 <- solve(t(delta_c) %*% solve(v_all) %*% delta_c)
     tmp2 <- t(delta_c) %*% gamma_all %*% delta_c
@@ -628,7 +628,7 @@ lav_test_satorra_bentler_trace_complement <- function(m_gamma = NULL,  # nolint
 
 # we write it like this to highlight the connection with MLR
 #
-lav_test_satorra_bentler_trace_aba <- function(m_gamma = NULL,       # nolint
+lav_test_sb_trace_aba <- function(m_gamma = NULL,
                                                m_delta = NULL,
                                                wls_v = NULL,
                                                e_inv = NULL,
@@ -691,12 +691,12 @@ lav_test_satorra_bentler_trace_aba <- function(m_gamma = NULL,       # nolint
           v_g[[g]] <- fg[g] * diag(wls_v[[g]])
         }
       }
-      v_all <- lav_matrix_bdiag(v_g)
+      v_all <- lav_mat_bdiag(v_g)
       gamma_f <- m_gamma
       for (g in 1:ngroups) {
         gamma_f[[g]] <- 1 / fg[g] * m_gamma[[g]]
       }
-      gamma_all <- lav_matrix_bdiag(gamma_f)
+      gamma_all <- lav_mat_bdiag(gamma_f)
       delta_all <- do.call("rbind", m_delta)
 
       aga1 <- v_all %*% gamma_all %*% v_all

--- a/R/lav_test_score.R
+++ b/R/lav_test_score.R
@@ -93,7 +93,7 @@ lavTestScore <- function(object, add = NULL, release = NULL,       # nolint star
     }
 
     # lhs/rhs
-    lhs <- lav_partable_labels(fit@ParTable)[fit@ParTable$user == 10L]
+    lhs <- lav_pt_labels(fit@ParTable)[fit@ParTable$user == 10L]
     op <- rep("==", nadd)
     rhs <- rep("0", nadd)
     table_1 <- data.frame(
@@ -300,7 +300,7 @@ lavTestScore <- function(object, add = NULL, release = NULL,       # nolint star
       ## release mode
       list_1 <- parTable(object)
     }
-    if (lav_partable_ngroups(list_1) == 1L) {
+    if (lav_pt_ngroups(list_1) == 1L) {
       list_1$group <- NULL
     }
     nonpar_idx <- which(list_1$op %in% c("==", ":=", "<", ">"))
@@ -309,7 +309,7 @@ lavTestScore <- function(object, add = NULL, release = NULL,       # nolint star
     }
 
     list_1$est[list_1$free > 0 & list_1$user != 10] <-
-            lav_object_inspect_coef(object, type = "free")
+            lav_inspect_coef(object, type = "free")
     list_1$est[list_1$user == 10L] <- 0
     list_1$epc <- rep(as.numeric(NA), length(list_1$lhs))
     list_1$epc[list_1$free > 0] <- epc_all
@@ -371,7 +371,7 @@ lavTestScore <- function(object, add = NULL, release = NULL,       # nolint star
     # remove some more columns
     list_1$id <- list_1$ustart <- list_1$exo <-
            list_1$start <- list_1$se <- list_1$prior <- NULL
-    if (lav_partable_nblocks(list_1) == 1L) {
+    if (lav_pt_nblocks(list_1) == 1L) {
       list_1$block <- NULL
       list_1$group <- NULL
       list_1$level <- NULL

--- a/R/lav_test_yuan_bentler.R
+++ b/R/lav_test_yuan_bentler.R
@@ -4,7 +4,7 @@
 #           Note however that Satterthwaite = FALSE always (for now), so
 #           the fix has no (visible) effect
 
-lav_test_yuan_bentler <- function(lavobject = NULL,
+lav_test_yb <- function(lavobject = NULL,
                                   lavsamplestats = NULL,
                                   lavmodel = NULL,
                                   lavimplied = NULL,
@@ -85,7 +85,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
   # do we have E.inv?
   if (is.null(e_inv) || e_inv_recompute) {
     e_inv <- try(
-      lav_model_information(
+      lav_model_info(
         lavmodel = lavmodel,
         lavsamplestats = lavsamplestats,
         lavdata = lavdata,
@@ -148,7 +148,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
   }
 
   # A1 is usually expected or observed
-  a1_group <- lav_model_h1_information(
+  a1_group <- lav_model_h1_info(
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats,
     lavdata = lavdata,
@@ -157,7 +157,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
     lavoptions = h1_options
   )
   # B1 is always first.order
-  b1_group <- lav_model_h1_information_firstorder(
+  b1_group <- lav_model_h1_info_firstorder(
     lavmodel = lavmodel,
     lavsamplestats = lavsamplestats,
     lavdata = lavdata,
@@ -168,7 +168,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
 
   if (test == "yuan.bentler.mplus") {
     if (is.null(b0_group)) {
-      b0 <- lav_model_information_firstorder(
+      b0 <- lav_model_info_firstorder(
         lavmodel = lavmodel,
         lavsamplestats = lavsamplestats,
         lavdata = lavdata,
@@ -182,7 +182,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
       b0_group <- attr(b0, "B0.group")
     }
     trace_ugamma <-
-      lav_test_yuan_bentler_mplus_trace(
+      lav_test_yb_mplus_trace(
         lavsamplestats = lavsamplestats,
         a1_group = a1_group,
         b1_group = b1_group,
@@ -205,7 +205,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
     )
 
     # compute trace 'U %*% Gamma' (or 'U %*% Omega')
-    trace_ugamma <- lav_test_yuan_bentler_trace(
+    trace_ugamma <- lav_test_yb_trace(
       lavsamplestats   = lavsamplestats,
       meanstructure    = lavmodel@meanstructure,
       a1_group         = a1_group,
@@ -277,7 +277,7 @@ lav_test_yuan_bentler <- function(lavobject = NULL,
 }
 
 
-lav_test_yuan_bentler_trace <- function(lavsamplestats = lavsamplestats,
+lav_test_yb_trace <- function(lavsamplestats = lavsamplestats,
                                         meanstructure = TRUE,
                                         a1_group = NULL,
                                         b1_group = NULL,
@@ -337,19 +337,19 @@ lav_test_yuan_bentler_trace <- function(lavsamplestats = lavsamplestats,
     for (g in 1:ngroups) {
       a1_f[[g]] <- a1_group[[g]] * fg[g]
     }
-    a1_all <- lav_matrix_bdiag(a1_f)
+    a1_all <- lav_mat_bdiag(a1_f)
 
     b1_f <- b1_group
     for (g in 1:ngroups) {
       b1_f[[g]] <- b1_group[[g]] * fg[g]
     }
-    b1_all <- lav_matrix_bdiag(b1_f)
+    b1_all <- lav_mat_bdiag(b1_f)
 
     gamma_f <- omega
     for (g in 1:ngroups) {
       gamma_f[[g]] <- 1 / fg[g] * omega[[g]]
     }
-    gamma_all <- lav_matrix_bdiag(gamma_f)
+    gamma_all <- lav_mat_bdiag(gamma_f)
     delta_all <- do.call("rbind", delta)
 
     d_einv_t_d <- delta_all %*% tcrossprod(e_inv, delta_all)
@@ -373,7 +373,7 @@ lav_test_yuan_bentler_trace <- function(lavsamplestats = lavsamplestats,
   trace_ugamma
 }
 
-lav_test_yuan_bentler_mplus_trace <- function(lavsamplestats = NULL, # nolint
+lav_test_yb_mplus_trace <- function(lavsamplestats = NULL,
                                               a1_group = NULL,
                                               b1_group = NULL,
                                               b0_group = NULL,

--- a/R/lav_utils.R
+++ b/R/lav_utils.R
@@ -160,9 +160,9 @@ lav_getcov <- function(x, lower = TRUE, diagonal = TRUE, sds = NULL,
   if (is.character(sds)) sds <- lav_char2num(sds)
 
   if (lower) {
-    cov_1 <- lav_matrix_lower2full(x, diagonal = diagonal)
+    cov_1 <- lav_mat_lower2full(x, diagonal = diagonal)
   } else {
-    cov_1 <- lav_matrix_upper2full(x, diagonal = diagonal)
+    cov_1 <- lav_mat_upper2full(x, diagonal = diagonal)
   }
   nvar <- ncol(cov_1)
 
@@ -216,7 +216,7 @@ lav_implied_to_vec <- function(implied = NULL, lavmodel = NULL,
       var <- var[var != 1]
     }
 
-    wls_obs[[g]] <- lav_samplestats_wls_obs(
+    wls_obs[[g]] <- lav_samp_wls_obs(
       # plain
       mean_g = implied$mean[[g]],
       cov_g = implied$cov[[g]],
@@ -299,7 +299,7 @@ lav_vec_to_implied <- function(x = NULL, lavmodel) {
 
       # cov - lower only
       idx <- seq_len(nvar * (nvar - 1) / 2)
-      cov_g <- lav_matrix_vech_reverse(x[idx], diagonal = FALSE)
+      cov_g <- lav_mat_vech_rev(x[idx], diagonal = FALSE)
       x <- x[-idx]
       diag(cov_g) <- var_g
 
@@ -330,7 +330,7 @@ lav_vec_to_implied <- function(x = NULL, lavmodel) {
       } else {
         idx <- seq_len(nvar * (nvar - 1) / 2)
       }
-      cov_g <- lav_matrix_vech_reverse(x[idx], diagonal = diag_flag)
+      cov_g <- lav_mat_vech_rev(x[idx], diagonal = diag_flag)
       x <- x[-idx]
 
       # fill in
@@ -351,8 +351,8 @@ lav_vec_to_implied <- function(x = NULL, lavmodel) {
 # theta = solve(t(Delta) %*% W %*% Delta) %*% t(Delta) %*% W %*% svec
 #
 # where Delta is the Jacobian of Sigma wrt the free parameters,
-# W is lav_matrix_bdiag(S.inv, S22_inv)
-# where S22_inv = 0.5 * lav_matrix_duplication_pre_post(S.inv %x% S.inv)
+# W is lav_mat_bdiag(S.inv, S22_inv)
+# where S22_inv = 0.5 * lav_mat_dup_pre_post(S.inv %x% S.inv)
 #  - S can be I (ULS) (then W = 0.5 * t(D) %*% D)
 #  - S can be sample.cov (GLS)
 #  - S can be Sigma (2RLS or RLS)
@@ -404,7 +404,7 @@ lav_utils_wls_linearization <- function(delta = NULL, s = NULL,
     jac_cov <- delta[-mean_idx, , drop = FALSE]
     s_mean <- svec[mean_idx]
     s_cov <- svec[-mean_idx]
-    w[lav_matrix_diagh_idx(nvar)] <- 0.5
+    w[lav_mat_diagh_idx(nvar)] <- 0.5
   } else if (nrow(delta) != pstar) {
     lav_msg_stop(gettext("nrow(Delta) != pstar"))
   }
@@ -436,9 +436,9 @@ lav_utils_wls_linearization <- function(delta = NULL, s = NULL,
     # cov part
     q_cov <- matrix(0, pstar, nc)
     for (j in seq_len(nc)) {
-      vmat <- lav_matrix_vech_reverse(jac_cov[, j])
+      vmat <- lav_mat_vech_rev(jac_cov[, j])
       m_w <- si %*% vmat %*% si
-      q_cov[, j] <- w * lav_matrix_vech(m_w)
+      q_cov[, j] <- w * lav_mat_vech(m_w)
     }
 
     a <- crossprod(jac_cov, q_cov)

--- a/R/lav_uvord.R
+++ b/R/lav_uvord.R
@@ -47,7 +47,7 @@ lav_uvord_fit <- function(y = NULL,
   min_objective <- lav_uvord_min_objective
   y_ncat <- length(tabulate(y)) # number of response categories
   if (y_ncat > 1L) {
-    min_gradient <- lav_uvord_min_gradient
+    min_gradient <- lav_uvord_min_grad
     min_hessian <- lav_uvord_min_hessian
   } else {
     min_gradient <- NULL
@@ -166,7 +166,7 @@ lav_uvord_init_cache <- function(y = NULL,
 
   # missing values
   if (any(is.na(y)) || (!is.null(x) && any(is.na(x)))) {
-    lav_crossprod <- lav_matrix_crossprod
+    lav_crossprod <- lav_mat_crossprod
   } else {
     lav_crossprod <- base::crossprod
   }
@@ -301,7 +301,7 @@ lav_uvord_loglik_cache <- function(cache = NULL) {
 }
 
 # casewise scores
-lav_uvord_scores <- function(y = NULL,
+lav_uvord_sc <- function(y = NULL,
                              x = NULL,
                              wt = rep(1, length(y)),
                              use_weights = TRUE,
@@ -313,7 +313,7 @@ lav_uvord_scores <- function(y = NULL,
       logistic = logistic, output = "cache"
     )
   }
-  sc <- lav_uvord_scores_cache(cache = cache)
+  sc <- lav_uvord_sc_cache(cache = cache)
 
   if (!is.null(wt) && use_weights) {
     sc <- sc * wt
@@ -322,7 +322,7 @@ lav_uvord_scores <- function(y = NULL,
   sc
 }
 
-lav_uvord_scores_cache <- function(cache = NULL) {
+lav_uvord_sc_cache <- function(cache = NULL) {
   with(cache, {
     # d logl / d pi
     dldpi <- 1 / pi_i # unweighted!
@@ -344,7 +344,7 @@ lav_uvord_scores_cache <- function(cache = NULL) {
   })
 }
 
-lav_uvord_gradient_cache <- function(cache = NULL) {
+lav_uvord_grad_cache <- function(cache = NULL) {
   with(cache, {
     # d logl / d pi
     wtp <- wt / pi_i
@@ -382,7 +382,7 @@ lav_uvord_hessian <- function(y = NULL,
     )
   }
   tmp <- lav_uvord_loglik_cache(cache = cache)
-  tmp <- lav_uvord_gradient_cache(cache = cache)
+  tmp <- lav_uvord_grad_cache(cache = cache)
   lav_uvord_hessian_cache(cache = cache)
 }
 
@@ -438,13 +438,13 @@ lav_uvord_min_objective <- function(x, cache = NULL) {
 }
 
 # compute gradient, for specific 'x' (nlminb)
-lav_uvord_min_gradient <- function(x, cache = NULL) {
+lav_uvord_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_uvord_loglik_cache(cache = cache)
   }
-  -1 * lav_uvord_gradient_cache(cache = cache) / cache$n
+  -1 * lav_uvord_grad_cache(cache = cache) / cache$n
 }
 
 # compute hessian, for specific 'x' (nlminb)
@@ -453,14 +453,14 @@ lav_uvord_min_hessian <- function(x, cache = NULL) {
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_uvord_loglik_cache(cache = cache)
-    tmp <- lav_uvord_gradient_cache(cache = cache)
+    tmp <- lav_uvord_grad_cache(cache = cache)
     rm(tmp)
   }
   -1 * lav_uvord_hessian_cache(cache = cache) / cache$n
 }
 
 # get 'z1' and 'z2' values, given (new) values for the parameters
-# only needed for lav_bvord_cor_scores(), which is called from
+# only needed for lav_bvord_cor_sc(), which is called from
 # lav_pml_dploglik_dimplied() in lav_model_gradient_pml.R
 lav_uvord_update_fit <- function(fit_y = NULL, th_new = NULL, sl_new = NULL) {
   # return fit.y with 'update' z1/z2 values

--- a/R/lav_uvreg.R
+++ b/R/lav_uvreg.R
@@ -25,7 +25,7 @@ lav_uvreg_fit <- function(y = NULL,
 
   # optim.method
   min_objective <- lav_uvreg_min_objective
-  min_gradient <- lav_uvreg_min_gradient
+  min_gradient <- lav_uvreg_min_grad
   min_hessian <- lav_uvreg_min_hessian
   if (optim_method == "nlminb" || optim_method == "nlminb2") {
     # nothing to do
@@ -120,7 +120,7 @@ lav_uvreg_init_cache <- function(y = NULL,
     theta_evar <- sum(fit_lm$residuals * wt_tmp * fit_lm$residuals) /
                   sum(wt_tmp)
 
-    lav_crossprod <- lav_matrix_crossprod
+    lav_crossprod <- lav_mat_crossprod
   } else {
     fit_lm <- stats::lm.wfit(y = y, x = x1, w = wt)
     theta_evar <- sum(fit_lm$residuals * wt * fit_lm$residuals) / sum(wt)
@@ -172,17 +172,17 @@ lav_uvreg_loglik_cache <- function(cache = NULL) {
 }
 
 # casewise scores
-lav_uvreg_scores <- function(y = NULL,
+lav_uvreg_sc <- function(y = NULL,
                              x = NULL,
                              wt = rep(1, length(y)),
                              cache = NULL) {
   if (is.null(cache)) {
     cache <- lav_uvreg_fit(y = y, x = x, wt = wt, output = "cache")
   }
-  lav_uvreg_scores_cache(cache = cache)
+  lav_uvreg_sc_cache(cache = cache)
 }
 
-lav_uvreg_scores_cache <- function(cache = NULL) {
+lav_uvreg_sc_cache <- function(cache = NULL) {
   with(cache, {   # nolint start
     res <- y - yhat
     resw <- res * wt
@@ -196,17 +196,17 @@ lav_uvreg_scores_cache <- function(cache = NULL) {
 }
 
 # gradient
-lav_uvreg_gradient <- function(y = NULL,
+lav_uvreg_grad <- function(y = NULL,
                                x = NULL,
                                wt = rep(1, length(y)),
                                cache = NULL) {
   if (is.null(cache)) {
     cache <- lav_uvreg_fit(y = y, x = x, wt = wt, output = "cache")
   }
-  lav_uvreg_gradient_cache(cache = cache)
+  lav_uvreg_grad_cache(cache = cache)
 }
 
-lav_uvreg_gradient_cache <- function(cache = NULL) {
+lav_uvreg_grad_cache <- function(cache = NULL) {
   with(cache, {    # nolint start
     res <- y - yhat
     resw <- res * wt
@@ -255,14 +255,14 @@ lav_uvreg_min_objective <- function(x, cache = NULL) {
 }
 
 # compute gradient, for specific 'x' (nlminb)
-lav_uvreg_min_gradient <- function(x, cache = NULL) {
+lav_uvreg_min_grad <- function(x, cache = NULL) {
   # check if x has changed
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_uvreg_loglik_cache(cache = cache)
     rm(tmp)
   }
-  -1 * lav_uvreg_gradient_cache(cache = cache) / cache$n
+  -1 * lav_uvreg_grad_cache(cache = cache) / cache$n
 }
 
 # compute hessian, for specific 'x' (nlminb)
@@ -271,7 +271,7 @@ lav_uvreg_min_hessian <- function(x, cache = NULL) {
   if (!all(x == cache$theta)) {
     cache$theta <- x
     tmp <- lav_uvreg_loglik_cache(cache = cache)
-    tmp <- lav_uvreg_gradient_cache(cache = cache)
+    tmp <- lav_uvreg_grad_cache(cache = cache)
     rm(tmp)
   }
   -1 * lav_uvreg_hessian_cache(cache = cache) / cache$n

--- a/R/xxx_fsr.R
+++ b/R/xxx_fsr.R
@@ -128,7 +128,7 @@ fsr <- function(model = NULL,
   lavoptions$test <- dotdotdot$test
   ngroups <- lavInspect(fit_1, "ngroups")
   lavpta <- fit_1@pta
-  lavpartable <- lav_partable_set_cache(fit_1@ParTable, lavpta)
+  lavpartable <- lav_pt_set_cache(fit_1@ParTable, lavpta)
 
   # FIXME: not ready for multiple groups yet
   if (ngroups > 1L) {
@@ -167,11 +167,11 @@ fsr <- function(model = NULL,
   # nfac <- length(lv_names)
 
   # check parameter table
-  pt_1 <- lav_partable_set_cache(parTable(fit_1))
+  pt_1 <- lav_pt_set_cache(parTable(fit_1))
   pt_1$est <- pt_1$se <- NULL
 
   # extract structural part
-  pt_pa <- lav_partable_subset_structural_model(pt_1)
+  pt_pa <- lav_pt_subset_structural_model(pt_1)
 
   # check if we can use skrondal & laake (no mediational terms?)
   if (fsr_method == "skrondal.laake") {
@@ -245,7 +245,7 @@ fsr <- function(model = NULL,
   for (b in 1:nblocks) {
     # create parameter table for this measurement block only
     pt_block <-
-      lav_partable_subset_measurement_model(
+      lav_pt_subset_measurement_model(
         pt_1 = pt_1,
         add_lv_cov = TRUE,
         lv_names = mm_list[[b]]
@@ -342,12 +342,12 @@ fsr <- function(model = NULL,
   } # measurement block
 
   # Sigma.2 = Delta.21 %*% Sigma.1  %*% t(Delta.21)
-  sigma_2 <- lav_matrix_bdiag(sigma2_block)
+  sigma_2 <- lav_mat_bdiag(sigma2_block)
 
 
   # compute empirical covariance matrix factor scores + observed variables
   # in structural part
-  group_values <- lav_partable_group_values(pt_pa)
+  group_values <- lav_pt_group_values(pt_pa)
   fs_cov <- vector("list", length = ngroups)
   fsr_cov <- vector("list", length = ngroups)
   fsr_cov2 <- vector("list", length = ngroups)
@@ -398,8 +398,8 @@ fsr <- function(model = NULL,
 
     # STEP 1b: if using `Croon' method: correct COV matrix:
     if (fsr_method %in% c("croon")) {
-      scoffset <- lav_matrix_bdiag(lapply(lvinfo_1[[g]], "[[", "scoffset"))
-      scale_inv <- lav_matrix_bdiag(lapply(lvinfo_1[[g]], "[[", "scale.inv"))
+      scoffset <- lav_mat_bdiag(lapply(lvinfo_1[[g]], "[[", "scoffset"))
+      scale_inv <- lav_mat_bdiag(lapply(lvinfo_1[[g]], "[[", "scale.inv"))
 
       scoffset_1 <- matrix(0,
         nrow = length(struc_names),
@@ -412,7 +412,7 @@ fsr <- function(model = NULL,
 
       fsr_cov[[g]] <- scale_inv_1 %*% fs_cov[[g]] %*% scale_inv_1 - scoffset_1
     } else if (fsr_method == "simple") {
-      psi <- lav_matrix_bdiag(lapply(lvinfo_1[[g]], "[[", "psi"))
+      psi <- lav_mat_bdiag(lapply(lvinfo_1[[g]], "[[", "psi"))
 
       fsr_cov[[g]] <- fs_cov[[g]]
       # scalar version only (for now)
@@ -453,8 +453,8 @@ fsr <- function(model = NULL,
     if (fsr_method %in% c("croon", "simple")) {
       for (g in 1:ngroups) {
         old_inv <- solve(fs_cov[[g]])
-        old_inv_sqrt <- lav_matrix_symmetric_sqrt(old_inv)
-        fsr_cov_sqrt <- lav_matrix_symmetric_sqrt(fsr_cov[[g]])
+        old_inv_sqrt <- lav_mat_sym_sqrt(old_inv)
+        fsr_cov_sqrt <- lav_mat_sym_sqrt(fsr_cov[[g]])
         sc <- as.matrix(y[[g]])
         sc <- sc %*% old_inv_sqrt %*% fsr_cov_sqrt
         sc <- as.data.frame(sc)
@@ -535,7 +535,7 @@ fsr <- function(model = NULL,
   lavoptions3$test <- "standard"
   lavoptions3$se <- "none"
   lavoptions3$check.gradient <- FALSE
-  lavoptions3$information <- "expected" ## FIXME: lav_model_gradient + delta
+  lavoptions3$information <- "expected" ## FIXME: lav_model_grad + delta
   fit_si2 <- lavaan(pt_si,
     sample.cov  = fsr_cov2,
     sample.mean = fs_mean,
@@ -548,7 +548,7 @@ fsr <- function(model = NULL,
   # i23 <- info_all[idx1, idx2]
   # i22 <- info_all[idx1, idx1]
 
-  i33_inv <- lav_matrix_symmetric_inverse(i33)
+  i33_inv <- lav_mat_sym_inverse(i33)
 
   v1 <- i33_inv
   v2 <- i33_inv %*% i32 %*% sigma_2 %*% t(i32) %*% i33_inv

--- a/R/xxx_lavaan.R
+++ b/R/xxx_lavaan.R
@@ -57,7 +57,7 @@ lavaan <- function(
 
   # ------------- adapt parameters -----------------
   mc <- match.call(expand.dots = TRUE)
-  temp <- lav_lavaan_step00_parameters(
+  temp <- lav_step00_parameters(
     matchcall = mc,
     syscall   = sys.call(), # to get main arguments without partial matching
     dotdotdot = list(...)
@@ -99,7 +99,7 @@ lavaan <- function(
   }
 
   # ------------ check data ------------------------
-  temp <- lav_lavaan_step00_checkdata(
+  temp <- lav_step00_checkdata(
     data        = data,
     dotdotdot   = dotdotdot,
     sample_cov  = sample.cov,
@@ -131,7 +131,7 @@ lavaan <- function(
     useparser <- dotdotdot$parser
   }
 
-  flat_model <- lav_lavaan_step01_ovnames_initflat(
+  flat_model <- lav_step01_ovnames_initflat(
     slot_par_table   = slotParTable,
     model            = model,
     dotdotdot_parser = useparser
@@ -140,11 +140,11 @@ lavaan <- function(
   # ------------ ov.names 1b ----- handle 'old way' for composites -------
   if (!is.null(dotdotdot$composites) && !dotdotdot$composites &&
      any(flat_model$op == "<~")) {
-    flat_model <- lav_lavaan_step01_ovnames_composites(flat_model)
+    flat_model <- lav_step01_ovnames_composites(flat_model)
   }
 
   # ------------ ov.names 2 ------ handle ov.order -----------------------
-  flat_model <- lav_lavaan_step01_ovnames_ovorder(
+  flat_model <- lav_step01_ovnames_ovorder(
     flat_model = flat_model,
     ov_order   = ov_order,
     data       = data,
@@ -154,7 +154,7 @@ lavaan <- function(
 
   # ------------ ov.names 3 ------- group blocks ------------------
   ngroups <- 1L # default value
-  temp <- lav_lavaan_step01_ovnames_group(
+  temp <- lav_step01_ovnames_group(
     flat_model = flat_model,
     ngroups    = ngroups
   )
@@ -167,7 +167,7 @@ lavaan <- function(
   ngroups <- temp$ngroups
 
   # ------------ ov.names 4 ------ sanity checks ------------------
-  lav_lavaan_step01_ovnames_checklv(
+  lav_step01_ovnames_checklv(
     lv_names     = lv_names,
     ov_names     = ov_names,
     data         = data,
@@ -177,7 +177,7 @@ lavaan <- function(
   )
 
   # ------------ ov.names 5 ------ handle ov.names.l --------------
-  temp <- lav_lavaan_step01_ovnames_namesl(
+  temp <- lav_step01_ovnames_namesl(
     data         = data,
     cluster      = cluster,
     flat_model   = flat_model,
@@ -189,7 +189,7 @@ lavaan <- function(
 
   # ------------ ov.names 6 ------ sanity check ordered --------------
   ordered_orig <- ordered
-  ordered <- lav_lavaan_step01_ovnames_ordered(
+  ordered <- lav_step01_ovnames_ordered(
     ordered    = ordered,
     flat_model = flat_model,
     data       = data
@@ -197,7 +197,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "ov.names")
 
   # ------------ lavoptions --------------------
-  lavoptions <- lav_lavaan_step02_options(
+  lavoptions <- lav_step02_options(
     slot_options      = slotOptions,
     slot_data         = slotData,
     flat_model       = flat_model,
@@ -225,7 +225,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "Options")
 
   # ------------ lavdata ------------------------
-  temp <- lav_lavaan_step03_data(
+  temp <- lav_step03_data(
     slot_data         = slotData,
     lavoptions       = lavoptions,
     ov_names         = ov_names,
@@ -255,7 +255,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "Data")
 
   # ------------ lavpartable -------------------
-  temp <- lav_lavaan_step04_partable(
+  temp <- lav_step04_pt(
     slot_par_table = slotParTable,
     model          = model,
     flat_model     = flat_model,
@@ -275,7 +275,7 @@ lavaan <- function(
   # timing <- lav_add_timing(timing, "lavpta")
 
   # ------------ lavsamplestats ---------------
-  lavsamplestats <- lav_lavaan_step05_samplestats(
+  lavsamplestats <- lav_step05_samp(
     slot_sample_stats = slotSampleStats,
     lavdata           = lavdata,
     lavoptions        = lavoptions,
@@ -292,7 +292,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "SampleStats")
 
   # ------------ lavh1 ------------------------
-  lavh1 <- lav_lavaan_step06_h1(
+  lavh1 <- lav_step06_h1(
     sloth1         = sloth1,
     lavoptions     = lavoptions,
     lavsamplestats = lavsamplestats,
@@ -302,7 +302,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "h1")
 
   # ------------ bounds ------------------------
-  lavpartable <- lav_lavaan_step07_bounds(
+  lavpartable <- lav_step07_bounds(
     lavoptions     = lavoptions,
     lavh1          = lavh1,
     lavdata        = lavdata,
@@ -312,7 +312,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "bounds")
 
   # ------------ lavstart ----------------------
-  lavpartable <- lav_lavaan_step08_start(
+  lavpartable <- lav_step08_start(
     slot_model      = slotModel,
     lavoptions      = lavoptions,
     lavpartable     = lavpartable,
@@ -323,7 +323,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "start")
 
   # ------------ model -------------------------
-  temp <- lav_lavaan_step09_model(
+  temp <- lav_step09_model(
     slot_model     = slotModel,
     lavoptions     = lavoptions,
     lavpartable    = lavpartable,
@@ -336,7 +336,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "Model")
 
   # -------- lavcache ----------------------------------
-  lavcache <- lav_lavaan_step10_cache(
+  lavcache <- lav_step10_cache(
     slot_cache       = slotCache,
     lavdata          = lavdata,
     lavmodel         = lavmodel,
@@ -347,7 +347,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "cache")
 
   # -------- est + lavoptim ----------------------------
-  temp <- lav_lavaan_step11_estoptim(
+  temp <- lav_step11_estoptim(
     lavdata        = lavdata,
     lavmodel       = lavmodel,
     lavcache       = lavcache,
@@ -369,13 +369,13 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "optim")
 
   # -------- lavimplied + lavloglik --------------------
-  lavimplied <- lav_lavaan_step12_implied(
+  lavimplied <- lav_step12_implied(
     lavoptions = lavoptions,
     lavmodel   = lavmodel
   )
   timing <- lav_add_timing(timing, "implied")
 
-  lavloglik <- lav_lavaan_step12_loglik(
+  lavloglik <- lav_step12_loglik(
     lavoptions     = lavoptions,
     lavdata        = lavdata,
     lavsamplestats = lavsamplestats,
@@ -386,7 +386,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "loglik")
 
   # ----------- lavvcov + lavboot -------------------
-  temp <- lav_lavaan_step13_vcov_boot(
+  temp <- lav_step13_vcov_boot(
     lavoptions     = lavoptions,
     lavmodel       = lavmodel,
     lavsamplestats = lavsamplestats,
@@ -407,7 +407,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "vcov")
 
   # ----------- lavtest ----------
-  lavtest <- lav_lavaan_step14_test(
+  lavtest <- lav_step14_test(
     lavoptions     = lavoptions,
     lavmodel       = lavmodel,
     lavsamplestats = lavsamplestats,
@@ -423,7 +423,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "test")
 
   # ----------- lavfit ----------
-  lavfit <- lav_lavaan_step14_fit(
+  lavfit <- lav_step14_fit(
     lavpartable = lavpartable,
     lavmodel    = lavmodel,
     lavimplied  = lavimplied,
@@ -434,7 +434,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "Fit")
 
   # ----------- baseline ----------------------------
-  lavbaseline <- lav_lavaan_step15_baseline(
+  lavbaseline <- lav_step15_baseline(
     lavoptions     = lavoptions,
     lavsamplestats = lavsamplestats,
     lavdata        = lavdata,
@@ -445,7 +445,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "baseline")
 
   # ----------- rotation ---------------------------
-  temp <- lav_lavaan_step16_rotation(
+  temp <- lav_step16_rotation(
     lavoptions     = lavoptions,
     lavmodel       = lavmodel,
     lavpartable    = lavpartable,
@@ -465,7 +465,7 @@ lavaan <- function(
   timing <- lav_add_timing(timing, "rotation")
 
   # ------ lavaan result  ----------------
-  out <- lav_lavaan_step17_lavaan(
+  out <- lav_step17_lavaan(
     lavmc          = lavmc,
     timing         = timing,
     lavoptions     = lavoptions,

--- a/R/xxx_lavaanList.R
+++ b/R/xxx_lavaanList.R
@@ -204,7 +204,7 @@ lavaanList <- function(model = NULL, # model                   # nolint start
     # - ov.x variances/covariances
     # FIXME: can we not make the changes internally?
     # if(lavmodel@fixed.x &&
-    #     length(lav_partable_vnames(lavpartable, "ov.x")) > 0L) {
+    #     length(lav_pt_vnames(lavpartable, "ov.x")) > 0L) {
     # for(g in 1:FIT@Data@ngroups) {
     #
     # }

--- a/R/zzz_OLDNAMES.R
+++ b/R/zzz_OLDNAMES.R
@@ -4,11 +4,8 @@
 # computeExpectedInformation <- lav_model_information_expected
 # only for simsem ==> tools::testinstalledpackages successful without next line
 
-# used in bain
-getParameterLabels <- lav_partable_labels                           # nolint start
-
 # standardize function names in lav_utils.R / 31 Oct 2025
-getCov <- function(x, lower = TRUE, diagonal = TRUE, sds = NULL,
+getCov <- function(x, lower = TRUE, diagonal = TRUE, sds = NULL,  # nolint start
                    names = paste("V", 1:nvar, sep = "")) {
   lav_deprecated("lav_getcov")
   if (diagonal) {
@@ -88,7 +85,7 @@ simulateData <- function(
                          standardized = FALSE) {
   lav_deprecated("lavSimulateData", times = 0L)   #--> for now no warning
   if (is.list(model)) {
-    ngroups <- lav_partable_ngroups(model)
+    ngroups <- lav_pt_ngroups(model)
   } else {
     ngroups <- sample.nobs
   }

--- a/R/zzz_old_long_names.R
+++ b/R/zzz_old_long_names.R
@@ -1,0 +1,536 @@
+#
+# added by procedure shortening function names
+#
+                                                                 # nolint start
+
+lav_matrix_duplication_ginv_pre_post <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_dup_ginv_pre_post", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_ginv_pre_post)
+  eval(sc, parent.frame())
+}
+lav_matrix_orthogonal_complement <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_ortho_complement", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_ortho_complement)
+  eval(sc, parent.frame())
+}
+lav_func_gradient_complex <- function(
+                                      func,
+                                      x,
+                                      h = .Machine$double.eps,
+                                      ...,
+                                      fallback.simple = TRUE) {
+  lav_deprecated("lav_func_grad_complex", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_func_grad_complex)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication_ginv_post <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_dup_ginv_post", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_ginv_post)
+  eval(sc, parent.frame())
+}
+lav_func_gradient_simple <- function(
+                                     func,
+                                     x,
+                                     h = sqrt(.Machine$double.eps),
+                                     ...) {
+  lav_deprecated("lav_func_grad_simple", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_func_grad_simple)
+  eval(sc, parent.frame())
+}
+lav_matrix_vech_row_idx <- function(n = 1L, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vech_row_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vech_row_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_vech_col_idx <- function(n = 1L, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vech_col_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vech_col_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_antidiag_idx <- function(n = 1L) {
+  lav_deprecated("lav_mat_antidiag_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_antidiag_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication_pre_post <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_dup_pre_post", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_pre_post)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication_ginv_pre <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_dup_ginv_pre", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_ginv_pre)
+  eval(sc, parent.frame())
+}
+lav_matrix_commutation_pre_post <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_com_pre_post", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_com_pre_post)
+  eval(sc, parent.frame())
+}
+lav_partable_unrestricted <- function(
+                                      lavobject = NULL,
+                                      lavdata = NULL,
+                                      lavpta = NULL,
+                                      lavoptions = NULL,
+                                      lavsamplestats = NULL,
+                                      lavh1 = NULL,
+                                      sample.cov = NULL,
+                                      sample.mean = NULL,
+                                      sample.slopes = NULL,
+                                      sample.th = NULL,
+                                      sample.th.idx = NULL,
+                                      sample.cov.x = NULL,
+                                      sample.mean.x = NULL) {
+  lav_deprecated("lav_pt_unrestricted", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_unrestricted)
+  eval(sc, parent.frame())
+}
+lav_partable_independence <- function(
+                                      lavobject = NULL,
+                                      lavdata = NULL,
+                                      lavpta = NULL,
+                                      lavoptions = NULL,
+                                      lavsamplestats = NULL,
+                                      lavh1 = NULL,
+                                      sample.cov = NULL,
+                                      sample.mean = NULL,
+                                      sample.slopes = NULL,
+                                      sample.th = NULL,
+                                      sample.th.idx = NULL,
+                                      sample.cov.x = NULL,
+                                      sample.mean.x = NULL) {
+  lav_deprecated("lav_pt_independence", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_independence)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechru_idx <- function(n = 1L, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechru_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechru_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_upper2full <- function(x, diagonal = TRUE) {
+  lav_deprecated("lav_mat_upper2full", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_upper2full)
+  eval(sc, parent.frame())
+}
+lav_matrix_lower2full <- function(x, diagonal = TRUE) {
+  lav_deprecated("lav_mat_lower2full", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_lower2full)
+  eval(sc, parent.frame())
+}
+lav_matrix_commutation_mn_pre <- function(
+                                          A,
+                                          m = 1L,
+                                          n = 1L) {
+  lav_deprecated("lav_mat_com_mn_pre", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_com_mn_pre)
+  eval(sc, parent.frame())
+}
+lav_samplestats_from_data <- function(
+                                      lavdata = NULL,
+                                      lavoptions = NULL,
+                                      WLS.V = NULL,
+                                      NACOV = NULL) {
+  lav_deprecated("lav_samp_from_data", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_samp_from_data)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechru_reverse <- function(x, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechru_rev", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechru_rev)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechr_idx <- function(n = 1L, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechr_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechr_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechu_idx <- function(n = 1L, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechu_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechu_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_diagh_idx <- function(n = 1L) {
+  lav_deprecated("lav_mat_diagh_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_diagh_idx)
+  eval(sc, parent.frame())
+}
+lav_partable_attributes <- function(partable, pta = NULL) {
+  lav_deprecated("lav_pt_attributes", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_attributes)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechr_reverse <- function(x, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechr_rev", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechr_rev)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechu_reverse <- function(x, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechu_rev", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechu_rev)
+  eval(sc, parent.frame())
+}
+lav_matrix_vech_idx <- function(n = 1L, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vech_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vech_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_diag_idx <- function(n = 1L) {
+  lav_deprecated("lav_mat_diag_idx", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_diag_idx)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication_post <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_dup_post", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_post)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication_ginv <- function(n = 1L) {
+  lav_deprecated("lav_mat_dup_ginv", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_ginv)
+  eval(sc, parent.frame())
+}
+lav_matrix_commutation_post <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_com_post", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_com_post)
+  eval(sc, parent.frame())
+}
+lav_matrix_symmetric_sqrt <- function(S = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_sym_sqrt", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_sym_sqrt)
+  eval(sc, parent.frame())
+}
+lav_matrix_vech_reverse <- function(x, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vech_rev", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vech_rev)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication_pre <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_dup_pre", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup_pre)
+  eval(sc, parent.frame())
+}
+lav_matrix_commutation_pre <- function(A = matrix(0, 0, 0)) {
+  lav_deprecated("lav_mat_com_pre", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_com_pre)
+  eval(sc, parent.frame())
+}
+lav_partable_complete <- function(partable = NULL, start = TRUE) {
+  lav_deprecated("lav_pt_complete", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_complete)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechru <- function(S, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechru", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechru)
+  eval(sc, parent.frame())
+}
+lav_partable_constraints_def <- function(
+                                         partable,
+                                         con = NULL,
+                                         debug = FALSE,
+                                         txtOnly = FALSE,
+                                         warn = TRUE) {
+  lav_deprecated("lav_pt_con_def", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_con_def)
+  eval(sc, parent.frame())
+}
+lav_partable_constraints_ceq <- function(
+                                         partable,
+                                         con = NULL,
+                                         debug = FALSE,
+                                         txtOnly = FALSE) {
+  lav_deprecated("lav_pt_con_ceq", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_con_ceq)
+  eval(sc, parent.frame())
+}
+lav_partable_constraints_ciq <- function(
+                                         partable,
+                                         con = NULL,
+                                         debug = FALSE,
+                                         txtOnly = FALSE) {
+  lav_deprecated("lav_pt_con_ciq", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_con_ciq)
+  eval(sc, parent.frame())
+}
+lav_partable_from_lm <- function(
+                                 object,
+                                 est = FALSE,
+                                 label = FALSE,
+                                 as.data.frame. = FALSE) {
+  lav_deprecated("lav_pt_from_lm", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_from_lm)
+  eval(sc, parent.frame())
+}
+lav_constraints_parse <- function(
+                                  partable = NULL,
+                                  constraints = NULL,
+                                  theta = NULL,
+                                  debug = FALSE) {
+  lav_deprecated("lav_con_parse", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_con_parse)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechr <- function(S, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechr", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechr)
+  eval(sc, parent.frame())
+}
+lav_matrix_vechu <- function(S, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vechu", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vechu)
+  eval(sc, parent.frame())
+}
+lav_matrix_bdiag <- function(...) {
+  lav_deprecated("lav_mat_bdiag", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_bdiag)
+  eval(sc, parent.frame())
+}
+lav_matrix_trace <- function(..., check = TRUE) {
+  lav_deprecated("lav_mat_trace", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_trace)
+  eval(sc, parent.frame())
+}
+lav_partable_labels <- function(
+                                partable,
+                                blocks = c("group", "level"),
+                                group.equal = "",
+                                group.partial = "",
+                                type = "user") {
+  lav_deprecated("lav_pt_labels", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_labels)
+  eval(sc, parent.frame())
+}
+# used in bain
+getParameterLabels <- lav_partable_labels  
+
+lav_matrix_vecr <- function(A) {
+  lav_deprecated("lav_mat_vecr", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vecr)
+  eval(sc, parent.frame())
+}
+lav_matrix_vech <- function(S, diagonal = TRUE) {
+  lav_deprecated("lav_mat_vech", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vech)
+  eval(sc, parent.frame())
+}
+lav_partable_merge <- function(
+                               pt1 = NULL,
+                               pt2 = NULL,
+                               remove.duplicated = FALSE,
+                               fromLast = FALSE,
+                               warn = TRUE) {
+  lav_deprecated("lav_pt_merge", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_merge)
+  eval(sc, parent.frame())
+}
+lav_model_partable <- function(
+                               model = NULL,
+                               meanstructure = FALSE,
+                               int.ov.free = FALSE,
+                               int.lv.free = FALSE,
+                               marker.int.zero = FALSE,
+                               orthogonal = FALSE,
+                               orthogonal.y = FALSE,
+                               orthogonal.x = FALSE,
+                               orthogonal.efa = FALSE,
+                               std.lv = FALSE,
+                               correlation = FALSE,
+                               composites = TRUE,
+                               effect.coding = "",
+                               conditional.x = FALSE,
+                               fixed.x = FALSE,
+                               parameterization = "delta",
+                               constraints = NULL,
+                               ceq.simple = FALSE,
+                               auto = FALSE,
+                               model.type = "sem",
+                               auto.fix.first = FALSE,
+                               auto.fix.single = FALSE,
+                               auto.var = FALSE,
+                               auto.cov.lv.x = FALSE,
+                               auto.cov.y = FALSE,
+                               auto.th = FALSE,
+                               auto.delta = FALSE,
+                               auto.efa = FALSE,
+                               varTable = NULL,
+                               ngroups = 1L,
+                               nthresholds = NULL,
+                               group.equal = NULL,
+                               group.partial = NULL,
+                               group.w.free = FALSE,
+                               debug = FALSE,
+                               warn = TRUE,
+                               as.data.frame. = TRUE) {
+  lav_deprecated("lavaanify", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lavaanify)
+  eval(sc, parent.frame())
+}
+lav_matrix_vec <- function(A) {
+  lav_deprecated("lav_mat_vec", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_vec)
+  eval(sc, parent.frame())
+}
+lav_matrix_duplication <- function(n = 1L) {
+  lav_deprecated("lav_mat_dup", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_dup)
+  eval(sc, parent.frame())
+}
+lav_matrix_commutation <- function(m = 1L, n = 1L) {
+  lav_deprecated("lav_mat_com", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_com)
+  eval(sc, parent.frame())
+}
+lav_matrix_cov <- function(Y, Mu = NULL) {
+  lav_deprecated("lav_mat_cov", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_mat_cov)
+  eval(sc, parent.frame())
+}
+lav_partable_ndat <- function(partable) {
+  lav_deprecated("lav_pt_ndat", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_ndat)
+  eval(sc, parent.frame())
+}
+lav_partable_npar <- function(partable) {
+  lav_deprecated("lav_pt_npar", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_npar)
+  eval(sc, parent.frame())
+}
+lav_partable_add <- function(partable = NULL, add = list()) {
+  lav_deprecated("lav_pt_add", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_add)
+  eval(sc, parent.frame())
+}
+lav_partable_df <- function(partable) {
+  lav_deprecated("lav_pt_df", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lav_pt_df)
+  eval(sc, parent.frame())
+}
+lav_scores <- function(
+                       object,
+                       scaling = FALSE,
+                       ignore.constraints = FALSE,
+                       remove.duplicated = TRUE,
+                       remove.empty.cases = TRUE) {
+  lav_deprecated("lavScores", times = 0L) # --> for now no warning
+  sc <- sys.call()
+  names(sc) <- lav_snake_case(names(sc))
+  sc[[1L]] <- quote(lavaan::lavScores)
+  eval(sc, parent.frame())
+}                                                               # nolint end

--- a/inst/understanding_lavaan_internals.R
+++ b/inst/understanding_lavaan_internals.R
@@ -97,12 +97,12 @@ lavdata@X[[1]] # the raw data in group/block 1
 lavpartable <- lavParTable(model = FLAT, auto = TRUE)
 
 # 4b. compute and store partable attributes (ov.names, ov.names.x, ...)
-lavpta <- lav_partable_attributes(lavpartable)
+lavpta <- lav_pt_attributes(lavpartable)
 lavpta$vnames$ov
 
 # 5. lavsamplestats
 # compute sample statistics (cov, mean, Gamma, ...)
-lavsamplestats <- lavaan:::lav_samplestats_from_data(lavdata,
+lavsamplestats <- lavaan:::lav_samp_from_data(lavdata,
                                                      lavoptions = lavoptions)
 slotNames(lavsamplestats)
 lavsamplestats@cov[[1]] # observed covariance matrix first group/block
@@ -124,7 +124,7 @@ lavoptions$bounds <- "standard"
 lavoptions$optim.bounds <- list(lower = c("ov.var", "loadings"),
                                 upper = c("ov.var", "loadings"),
                                 min.reliability.marker = 0.1)
-lavpartable <- lavaan:::lav_partable_add_bounds(partable = lavpartable,
+lavpartable <- lavaan:::lav_pt_add_bounds(partable = lavpartable,
                 lavh1 = lavh1, lavdata = lavdata, lavsamplestats = lavsamplestats,
                 lavoptions = lavoptions)
 # remove bounds again to save space
@@ -147,12 +147,12 @@ lavmodel@GLIST
 lavcache <- list()
 
 # 11. estimation
-# - default: lav_model_estimate() + nlminb() (quasi-Newton optimization)
+# - default: lav_model_est() + nlminb() (quasi-Newton optimization)
 # - lav_optim_gn(): Gauss-Newton optimization
 # - lav_optim_noniter(): non-iterative procedures
-# - lav_mvnorm_cluster_em_h0: EM for multilevel models
+# - lav_mvn_cl_em_h0: EM for multilevel models
 lavaan:::lav_verbose(TRUE) # be verbose
-x <- try(lavaan:::lav_model_estimate(lavmodel        = lavmodel,
+x <- try(lavaan:::lav_model_est(lavmodel        = lavmodel,
                             lavpartable     = lavpartable,
                             lavsamplestats  = lavsamplestats,
                             lavdata         = lavdata,

--- a/man/lav_constraints.Rd
+++ b/man/lav_constraints.Rd
@@ -1,19 +1,19 @@
 \name{lav_constraints}
-\alias{lav_constraints_parse}
-\alias{lav_partable_constraints_ceq}
-\alias{lav_partable_constraints_ciq}
-\alias{lav_partable_constraints_def}
+\alias{lav_con_parse}
+\alias{lav_pt_con_ceq}
+\alias{lav_pt_con_ciq}
+\alias{lav_pt_con_def}
 \title{Utility Functions: Constraints}
 \description{Utility functions for equality and inequality constraints.}
 \usage{
-lav_constraints_parse(partable = NULL, constraints = NULL, theta = NULL, 
+lav_con_parse(partable = NULL, constraints = NULL, theta = NULL, 
                      debug = FALSE)
-lav_partable_constraints_ceq(partable, con = NULL, debug = FALSE, 
-                             txtOnly = FALSE)
-lav_partable_constraints_ciq(partable, con = NULL, debug = FALSE, 
-                             txtOnly = FALSE)
-lav_partable_constraints_def(partable, con = NULL, debug = FALSE, 
-                             txtOnly = FALSE, warn = TRUE)
+lav_pt_con_ceq(partable, con = NULL, debug = FALSE, 
+                             txt_only = FALSE)
+lav_pt_con_ciq(partable, con = NULL, debug = FALSE, 
+                             txt_only = FALSE)
+lav_pt_con_def(partable, con = NULL, debug = FALSE, 
+                             txt_only = FALSE, warn = TRUE)
 }
 \arguments{
 \item{partable}{A lavaan parameter table.}
@@ -23,7 +23,7 @@ model parameters in the parameter table.}
 \item{debug}{Logical. If TRUE, show debugging information.}
 \item{con}{An optional partable where the operator is one of `==',
 `>', `<' or `:='}
-\item{txtOnly}{Logical. If TRUE, only the body of the function is returned as a character string. If FALSE, a function is returned.}
+\item{txt_only}{Logical. If TRUE, only the body of the function is returned as a character string. If FALSE, a function is returned.}
 \item{warn}{Logical. If FALSE, warnings are suppressed.}
 }
 \details{
@@ -32,20 +32,20 @@ that are used in the lavaan code. They are made public per
 request of package developers. Below is a brief description of what
 they do:
 
-The \code{lav_constraints_parse} function parses the constraints
+The \code{lav_con_parse} function parses the constraints
 specification (provided as a string, see example), and generates
 a list with useful information about the constraints.
 
-The \code{lav_partable_constraints_ceq} function creates a function 
+The \code{lav_pt_con_ceq} function creates a function 
 which takes the (unconstrained) parameter vector as input, and
 returns the slack values for each equality constraint. If the equality
 constraints hold perfectly, this function returns zeroes.
 
-The \code{lav_partable_constraints_ciq} function creates a function
+The \code{lav_pt_con_ciq} function creates a function
 which takes the (unconstrained) parameter vector as input, and
 returns the slack values for each inequality constraint. 
 
-The \code{lav_partable_constraints_def} function creates a function
+The \code{lav_pt_con_def} function creates a function
 which takes the (unconstrained) parameter vector as input, and
 returns the computed values of the defined parameters.
 }
@@ -54,12 +54,12 @@ myModel <- 'x1 ~ a*x2 + b*x3 + c*x4'
 myParTable <- lavParTable(myModel, as.data.frame. = FALSE)
 con <- ' a == 2*b
          b - c == 5 '
-conInfo <- lav_constraints_parse(myParTable, constraints = con)
+conInfo <- lav_con_parse(myParTable, constraints = con)
 
 myModel2 <- 'x1 ~ a*x2 + b*x3 + c*x4
              a == 2*b
              b - c == 5 '
-ceq <- lav_partable_constraints_ceq(partable = lavParTable(myModel2))
+ceq <- lav_pt_con_ceq(partable = lavParTable(myModel2))
 ceq( c(2,3,4) )
 }
 

--- a/man/lav_func.Rd
+++ b/man/lav_func.Rd
@@ -1,18 +1,18 @@
 \name{lav_func}
-\alias{lav_func_gradient_complex}
-\alias{lav_func_gradient_simple}
+\alias{lav_func_grad_complex}
+\alias{lav_func_grad_simple}
 \alias{lav_func_jacobian_complex}
 \alias{lav_func_jacobian_simple}
 \title{Utility Functions: Gradient and Jacobian}
 \description{Utility functions for computing the gradient of a scalar-valued 
 function or the Jacobian of a vector-valued function by numerical approximation.}
 \usage{
-lav_func_gradient_complex(func, x, h = .Machine$double.eps, ..., 
-                          fallback.simple = TRUE)
+lav_func_grad_complex(func, x, h = .Machine$double.eps, ..., 
+                          fallback_simple = TRUE)
 lav_func_jacobian_complex(func, x, h = .Machine$double.eps, ...,
                           fallback.simple = TRUE)
 
-lav_func_gradient_simple(func, x, h = sqrt(.Machine$double.eps), ...)
+lav_func_grad_simple(func, x, h = sqrt(.Machine$double.eps), ...)
 lav_func_jacobian_simple(func, x, h = sqrt(.Machine$double.eps), ...)
 }
 \arguments{
@@ -24,6 +24,8 @@ of the function should be computed.}
 computing the gradient/Jacobian.}
 \item{...}{Additional arguments to be passed to the function `func'.}
 \item{fallback.simple}{Logical. If TRUE, and the function evaluation fails,
+we call the corresponding simple (non-complex) method instead.}
+\item{fallback_simple}{Logical. If TRUE, and the function evaluation fails,
 we call the corresponding simple (non-complex) method instead.}
 }
 \details{
@@ -40,10 +42,10 @@ Derivatives of Real Functions. SIAM Review, 40(1), 110-112.
 }
 \examples{
 # very accurate complex method
-lav_func_gradient_complex(func = exp, x = 1) - exp(1)
+lav_func_grad_complex(func = exp, x = 1) - exp(1)
 
 # less accurate forward method
-lav_func_gradient_simple(func = exp, x = 1) - exp(1)
+lav_func_grad_simple(func = exp, x = 1) - exp(1)
 
 # very accurate complex method
 diag(lav_func_jacobian_complex(func = exp, x = c(1,2,3))) - exp(c(1,2,3))

--- a/man/lav_long_names.Rd
+++ b/man/lav_long_names.Rd
@@ -1,0 +1,358 @@
+\name{lav_long_names}
+\alias{lav_matrix_duplication_ginv_pre_post}
+\alias{lav_matrix_orthogonal_complement}
+\alias{lav_func_gradient_complex}
+\alias{lav_matrix_duplication_ginv_post}
+\alias{lav_func_gradient_simple}
+\alias{lav_matrix_vech_row_idx}
+\alias{lav_matrix_vech_col_idx}
+\alias{lav_matrix_antidiag_idx}
+\alias{lav_matrix_duplication_pre_post}
+\alias{lav_matrix_duplication_ginv_pre}
+\alias{lav_matrix_commutation_pre_post}
+\alias{lav_partable_unrestricted}
+\alias{lav_partable_independence}
+\alias{lav_matrix_vechru_idx}
+\alias{lav_matrix_upper2full}
+\alias{lav_matrix_lower2full}
+\alias{lav_matrix_commutation_mn_pre}
+\alias{lav_samplestats_from_data}
+\alias{lav_matrix_vechru_reverse}
+\alias{lav_matrix_vechr_idx}
+\alias{lav_matrix_vechu_idx}
+\alias{lav_matrix_diagh_idx}
+\alias{lav_partable_attributes}
+\alias{lav_matrix_vechr_reverse}
+\alias{lav_matrix_vechu_reverse}
+\alias{lav_matrix_vech_idx}
+\alias{lav_matrix_diag_idx}
+\alias{lav_matrix_duplication_post}
+\alias{lav_matrix_duplication_ginv}
+\alias{lav_matrix_commutation_post}
+\alias{lav_matrix_symmetric_sqrt}
+\alias{lav_matrix_vech_reverse}
+\alias{lav_matrix_duplication_pre}
+\alias{lav_matrix_commutation_pre}
+\alias{lav_partable_complete}
+\alias{lav_matrix_vechru}
+\alias{lav_partable_constraints_def}
+\alias{lav_partable_constraints_ceq}
+\alias{lav_partable_constraints_ciq}
+\alias{lav_partable_from_lm}
+\alias{lav_constraints_parse}
+\alias{lav_matrix_vechr}
+\alias{lav_matrix_vechu}
+\alias{lav_matrix_bdiag}
+\alias{lav_matrix_trace}
+\alias{lav_partable_labels}
+\alias{lav_matrix_print}
+\alias{lav_matrix_vecr}
+\alias{lav_matrix_vech}
+\alias{lav_partable_merge}
+\alias{lav_model_partable}
+\alias{lav_matrix_vec}
+\alias{lav_matrix_duplication}
+\alias{lav_matrix_commutation}
+\alias{lav_matrix_cov}
+\alias{lav_partable_ndat}
+\alias{lav_partable_npar}
+\alias{lav_partable_add}
+\alias{lav_partable_df}
+\alias{lav_scores}
+
+\title{deprecated functions with long names}
+\description{Functions which are deprecated because of adaption of shorter names in May, 2026}
+\usage{
+lav_matrix_duplication_ginv_pre_post(A = matrix(0, 0, 0))
+lav_matrix_orthogonal_complement(A = matrix(0, 0, 0))
+lav_func_gradient_complex(
+                          func,
+                          x,
+                          h = .Machine$double.eps,
+                          ...,
+                          fallback.simple = TRUE)
+lav_matrix_duplication_ginv_post(A = matrix(0, 0, 0))
+lav_func_gradient_simple(
+                         func,
+                         x,
+                         h = sqrt(.Machine$double.eps),
+                         ...)
+lav_matrix_vech_row_idx(n = 1L, diagonal = TRUE)
+lav_matrix_vech_col_idx(n = 1L, diagonal = TRUE)
+lav_matrix_antidiag_idx(n = 1L)
+lav_matrix_duplication_pre_post(A = matrix(0, 0, 0))
+lav_matrix_duplication_ginv_pre(A = matrix(0, 0, 0))
+lav_matrix_commutation_pre_post(A = matrix(0, 0, 0))
+lav_partable_unrestricted(
+                          lavobject = NULL,
+                          lavdata = NULL,
+                          lavpta = NULL,
+                          lavoptions = NULL,
+                          lavsamplestats = NULL,
+                          lavh1 = NULL,
+                          sample.cov = NULL,
+                          sample.mean = NULL,
+                          sample.slopes = NULL,
+                          sample.th = NULL,
+                          sample.th.idx = NULL,
+                          sample.cov.x = NULL,
+                          sample.mean.x = NULL)
+lav_partable_independence(
+                          lavobject = NULL,
+                          lavdata = NULL,
+                          lavpta = NULL,
+                          lavoptions = NULL,
+                          lavsamplestats = NULL,
+                          lavh1 = NULL,
+                          sample.cov = NULL,
+                          sample.mean = NULL,
+                          sample.slopes = NULL,
+                          sample.th = NULL,
+                          sample.th.idx = NULL,
+                          sample.cov.x = NULL,
+                          sample.mean.x = NULL)
+lav_matrix_vechru_idx(n = 1L, diagonal = TRUE)
+lav_matrix_upper2full(x, diagonal = TRUE)
+lav_matrix_lower2full(x, diagonal = TRUE)
+lav_matrix_commutation_mn_pre(
+                              A,
+                              m = 1L,
+                              n = 1L)
+lav_samplestats_from_data(
+                          lavdata = NULL,
+                          lavoptions = NULL,
+                          WLS.V = NULL,
+                          NACOV = NULL)
+lav_matrix_vechru_reverse(x, diagonal = TRUE)
+lav_matrix_vechr_idx(n = 1L, diagonal = TRUE)
+lav_matrix_vechu_idx(n = 1L, diagonal = TRUE)
+lav_matrix_diagh_idx(n = 1L)
+lav_partable_attributes(partable, pta = NULL)
+lav_matrix_vechr_reverse(x, diagonal = TRUE)
+lav_matrix_vechu_reverse(x, diagonal = TRUE)
+lav_matrix_vech_idx(n = 1L, diagonal = TRUE)
+lav_matrix_diag_idx(n = 1L)
+lav_matrix_duplication_post(A = matrix(0, 0, 0))
+lav_matrix_duplication_ginv(n = 1L)
+lav_matrix_commutation_post(A = matrix(0, 0, 0))
+lav_matrix_symmetric_sqrt(S = matrix(0, 0, 0))
+lav_matrix_vech_reverse(x, diagonal = TRUE)
+lav_matrix_duplication_pre(A = matrix(0, 0, 0))
+lav_matrix_commutation_pre(A = matrix(0, 0, 0))
+lav_partable_complete(partable = NULL, start = TRUE)
+lav_matrix_vechru(S, diagonal = TRUE)
+lav_partable_constraints_def(
+                             partable,
+                             con = NULL,
+                             debug = FALSE,
+                             txtOnly = FALSE,
+                             warn = TRUE)
+lav_partable_constraints_ceq(
+                             partable,
+                             con = NULL,
+                             debug = FALSE,
+                             txtOnly = FALSE)
+lav_partable_constraints_ciq(
+                             partable,
+                             con = NULL,
+                             debug = FALSE,
+                             txtOnly = FALSE)
+lav_partable_from_lm(
+                     object,
+                     est = FALSE,
+                     label = FALSE,
+                     as.data.frame. = FALSE)
+lav_constraints_parse(
+                      partable = NULL,
+                      constraints = NULL,
+                      theta = NULL,
+                      debug = FALSE)
+lav_matrix_vechr(S, diagonal = TRUE)
+lav_matrix_vechu(S, diagonal = TRUE)
+lav_matrix_bdiag(...)
+lav_matrix_trace(..., check = TRUE)
+lav_partable_labels(
+                    partable,
+                    blocks = c("group", "level"),
+                    group.equal = "",
+                    group.partial = "",
+                    type = "user")
+lav_matrix_vecr(A)
+lav_matrix_vech(S, diagonal = TRUE)
+lav_partable_merge(
+                   pt1 = NULL,
+                   pt2 = NULL,
+                   remove.duplicated = FALSE,
+                   fromLast = FALSE,
+                   warn = TRUE)
+lav_model_partable(
+                   model = NULL,
+                   meanstructure = FALSE,
+                   int.ov.free = FALSE,
+                   int.lv.free = FALSE,
+                   marker.int.zero = FALSE,
+                   orthogonal = FALSE,
+                   orthogonal.y = FALSE,
+                   orthogonal.x = FALSE,
+                   orthogonal.efa = FALSE,
+                   std.lv = FALSE,
+                   correlation = FALSE,
+                   composites = TRUE,
+                   effect.coding = "",
+                   conditional.x = FALSE,
+                   fixed.x = FALSE,
+                   parameterization = "delta",
+                   constraints = NULL,
+                   ceq.simple = FALSE,
+                   auto = FALSE,
+                   model.type = "sem",
+                   auto.fix.first = FALSE,
+                   auto.fix.single = FALSE,
+                   auto.var = FALSE,
+                   auto.cov.lv.x = FALSE,
+                   auto.cov.y = FALSE,
+                   auto.th = FALSE,
+                   auto.delta = FALSE,
+                   auto.efa = FALSE,
+                   varTable = NULL,
+                   ngroups = 1L,
+                   nthresholds = NULL,
+                   group.equal = NULL,
+                   group.partial = NULL,
+                   group.w.free = FALSE,
+                   debug = FALSE,
+                   warn = TRUE,
+                   as.data.frame. = TRUE)
+lav_matrix_vec(A)
+lav_matrix_duplication(n = 1L)
+lav_matrix_commutation(m = 1L, n = 1L)
+lav_matrix_cov(Y, Mu = NULL)
+lav_partable_ndat(partable)
+lav_partable_npar(partable)
+lav_partable_add(partable = NULL, add = list())
+lav_partable_df(partable)
+lav_scores(
+           object,
+           scaling = FALSE,
+           ignore.constraints = FALSE,
+           remove.duplicated = TRUE,
+           remove.empty.cases = TRUE)
+}
+\arguments{
+\item{...}{See argument \code{...} in the corresponding function with shortened name.}
+\item{A}{See argument \code{a} in the corresponding function with shortened name.}
+\item{add}{See argument \code{add} in the corresponding function with shortened name.}
+\item{as.data.frame.}{See argument \code{as_data_frame} in the corresponding function with shortened name.}
+\item{auto}{See argument \code{auto} in the corresponding function with shortened name.}
+\item{auto.cov.lv.x}{See argument \code{auto_cov_lv_x} in the corresponding function with shortened name.}
+\item{auto.cov.y}{See argument \code{auto_cov_y} in the corresponding function with shortened name.}
+\item{auto.delta}{See argument \code{auto_delta} in the corresponding function with shortened name.}
+\item{auto.efa}{See argument \code{auto_efa} in the corresponding function with shortened name.}
+\item{auto.fix.first}{See argument \code{auto_fix_first} in the corresponding function with shortened name.}
+\item{auto.fix.single}{See argument \code{auto_fix_single} in the corresponding function with shortened name.}
+\item{auto.th}{See argument \code{auto_th} in the corresponding function with shortened name.}
+\item{auto.var}{See argument \code{auto_var} in the corresponding function with shortened name.}
+\item{blocks}{See argument \code{blocks} in the corresponding function with shortened name.}
+\item{ceq.simple}{See argument \code{ceq_simple} in the corresponding function with shortened name.}
+\item{check}{See argument \code{check} in the corresponding function with shortened name.}
+\item{composites}{See argument \code{composites} in the corresponding function with shortened name.}
+\item{con}{See argument \code{con} in the corresponding function with shortened name.}
+\item{conditional.x}{See argument \code{conditional_x} in the corresponding function with shortened name.}
+\item{constraints}{See argument \code{constraints} in the corresponding function with shortened name.}
+\item{correlation}{See argument \code{correlation} in the corresponding function with shortened name.}
+\item{debug}{See argument \code{debug} in the corresponding function with shortened name.}
+\item{diagonal}{See argument \code{diagonal} in the corresponding function with shortened name.}
+\item{effect.coding}{See argument \code{effect_coding} in the corresponding function with shortened name.}
+\item{est}{See argument \code{est} in the corresponding function with shortened name.}
+\item{fallback.simple}{See argument \code{fallback_simple} in the corresponding function with shortened name.}
+\item{fixed.x}{See argument \code{fixed_x} in the corresponding function with shortened name.}
+\item{fromLast}{See argument \code{from_last} in the corresponding function with shortened name.}
+\item{func}{See argument \code{func} in the corresponding function with shortened name.}
+\item{group.equal}{See argument \code{group_equal} in the corresponding function with shortened name.}
+\item{group.partial}{See argument \code{group_partial} in the corresponding function with shortened name.}
+\item{group.w.free}{See argument \code{group_w_free} in the corresponding function with shortened name.}
+\item{h}{See argument \code{h} in the corresponding function with shortened name.}
+\item{ignore.constraints}{See argument \code{ignore_constraints} in the corresponding function with shortened name.}
+\item{int.lv.free}{See argument \code{int_lv_free} in the corresponding function with shortened name.}
+\item{int.ov.free}{See argument \code{int_ov_free} in the corresponding function with shortened name.}
+\item{label}{See argument \code{label} in the corresponding function with shortened name.}
+\item{lavdata}{See argument \code{lavdata} in the corresponding function with shortened name.}
+\item{lavh1}{See argument \code{lavh1} in the corresponding function with shortened name.}
+\item{lavobject}{See argument \code{lavobject} in the corresponding function with shortened name.}
+\item{lavoptions}{See argument \code{lavoptions} in the corresponding function with shortened name.}
+\item{lavpta}{See argument \code{lavpta} in the corresponding function with shortened name.}
+\item{lavsamplestats}{See argument \code{lavsamplestats} in the corresponding function with shortened name.}
+\item{m}{See argument \code{m} in the corresponding function with shortened name.}
+\item{marker.int.zero}{See argument \code{marker_int_zero} in the corresponding function with shortened name.}
+\item{meanstructure}{See argument \code{meanstructure} in the corresponding function with shortened name.}
+\item{model}{See argument \code{model} in the corresponding function with shortened name.}
+\item{model.type}{See argument \code{model_type} in the corresponding function with shortened name.}
+\item{Mu}{See argument \code{mu} in the corresponding function with shortened name.}
+\item{n}{See argument \code{n} in the corresponding function with shortened name.}
+\item{NACOV}{See argument \code{nacov} in the corresponding function with shortened name.}
+\item{ngroups}{See argument \code{ngroups} in the corresponding function with shortened name.}
+\item{nthresholds}{See argument \code{nthresholds} in the corresponding function with shortened name.}
+\item{object}{See argument \code{object} in the corresponding function with shortened name.}
+\item{orthogonal}{See argument \code{orthogonal} in the corresponding function with shortened name.}
+\item{orthogonal.efa}{See argument \code{orthogonal_efa} in the corresponding function with shortened name.}
+\item{orthogonal.x}{See argument \code{orthogonal_x} in the corresponding function with shortened name.}
+\item{orthogonal.y}{See argument \code{orthogonal_y} in the corresponding function with shortened name.}
+\item{parameterization}{See argument \code{parameterization} in the corresponding function with shortened name.}
+\item{partable}{See argument \code{partable} in the corresponding function with shortened name.}
+\item{pt1}{See argument \code{pt1} in the corresponding function with shortened name.}
+\item{pt2}{See argument \code{pt2} in the corresponding function with shortened name.}
+\item{pta}{See argument \code{pta} in the corresponding function with shortened name.}
+\item{remove.duplicated}{See argument \code{remove_duplicated} in the corresponding function with shortened name.}
+\item{remove.empty.cases}{See argument \code{remove_empty_cases} in the corresponding function with shortened name.}
+\item{S}{See argument \code{s} in the corresponding function with shortened name.}
+\item{sample.cov}{See argument \code{sample_cov} in the corresponding function with shortened name.}
+\item{sample.cov.x}{See argument \code{sample_cov_x} in the corresponding function with shortened name.}
+\item{sample.mean}{See argument \code{sample_mean} in the corresponding function with shortened name.}
+\item{sample.mean.x}{See argument \code{sample_mean_x} in the corresponding function with shortened name.}
+\item{sample.slopes}{See argument \code{sample_slopes} in the corresponding function with shortened name.}
+\item{sample.th}{See argument \code{sample_th} in the corresponding function with shortened name.}
+\item{sample.th.idx}{See argument \code{sample_th_idx} in the corresponding function with shortened name.}
+\item{scaling}{See argument \code{scaling} in the corresponding function with shortened name.}
+\item{start}{See argument \code{start} in the corresponding function with shortened name.}
+\item{std.lv}{See argument \code{std_lv} in the corresponding function with shortened name.}
+\item{theta}{See argument \code{theta} in the corresponding function with shortened name.}
+\item{txtOnly}{See argument \code{txt_only} in the corresponding function with shortened name.}
+\item{type}{See argument \code{type} in the corresponding function with shortened name.}
+\item{varTable}{See argument \code{var_table} in the corresponding function with shortened name.}
+\item{warn}{See argument \code{warn} in the corresponding function with shortened name.}
+\item{WLS.V}{See argument \code{wls_v} in the corresponding function with shortened name.}
+\item{x}{See argument \code{x} in the corresponding function with shortened name.}
+\item{Y}{See argument \code{y} in the corresponding function with shortened name.}
+}
+\details{
+Function names are shortened by following replacements:
+
+\describe{
+  \item{_mvnorm}{_mvn}
+  \item{_cluster}{_cl}
+  \item{_missing}{_mi}
+  \item{_matrix}{_mat}
+  \item{_duplication}{_dup}
+  \item{_commutation}{_com}
+  \item{_information}{_info}
+  \item{_samplestats}{_samp}
+  \item{_satorra_bentler}{_sb}
+  \item{_SatorraBentler}{_sb}
+  \item{_yuan_bentler}{_yb}
+  \item{_inverted}{_inv}
+  \item{_estimate}{_est}
+  \item{_symmetric}{_sym}
+  \item{_lavaan_step}{_step}
+  \item{_univariate}{_uni}
+  \item{_fit_measures}{_fit}
+  \item{_constraints}{_con}
+  \item{_scores}{_sc}
+  \item{_reverse}{_rev}
+  \item{_vech_sigma}{_sigma}
+  \item{_vechsigma}{_sigma}
+  \item{_object_inspect}{_inspect}
+  \item{_orthogonal}{_ortho}
+  \item{_gradient}{_grad}
+  \item{_partable}{_pt}
+}
+}

--- a/man/lav_matrix.Rd
+++ b/man/lav_matrix.Rd
@@ -1,107 +1,107 @@
 \name{lav_matrix}
-\alias{lav_matrix_vec}
-\alias{lav_matrix_vecr}
-\alias{lav_matrix_vech}
-\alias{lav_matrix_vechr}
-\alias{lav_matrix_vechu}
-\alias{lav_matrix_vechru}
-\alias{lav_matrix_vech_idx}
-\alias{lav_matrix_vech_row_idx}
-\alias{lav_matrix_vech_col_idx}
-\alias{lav_matrix_vechr_idx}
-\alias{lav_matrix_vechu_idx}
-\alias{lav_matrix_vechru_idx}
-\alias{lav_matrix_vech_reverse}
-\alias{lav_matrix_vechru_reverse}
-\alias{lav_matrix_upper2full}
-\alias{lav_matrix_vechr_reverse}
-\alias{lav_matrix_vechu_reverse}
-\alias{lav_matrix_lower2full}
-\alias{lav_matrix_diag_idx}
-\alias{lav_matrix_diagh_idx}
-\alias{lav_matrix_antidiag_idx}
-\alias{lav_matrix_duplication}
-\alias{lav_matrix_duplication_pre}
-\alias{lav_matrix_duplication_post}
-\alias{lav_matrix_duplication_pre_post}
-\alias{lav_matrix_duplication_ginv}
-\alias{lav_matrix_duplication_ginv_pre}
-\alias{lav_matrix_duplication_ginv_post}
-\alias{lav_matrix_duplication_ginv_pre_post}
-\alias{lav_matrix_commutation}
-\alias{lav_matrix_commutation_pre}
-\alias{lav_matrix_commutation_post}
-\alias{lav_matrix_commutation_pre_post}
-\alias{lav_matrix_commutation_mn_pre}
-\alias{lav_matrix_symmetric_sqrt}
-\alias{lav_matrix_orthogonal_complement}
-\alias{lav_matrix_bdiag}
-\alias{lav_matrix_trace}
-\alias{lav_matrix_cov}
+\alias{lav_mat_vec}
+\alias{lav_mat_vecr}
+\alias{lav_mat_vech}
+\alias{lav_mat_vechr}
+\alias{lav_mat_vechu}
+\alias{lav_mat_vechru}
+\alias{lav_mat_vech_idx}
+\alias{lav_mat_vech_row_idx}
+\alias{lav_mat_vech_col_idx}
+\alias{lav_mat_vechr_idx}
+\alias{lav_mat_vechu_idx}
+\alias{lav_mat_vechru_idx}
+\alias{lav_mat_vech_rev}
+\alias{lav_mat_vechru_rev}
+\alias{lav_mat_upper2full}
+\alias{lav_mat_vechr_rev}
+\alias{lav_mat_vechu_rev}
+\alias{lav_mat_lower2full}
+\alias{lav_mat_diag_idx}
+\alias{lav_mat_diagh_idx}
+\alias{lav_mat_antidiag_idx}
+\alias{lav_mat_dup}
+\alias{lav_mat_dup_pre}
+\alias{lav_mat_dup_post}
+\alias{lav_mat_dup_pre_post}
+\alias{lav_mat_dup_ginv}
+\alias{lav_mat_dup_ginv_pre}
+\alias{lav_mat_dup_ginv_post}
+\alias{lav_mat_dup_ginv_pre_post}
+\alias{lav_mat_com}
+\alias{lav_mat_com_pre}
+\alias{lav_mat_com_post}
+\alias{lav_mat_com_pre_post}
+\alias{lav_mat_com_mn_pre}
+\alias{lav_mat_sym_sqrt}
+\alias{lav_mat_ortho_complement}
+\alias{lav_mat_bdiag}
+\alias{lav_mat_trace}
+\alias{lav_mat_cov}
 
 \title{Utility Functions: Matrices and Vectors}
 \description{Utility functions for Matrix and Vector operations.}
 \usage{
 # matrix to vector
-lav_matrix_vec(A)
-lav_matrix_vecr(A)
-lav_matrix_vech(S, diagonal = TRUE)
-lav_matrix_vechr(S, diagonal = TRUE)
+lav_mat_vec(a)
+lav_mat_vecr(a)
+lav_mat_vech(s, diagonal = TRUE)
+lav_mat_vechr(s, diagonal = TRUE)
 
 # matrix/vector indices
-lav_matrix_vech_idx(n = 1L, diagonal = TRUE)
-lav_matrix_vech_row_idx(n = 1L, diagonal = TRUE)
-lav_matrix_vech_col_idx(n = 1L, diagonal = TRUE)
-lav_matrix_vechr_idx(n = 1L, diagonal = TRUE)
-lav_matrix_vechru_idx(n = 1L, diagonal = TRUE)
-lav_matrix_diag_idx(n = 1L)
-lav_matrix_diagh_idx(n = 1L)
-lav_matrix_antidiag_idx(n = 1L)
+lav_mat_vech_idx(n = 1L, diagonal = TRUE)
+lav_mat_vech_row_idx(n = 1L, diagonal = TRUE)
+lav_mat_vech_col_idx(n = 1L, diagonal = TRUE)
+lav_mat_vechr_idx(n = 1L, diagonal = TRUE)
+lav_mat_vechru_idx(n = 1L, diagonal = TRUE)
+lav_mat_diag_idx(n = 1L)
+lav_mat_diagh_idx(n = 1L)
+lav_mat_antidiag_idx(n = 1L)
 
 # vector to matrix
-lav_matrix_vech_reverse(x, diagonal = TRUE)
-lav_matrix_vechru_reverse(x, diagonal = TRUE) 
-lav_matrix_upper2full(x, diagonal = TRUE)
-lav_matrix_vechr_reverse(x, diagonal = TRUE)
-lav_matrix_vechu_reverse(x, diagonal = TRUE)
-lav_matrix_lower2full(x, diagonal = TRUE)
+lav_mat_vech_rev(x, diagonal = TRUE)
+lav_mat_vechru_rev(x, diagonal = TRUE) 
+lav_mat_upper2full(x, diagonal = TRUE)
+lav_mat_vechr_rev(x, diagonal = TRUE)
+lav_mat_vechu_rev(x, diagonal = TRUE)
+lav_mat_lower2full(x, diagonal = TRUE)
 
 # the duplication matrix
-lav_matrix_duplication(n = 1L)
-lav_matrix_duplication_pre(A = matrix(0,0,0))
-lav_matrix_duplication_post(A = matrix(0,0,0))
-lav_matrix_duplication_pre_post(A = matrix(0,0,0))
-lav_matrix_duplication_ginv(n = 1L)
-lav_matrix_duplication_ginv_pre(A = matrix(0,0,0))
-lav_matrix_duplication_ginv_post(A = matrix(0,0,0))
-lav_matrix_duplication_ginv_pre_post(A = matrix(0,0,0))
+lav_mat_dup(n = 1L)
+lav_mat_dup_pre(a = matrix(0,0,0))
+lav_mat_dup_post(a = matrix(0,0,0))
+lav_mat_dup_pre_post(a = matrix(0,0,0))
+lav_mat_dup_ginv(n = 1L)
+lav_mat_dup_ginv_pre(a = matrix(0,0,0))
+lav_mat_dup_ginv_post(a = matrix(0,0,0))
+lav_mat_dup_ginv_pre_post(a = matrix(0,0,0))
 
 # the commutation matrix
-lav_matrix_commutation(m = 1L, n = 1L)
-lav_matrix_commutation_pre(A = matrix(0,0,0))
-lav_matrix_commutation_post(A = matrix(0,0,0))
-lav_matrix_commutation_pre_post(A = matrix(0,0,0))
-lav_matrix_commutation_mn_pre(A, m = 1L, n = 1L)
+lav_mat_com(m = 1L, n = 1L)
+lav_mat_com_pre(a = matrix(0,0,0))
+lav_mat_com_post(a = matrix(0,0,0))
+lav_mat_com_pre_post(a = matrix(0,0,0))
+lav_mat_com_mn_pre(a, m = 1L, n = 1L)
 
 # sample statistics
-lav_matrix_cov(Y, Mu = NULL)
+lav_mat_cov(y, mu = NULL)
 
 # other matrix operations
-lav_matrix_symmetric_sqrt(S = matrix(0,0,0))
-lav_matrix_orthogonal_complement(A = matrix(0,0,0))
-lav_matrix_bdiag(...)
-lav_matrix_trace(..., check = TRUE)
+lav_mat_sym_sqrt(s = matrix(0,0,0))
+lav_mat_ortho_complement(a = matrix(0,0,0))
+lav_mat_bdiag(...)
+lav_mat_trace(..., check = TRUE)
 }
 \arguments{
-\item{A}{A general matrix.}
-\item{S}{A symmetric matrix.}
-\item{Y}{A matrix representing a (numeric) dataset.}
+\item{a}{A general matrix.}
+\item{s}{A symmetric matrix.}
+\item{y}{A matrix representing a (numeric) dataset.}
 \item{diagonal}{Logical. If TRUE, include the diagonal.}
 \item{n}{Integer. When it is the only argument, the dimension of a square 
 matrix. If m is also provided, the number of column of the matrix.}
 \item{m}{Integer. The number of rows of a matrix.}
 \item{x}{Numeric. A vector.}
-\item{Mu}{Numeric. If given, use Mu (instead of sample mean) to center, before 
+\item{mu}{Numeric. If given, use mu (instead of sample mean) to center, before 
  taking the crossproduct.}
 \item{...}{One or more matrices, or a list of matrices.}
 \item{check}{Logical. If \code{check = TRUE}, we check if the (final) matrix 
@@ -113,139 +113,139 @@ that are used throughout the lavaan code. They are made public per
 request of package developers. Below is a brief description of what
 they do:
 
-The \code{lav_matrix_vec} function implements the vec operator (for
+The \code{lav_mat_vec} function implements the vec operator (for
 'vectorization') and transforms a matrix into a vector by stacking the
 columns of the matrix one underneath the other.
 
-The \code{lav_matrix_vecr} function is similar to the \code{lav_matrix_vec}
+The \code{lav_mat_vecr} function is similar to the \code{lav_mat_vec}
 function but transforms a matrix into a vector by stacking the
 rows of the matrix one underneath the other.
 
-The \code{lav_matrix_vech} function implements the vech operator
+The \code{lav_mat_vech} function implements the vech operator
 (for 'half vectorization') and transforms a symmetric matrix
 into a vector by stacking the columns of the matrix one underneath the
 other, but eliminating all supradiagonal elements. If diagonal = FALSE,
 the diagonal elements are also eliminated.
 
-The \code{lav_matrix_vechr} function is similar to the \code{lav_matrix_vech} 
+The \code{lav_mat_vechr} function is similar to the \code{lav_mat_vech} 
 function but transforms a matrix into a vector by stacking the
 rows of the matrix one underneath the other, eliminating all 
 supradiagonal elements.
 
-The \code{lav_matrix_vech_idx} function returns the vector indices of the lower
+The \code{lav_mat_vech_idx} function returns the vector indices of the lower
 triangular elements of a symmetric matrix of size n, column by column.
 
-The \code{lav_matrix_vech_row_idx} function returns the row indices of the
+The \code{lav_mat_vech_row_idx} function returns the row indices of the
 lower triangular elements of a symmetric matrix of size n.
 
-The \code{lav_matrix_vech_col_idx} function returns the column indices of the
+The \code{lav_mat_vech_col_idx} function returns the column indices of the
 lower triangular elements of a symmetric matrix of size n.
 
-The \code{lav_matrix_vechr_idx} function returns the vector indices of the
+The \code{lav_mat_vechr_idx} function returns the vector indices of the
 lower triangular elements of a symmetric matrix of size n, row by row.
 
-The \code{lav_matrix_vechu_idx} function returns the vector indices of the
+The \code{lav_mat_vechu_idx} function returns the vector indices of the
 upper triangular elements of a symmetric matrix of size n, column by column.
 
-The \code{lav_matrix_vechru_idx} function returns the vector indices
+The \code{lav_mat_vechru_idx} function returns the vector indices
 of the upper triangular elements of a symmetric matrix of size n, row by row.
 
-The \code{lav_matrix_diag_idx} function returns the vector indices of the
+The \code{lav_mat_diag_idx} function returns the vector indices of the
 diagonal elements of a symmetric matrix of size n.
 
-The \code{lav_matrix_diagh_idx} function returns the vector indices of
+The \code{lav_mat_diagh_idx} function returns the vector indices of
 the lower part of a symmetric matrix of size n.
 
-The \code{lav_matrix_antidiag_idx} function returns the vector indices of
+The \code{lav_mat_antidiag_idx} function returns the vector indices of
 the anti diagonal elements a symmetric matrix of size n.
 
-The \code{lav_matrix_vech_reverse} function (alias:
-\code{lav_matrix_vechru_reverse} and \code{lav_matrix_upper2full}) creates a
+The \code{lav_mat_vech_rev} function (alias:
+\code{lav_mat_vechru_rev} and \code{lav_mat_upper2full}) creates a
 symmetric matrix, given only upper triangular elements, row by row. If
 diagonal = FALSE, an diagonal with zero elements is added.
 
-The \code{lav_matrix_vechr_reverse} (alias: \code{lav_matrix_vechu_reverse} and
-\code{lav_matrix_lower2full}) creates a symmetric matrix, given only the lower
+The \code{lav_mat_vechr_rev} (alias: \code{lav_mat_vechu_rev} and
+\code{lav_mat_lower2full}) creates a symmetric matrix, given only the lower
 triangular elements, row by row. If diagonal = FALSE, an diagonal with zero
 elements is added.
 
-The \code{lav_matrix_duplication} function generates the duplication matrix
+The \code{lav_mat_dup} function generates the duplication matrix
 for a symmetric matrix of size n. This matrix duplicates the elements in
 vech(S) to create vec(S) (where S is symmetric). This matrix is very
 sparse, and should probably never be explicitly created. Use one of 
 the functions below.
 
-The \code{lav_matrix_duplication_pre} function computes the product of the
+The \code{lav_mat_dup_pre} function computes the product of the
 transpose of the duplication matrix and a matrix A. The A matrix should have
 n*n rows, where n is an integer. The duplication matrix is not explicitly
 created.
 
-The \code{lav_matrix_duplication_post} function computes the product of a
+The \code{lav_mat_dup_post} function computes the product of a
 matrix A with the duplication matrix. The A matrix should have n*n columns,
 where n is an integer. The duplication matrix is not explicitly created.
 
-The \code{lav_matrix_duplication_pre_post} function first pre-multiplies a
+The \code{lav_mat_dup_pre_post} function first pre-multiplies a
 matrix A with the transpose of the duplication matrix, and then post multiplies
 the result again with the duplication matrix. A must be square matrix with n*n
 rows and columns, where n is an integer. The duplication matrix is not
 explicitly created.
 
-The \code{lav_matrix_duplication_ginv} function computes the generalized
+The \code{lav_mat_dup_ginv} function computes the generalized
 inverse of the duplication matrix. The matrix removes the duplicated elements
 in vec(S) to create vech(S). This matrix is very sparse, and should probably
 never be explicitly created. Use one of the functions below.
 
-The \code{lav_matrix_duplication_ginv_pre} function computes the product of the
+The \code{lav_mat_dup_ginv_pre} function computes the product of the
 generalized inverse of the duplication matrix and a matrix A with n*n rows,
 where n is an integer. The generalized inverse of the duplication matrix
 is not explicitly created.
 
-The \code{lav_matrix_duplication_ginv_post} function computes the product of a
+The \code{lav_mat_dup_ginv_post} function computes the product of a
 matrix A (with n*n columns, where n is an integer) and the transpose of the
 generalized inverse of the duplication matrix. The generalized inverse of the
 duplication matrix is not explicitly created.
 
-The \code{lav_matrix_duplication_ginv_pre_post} function first pre-multiplies
+The \code{lav_mat_dup_ginv_pre_post} function first pre-multiplies
 a matrix A with the transpose of the generalized inverse of the duplication
 matrix, and then post multiplies the result again with the transpose of the
 generalized inverse matrix. The matrix A must be square with n*n rows and
 columns, where n is an integer. The generalized inverse of the duplication
 matrix is not explicitly created.
 
-The \code{lav_matrix_commutation} function computes the commutation matrix which
+The \code{lav_mat_com} function computes the commutation matrix which
 is a permutation matrix which transforms vec(A) (with m rows and n columns) 
 into vec(t(A)).
 
-The \code{lav_matrix_commutation_pre} function computes the product of the
+The \code{lav_mat_com_pre} function computes the product of the
 commutation matrix with a matrix A, without explicitly creating the commutation
 matrix. The matrix A must have n*n rows, where n is an integer.
 
-The \code{lav_matrix_commutation_post} function computes the product of a 
+The \code{lav_mat_com_post} function computes the product of a 
 matrix A with the commutation matrix, without explicitly creating the 
 commutation matrix. The matrix A must have n*n rows, where n is an integer.
 
-The \code{lav_matrix_commutation_pre_post} function first pre-multiplies
+The \code{lav_mat_com_pre_post} function first pre-multiplies
 a matrix A with the commutation matrix, and then post multiplies the result again with the commutation matrix, without explicitly creating the 
 commutation matrix. The matrix A must have n*n rows, where n is an integer.
 
-The \code{lav_matrix_commutation_mn_pre} function computes the product of the
+The \code{lav_mat_com_mn_pre} function computes the product of the
 commutation matrix with a matrix A, without explicitly creating the commutation
 matrix. The matrix A must have m*n rows, where m and n are integers.
 
-The \code{lav_matrix_cov} function computes the sample covariance matrix of
+The \code{lav_mat_cov} function computes the sample covariance matrix of
 its input matrix, where the elements are divided by N (the number of rows).
 
-The \code{lav_matrix_symmetric_sqrt} function computes the square root of a
+The \code{lav_mat_sym_sqrt} function computes the square root of a
 positive definite symmetric matrix (using an eigen decomposition).  If some of
 the eigenvalues are negative, they are silently fixed to zero.
 
-The \code{lav_matrix_orthogonal_complement} function computes an orthogonal
+The \code{lav_mat_ortho_complement} function computes an orthogonal
 complement of the matrix A, using a qr decomposition.
 
-The \code{lav_matrix_bdiag} function constructs a block diagonal matrix from
+The \code{lav_mat_bdiag} function constructs a block diagonal matrix from
 its arguments.
 
-The \code{lav_matrix_trace} function computes the trace (the sum of the
+The \code{lav_mat_trace} function computes the trace (the sum of the
 diagonal elements) of a single (square) matrix, or if multiple matrices are
 provided (either as a list, or as multiple arguments), we first compute their
 product (which must result in a square matrix), and then we compute the trace; 
@@ -259,10 +259,10 @@ with Applications in Statistics and Econometrics, Second Edition, John Wiley.
 # upper elements of a 3 by 3 symmetric matrix (row by row)
 x <- c(30, 16, 5, 10, 3, 1)
 # construct full symmetric matrix
-S <- lav_matrix_upper2full(x)
+S <- lav_mat_upper2full(x)
 
 # compute the normal theory `Gamma' matrix given a covariance
 # matrix (S), using the formula: Gamma = 2 * D^{+} (S %x% S) t(D^{+})
-Gamma.NT <- 2 * lav_matrix_duplication_ginv_pre_post(S \%x\% S)
+Gamma.NT <- 2 * lav_mat_dup_ginv_pre_post(S \%x\% S)
 Gamma.NT
 }

--- a/man/lav_partable.Rd
+++ b/man/lav_partable.Rd
@@ -1,55 +1,55 @@
 \name{lav_partable}
-\alias{lav_partable_independence}
-\alias{lav_partable_unrestricted}
-\alias{lav_partable_df}
-\alias{lav_partable_ndat}
-\alias{lav_partable_npar}
-\alias{lav_partable_labels}
-\alias{lav_partable_from_lm}
-\alias{lav_partable_complete}
-\alias{lav_partable_attributes}
-\alias{lav_partable_merge}
-\alias{lav_partable_add}
+\alias{lav_pt_independence}
+\alias{lav_pt_unrestricted}
+\alias{lav_pt_df}
+\alias{lav_pt_ndat}
+\alias{lav_pt_npar}
+\alias{lav_pt_labels}
+\alias{lav_pt_from_lm}
+\alias{lav_pt_complete}
+\alias{lav_pt_attributes}
+\alias{lav_pt_merge}
+\alias{lav_pt_add}
 \title{lavaan partable functions}
 \description{Utility functions related to the parameter table (partable)}
 \usage{
 # extract information from a parameter table
-lav_partable_df(partable)
-lav_partable_ndat(partable)
-lav_partable_npar(partable)
-lav_partable_attributes(partable, pta = NULL)
+lav_pt_df(partable)
+lav_pt_ndat(partable)
+lav_pt_npar(partable)
+lav_pt_attributes(partable, pta = NULL)
 
 # generate parameter labels
-lav_partable_labels(partable, blocks = c("group", "level"), 
-                    group.equal = "", group.partial = "", type = "user")
+lav_pt_labels(partable, blocks = c("group", "level"), 
+                    group_equal = "", group_partial = "", type = "user")
 
 # generate parameter table for specific models
-lav_partable_independence(lavobject = NULL, lavdata = NULL,
+lav_pt_independence(lavobject = NULL, lavdata = NULL,
     lavpta = NULL, lavoptions = NULL, lavsamplestats = NULL,
     lavh1 = NULL,
-    sample.cov = NULL, sample.mean = NULL, sample.slopes = NULL,
-    sample.th = NULL, sample.th.idx = NULL,
-    sample.cov.x = NULL, sample.mean.x = NULL)
+    sample_cov = NULL, sample_mean = NULL, sample_slopes = NULL,
+    sample_th = NULL, sample_th_idx = NULL,
+    sample_cov_x = NULL, sample_mean_x = NULL)
 
-lav_partable_unrestricted(lavobject = NULL, lavdata = NULL, 
+lav_pt_unrestricted(lavobject = NULL, lavdata = NULL, 
     lavpta = NULL, lavoptions = NULL, lavsamplestats = NULL, 
     lavh1 = NULL,
-    sample.cov = NULL, sample.mean = NULL, sample.slopes = NULL, 
-    sample.th = NULL, sample.th.idx = NULL,
-    sample.cov.x = NULL, sample.mean.x = NULL) 
+    sample_cov = NULL, sample_mean = NULL, sample_slopes = NULL, 
+    sample_th = NULL, sample_th_idx = NULL,
+    sample_cov_x = NULL, sample_mean_x = NULL) 
 
-lav_partable_from_lm(object, est = FALSE, label = FALSE, 
-    as.data.frame. = FALSE)
+lav_pt_from_lm(object, est = FALSE, label = FALSE, 
+    as_data_frame = FALSE)
 
 # complete a parameter table only containing a few columns (lhs,op,rhs)
-lav_partable_complete(partable = NULL, start = TRUE)
+lav_pt_complete(partable = NULL, start = TRUE)
 
 # merge two parameter tables
-lav_partable_merge(pt1 = NULL, pt2 = NULL, remove.duplicated = FALSE, 
-    fromLast = FALSE, warn = TRUE)
+lav_pt_merge(pt1 = NULL, pt2 = NULL, remove_duplicated = FALSE, 
+    from_last = FALSE, warn = TRUE)
 
 # add a single parameter to an existing parameter table
-lav_partable_add(partable = NULL, add = list())
+lav_pt_add(partable = NULL, add = list())
 }
 \arguments{
 \item{partable}{A parameter table. See \code{\link{lavParTable}} 
@@ -63,9 +63,10 @@ for more information.}
   the parameters of all but the first level. If \code{"blocks"} includes, 
   say \code{"foo"}, a suffix \code{".foo"} and the corresponding value of
   \code{"foo"} is added to all parameters.}
-\item{group.equal}{The same options can be used here as in the fitting functions. Parameters that are constrained to be equal across groups will be given the
+\item{group_equal}{The same options can be used here as in the fitting functions.
+Parameters that are constrained to be equal across groups will be given the
 same label.}
-\item{group.partial}{A vector of character strings containing the labels
+\item{group_partial}{A vector of character strings containing the labels
     of the parameters which should be free in all groups.}
 \item{type}{Character string. Can be either `user' or `free' to select all
 entries or only the free parameters from the parameter table respectively.}
@@ -78,42 +79,42 @@ are extracted from this object.}
 slot from a lavaan object.}
 \item{lavh1}{A named list. The h1 slot from a lavaan object.}
 \item{lavpta}{The pta (parameter table attributes) slot from a lavaan object.}
-\item{sample.cov}{Optional list of numeric matrices. 
+\item{sample_cov}{Optional list of numeric matrices. 
 Each list element contains a sample variance-covariance matrix for this group.
 If provided, these values will be used as starting values.}
-\item{sample.mean}{Optional list of numeric vectors. 
+\item{sample_mean}{Optional list of numeric vectors. 
 Each list element contains a sample mean vector for this group. 
 If provided, these values will be used as starting values.}
-\item{sample.slopes}{Optional list of numeric matrices.
+\item{sample_slopes}{Optional list of numeric matrices.
 Each list element contains the sample slopes for this group (only used
 when \code{conditional.x = TRUE}).
 If provided, these values will be used as starting values.}
-\item{sample.th}{Optional list of numeric vectors. 
+\item{sample_th}{Optional list of numeric vectors. 
 Each list element contains a vector of sample thresholds for this group.
 If provided (and also sample.th.idx is provided), 
 these values will be used as starting values.}
-\item{sample.th.idx}{Optional list of integers. Each list contains the
+\item{sample_th_idx}{Optional list of integers. Each list contains the
 threshold indices for this group.}
-\item{sample.cov.x}{Optional list of numeric matrices.  Each list element
+\item{sample_cov_x}{Optional list of numeric matrices.  Each list element
 contains a sample variance-covariance matrix for the exogenous variables
 for this group (only used when \code{conditional.x = TRUE}).  If provided,
 these values will be used as starting values.}
-\item{sample.mean.x}{Optional list of numeric vectors.
+\item{sample_mean_x}{Optional list of numeric vectors.
 Each list element contains a sample mean vector for the exogenous variables
 for this group (only used when \code{conditional.x = TRUE}).
 If provided, these values will be used as starting values.}
 \item{est}{Logical. If TRUE, include the fitted estimates in the parameter table.}
 \item{label}{Logical. If TRUE, include parameter labels in the parameter table.}
-\item{as.data.frame.}{Logical. If TRUE, return the parameter table as a data.frame.}
+\item{as_data_frame}{Logical. If TRUE, return the parameter table as a data.frame.}
 \item{object}{An object of class \code{lm}.}
 \item{start}{Logical. If TRUE, include a start column, based on 
 the simple method for generating starting values.}
 \item{pta}{A list containing parameter attributes.}
 \item{pt1}{A parameter table.}
 \item{pt2}{A parameter table.}
-\item{remove.duplicated}{Logical. If \code{TRUE}, remove duplicated elements
+\item{remove_duplicated}{Logical. If \code{TRUE}, remove duplicated elements
 when merging two parameter tables.}
-\item{fromLast}{Logical. If \code{TRUE}, duplicated elements are considered
+\item{from_last}{Logical. If \code{TRUE}, duplicated elements are considered
 from the bottom of the merged parameter table.}
 \item{warn}{Logical. If \code{TRUE}, a warning is produced when duplicated
 elements are found, when merging two parameter tables.}
@@ -126,14 +127,14 @@ HS.model <- ' visual  =~ x1 + x2 + x3
               speed   =~ x7 + x8 + x9 '
 
 fit <- cfa(HS.model, data=HolzingerSwineford1939)
-lav <- lav_partable_independence(fit)
+lav <- lav_pt_independence(fit)
 as.data.frame(lav, stringsAsFactors = FALSE)
 
 
 # how many free parameters?
-lav_partable_npar(lav)
+lav_pt_npar(lav)
 
 # how many sample statistics?
-lav_partable_ndat(lav)
+lav_pt_ndat(lav)
 }
 

--- a/man/lav_samplestats.Rd
+++ b/man/lav_samplestats.Rd
@@ -1,17 +1,17 @@
 \name{lav_samplestats}
-\alias{lav_samplestats_from_data}
+\alias{lav_samp_from_data}
 \title{lavaan samplestats functions}
 \description{Utility functions related to the sample statistics}
 \usage{
 # generate samplestats object from full data
-lav_samplestats_from_data(lavdata = NULL, lavoptions = NULL, 
-                          WLS.V = NULL, NACOV = NULL)
+lav_samp_from_data(lavdata = NULL, lavoptions = NULL, 
+                          wls_v = NULL, nacov = NULL)
 }
 \arguments{
 \item{lavdata}{A lavdata object.}
 \item{lavoptions}{A named list. The Options lsot from a lavaan object.}
-\item{WLS.V}{A user provided weight matrix.}
-\item{NACOV}{A user provided matrix containing the elements of (N times)
+\item{wls_v}{A user provided weight matrix.}
+\item{nacov}{A user provided matrix containing the elements of (N times)
     the asymptotic variance-covariance matrix of the sample statistics.
     For a multiple group analysis, a list with an asymptotic
     variance-covariance matrix for each group.}
@@ -29,7 +29,7 @@ lavdata <- fit@Data
 lavoptions <- lavInspect(fit, "options")
 
 # generate sample statistics object
-sampleStats <- lav_samplestats_from_data(lavdata = lavdata, 
+sampleStats <- lav_samp_from_data(lavdata = lavdata, 
                                          lavoptions = lavoptions)
 }
 


### PR DESCRIPTION
functions to snake_case. 
Exported functions with long names and original arguments are kept but moved to zzz_old_long_names.R, where there is a possibility to report them as obsolete (by increasing the times parameter of lav_deprecated). 