### PR TITLE
Convert items in temporary lists in lavaan() to snake_case, ...

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -20,7 +20,7 @@ importFrom("stats",
            "as.formula", "complete.cases", "cor", "cov", "cov2cor", "cov.wt",
            "dnorm", "lm.fit", "lm.wfit", "mad", "na.omit", "nlminb", "optim", 
            "pchisq", "plogis", "pnorm", "qchisq", "qnorm", "quantile", "rnorm",
-           "runif", "sd", "terms", "uniroot", "var", "weighted.mean", 
+           "runif", "sd", "terms", "uniroot", "var", "weighted.mean", "median",
            "aggregate", "dlogis", "qlogis", "optimize", "lm", "setNames",
            # generics
            "coef", "residuals", "resid", "fitted.values", "fitted",

--- a/R/lav_lavaan_step00_init.R
+++ b/R/lav_lavaan_step00_init.R
@@ -172,8 +172,8 @@ lav_step00_checkdata <- function(data = NULL,
   }
 
   list(
-    data = data, dotdotdot = dotdotdot, sample.cov = sample_cov,
-    sample.nobs = sample_nobs, sample.mean = sample_mean,
-    sample.th = sample_th, NACOV = nacov, WLS.V = wls_v, ov.order = ov_order
+    data = data, dotdotdot = dotdotdot, sample_cov = sample_cov,
+    sample_nobs = sample_nobs, sample_mean = sample_mean,
+    sample_th = sample_th, nacov = nacov, wls_v = wls_v, ov_order = ov_order
   )
 }

--- a/R/lav_lavaan_step01_ovnames.R
+++ b/R/lav_lavaan_step01_ovnames.R
@@ -1,20 +1,20 @@
 lav_step01_ovnames_initflat <- function(slot_par_table     = NULL,
                                                model            = NULL,
                                                dotdotdot_parser = "new") {
-  # if slotPartable not NULL copy to flat.model
+  # if slotPartable not NULL copy to flat_model
   # else
   #   if model is of type character
-  #     parse model to flat.model
+  #     parse model to flat_model
   #   else if model is a formula (** warning **)
   #     transform "~ x1 + x2 + x3" to character "f =~ x1 + x2 + x3",
-  #         and parse to flat.model
-  #     transform "y =~ x1 + x2 + x3" to character and parse to flat.model
+  #         and parse to flat_model
+  #     transform "y =~ x1 + x2 + x3" to character and parse to flat_model
   #     something else : *** error ***
   #   else if model is a lavaan object
-  #     extract flat.model from @parTable
+  #     extract flat_model from @parTable
   #   else if model is a list
   #     if bare minimum present (columns lhs, op, rhs, free)
-  #        flat.model = model
+  #        flat_model = model
   #        replace column block by column group (if present)
   #     else
   #        --> *** error ***
@@ -66,7 +66,7 @@ lav_step01_ovnames_initflat <- function(slot_par_table     = NULL,
     # a list! perhaps a full parameter table, or an initial flat model,
     # or something else...
 
-  # 1. flat.model already (output of lavParseModelString)?
+  # 1. flat_model already (output of lavParseModelString)?
   if (!is.null(model$lhs) && !is.null(model$op) &&
       !is.null(model$rhs) && !is.null(model$mod.idx) &&
     !is.null(attr(model, "modifiers"))) {
@@ -102,7 +102,7 @@ lav_step01_ovnames_initflat <- function(slot_par_table     = NULL,
     lav_msg_stop(gettext("model is NULL or not a valid type for it!"))
   }
 
-  # Ok, we got a flattened model; usually this a flat.model object, but it
+  # Ok, we got a flattened model; usually this a flat_model object, but it
   # could also be an already lavaanified parTable, or a bare-minimum list with
   # lhs/op/rhs/free elements
   flat_model
@@ -125,7 +125,7 @@ lav_step01_ovnames_composites <- function(flat_model = NULL) {
     return(flat_model)
   }
 
-  # flat.model info
+  # flat_model info
   flat_names <- names(flat_model)
   c_names <- unique(flat_model$lhs[c_idx])
   nc <- length(c_names)
@@ -188,13 +188,13 @@ lav_step01_ovnames_ovorder <- function(flat_model = NULL,
   # set ov.order in lowercase, check if it is "data" or "model",
   #  if not *** error ***
   # if ov.order == "data"
-  #   try adapt flat.model via lav_partable_ov_from_data
+  #   try adapt flat_model via lav_partable_ov_from_data
   #   (** warning ** if this fails)
 
   # new in 0.6-14
   # if ov.order = "data", it would seem we need to intervene here;
   # ldw 1/3/2024:
-  # we do this by adding an attribute "ovda" to flat.model and partable
+  # we do this by adding an attribute "ovda" to flat_model and partable
   ov_order <- tolower(ov_order)
   if (ov_order == "data") {
     flat_model_orig <- flat_model
@@ -221,20 +221,20 @@ lav_step01_ovnames_ovorder <- function(flat_model = NULL,
 
 lav_step01_ovnames_group <- function(flat_model = NULL,
                                             ngroups    = 1L) {
-  # if "group :" appears in flat.model
+  # if "group :" appears in flat_model
   #   tmp.group.values: set of names in corresponding right hand sides
-  #   copy flat.model without attributes and call lav_model_pt,
+  #   copy flat_model without attributes and call lav_model_pt,
   #     store result in tmp.lav
   #   extract ov.names, ov.names.y, ov.names.x, lv.names from tmp.lav
   #     via lav_partable_vnames
   # else
-  #   if flat.model$group not NULL and more than 1 group.value
+  #   if flat_model$group not NULL and more than 1 group.value
   #     extract group.values via lav_partable_group_values
   #     extract, for each group.value,
-  #       ov.names, ov.names.y, ov.names.x, lv.names from flat.model
+  #       ov.names, ov.names.y, ov.names.x, lv.names from flat_model
   #       via lav_partable_vnames
   #   else
-  #     extract ov.names, ov.names.y, ov.names.x, lv.names from flat.model
+  #     extract ov.names, ov.names.y, ov.names.x, lv.names from flat_model
   #     via lav_partable_vnames
   #
   #     TODO: call lav_pt_vnames only ones and not for each type
@@ -330,12 +330,12 @@ lav_step01_ovnames_group <- function(flat_model = NULL,
   }
 
   list(
-    flat.model   = flat_model,
-    ov.names     = ov_names,
-    ov.names.x   = ov_names_x,
-    ov.names.y   = ov_names_y,
-    lv.names     = lv_names,
-    group.values = group_values,
+    flat_model   = flat_model,
+    ov_names     = ov_names,
+    ov_names_x   = ov_names_x,
+    ov_names_y   = ov_names_y,
+    lv_names     = lv_names,
+    group_values = group_values,
     ngroups      = ngroups
   )
 }
@@ -408,24 +408,24 @@ lav_step01_ovnames_checklv <- function(
   invisible(NULL)
 }
 
-lav_step01_ovnames_namesl <- function(data         = NULL,
-                                             cluster      = NULL,
-                                             flat_model   = NULL,
-                                             group_values = NULL,
-                                             ngroups      = 1L) {
-  # if "level :" appears in flat.model
+lav_step01_ovnames_namesl <- function(data = NULL,
+                                      cluster      = NULL,
+                                      flat_model   = NULL,
+                                      group_values = NULL,
+                                      ngroups      = 1L) {
+  # if "level :" appears in flat_model
   #   if data not NULL, cluster must not be NULL, if it is: *** error ***
-  #   compute tmp.group.values and tmp.level.values from flat.model
+  #   compute tmp.group.values and tmp.level.values from flat_model
   #   there should be at least 2 levels, if not *** error ***
-  #   copy flat.model without attributes and lav_model_pt -> tmp.lav
+  #   copy flat_model without attributes and lav_model_pt -> tmp.lav
   #   check at least 2 levels for tmp.lav, if not *** error ***
   #   compute ov.names.l per group and per level (via lav_partable_vnames
   #     on tmp.lav)
   # else
-  #   if lav_pt_nlevels(flat.model) > 0
+  #   if lav_pt_nlevels(flat_model) > 0
   #   if data not NULL, cluster must not be NULL, if it is: *** error ***
   #     compute ov.names.l per group and per level (via lav_partable_vnames
-  #     on flat.model)
+  #     on flat_model)
   #   else
   #     there are no levels (ov.names.l = list())
 
@@ -519,8 +519,8 @@ lav_step01_ovnames_namesl <- function(data         = NULL,
   }
 
   list(
-    flat.model = flat_model,
-    ov.names.l = ov_names_l
+    flat_model = flat_model,
+    ov_names_l = ov_names_l
   )
 }
 

--- a/R/lav_lavaan_step02_options.R
+++ b/R/lav_lavaan_step02_options.R
@@ -48,7 +48,7 @@ lav_step02_options <- function(slot_options = NULL,
   #     set opt$estimator to "MLR"
   #   if constraints present and estimator == "ML", set opt$information to
   #     c("observed", "observed")
-  #   if there is an operator "~1" in flat.model and sample.mean not NULL,
+  #   if there is an operator "~1" in flat_model and sample.mean not NULL,
   #     set opt$meanstructure TRUE
   #   if there are no exogenous variables but conditional.x explicitly
   #     requested: ** warning **

--- a/R/lav_lavaan_step03_data.R
+++ b/R/lav_lavaan_step03_data.R
@@ -31,7 +31,7 @@ lav_step03_data <- function(slot_data = NULL,
   #     if lavoptions$conditional.x
   # if lavdata$data.type is "none"
   #   set lavoptions$do.fit to FALSE
-  #   if flat.model$est not null set lavoptions$start to "est", else set
+  #   if flat_model$est not null set lavoptions$start to "est", else set
   #     it to "simple"
   #   set lavoptions$se and lavoptions$test to "none"
   # else

--- a/R/lav_lavaan_step04_partable.R
+++ b/R/lav_lavaan_step04_partable.R
@@ -25,7 +25,7 @@ lav_step04_pt <- function(slot_par_table = NULL,
   #     else
   #       if model is a list
   #         set lavpartable to
-  #           as.list(lav_pt_complete(as.list(flat.model)))
+  #           as.list(lav_pt_complete(as.list(flat_model)))
   #       else
   #         *** error ***
   # if slotParTable is NULL check lavpartable via lav_partable_check
@@ -38,13 +38,13 @@ lav_step04_pt <- function(slot_par_table = NULL,
     lavpartable <- lav_pt_set_cache(slot_par_table)
   } else if (is.character(model) ||
     inherits(model, "formula") ||
-  # model was already a flat.model
+  # model was already a flat_model
   (is.list(model) && !is.null(model$mod.idx) &&
    !is.null(attr(model, "modifiers")))) {
     if (lav_verbose()) {
       cat("lavpartable        ...")
     }
-    # check flat.model before we proceed
+    # check flat_model before we proceed
     if (lav_debug()) {
       print(as.data.frame(flat_model))
     }
@@ -52,9 +52,9 @@ lav_step04_pt <- function(slot_par_table = NULL,
     # --> done inside lav_model_pt!
 
     # if(lavoptions$fixed.x) {
-    #    tmp <- lav_pt_vnames(flat.model, type = "ov.x",
+    #    tmp <- lav_pt_vnames(flat_model, type = "ov.x",
     #                               ov.x.fatal = FALSE, warn = TRUE)
-    # tmp <- try(lav_pt_vnames(flat.model, type = "ov.x",
+    # tmp <- try(lav_pt_vnames(flat_model, type = "ov.x",
     #                                         ov.x.fatal = TRUE),
     #           silent = TRUE)
     # if(inherits(tmp, "try-error")) {
@@ -64,7 +64,7 @@ lav_step04_pt <- function(slot_par_table = NULL,
     # }
     # }
     # if(lavoptions$conditional.x) {
-    #    tmp <- lav_pt_vnames(flat.model,
+    #    tmp <- lav_pt_vnames(flat_model,
     #                  type = "ov.x", ov.x.fatal = TRUE)
     # }
     tmp_data_ov <- lavdata@ov
@@ -114,7 +114,7 @@ lav_step04_pt <- function(slot_par_table = NULL,
   } else if (inherits(model, "lavaan")) {
     lavpartable <- lav_pt_set_cache(as.list(parTable(model)), model@pta)
   } else if (is.list(model)) {
-    # we already checked this when creating flat.model
+    # we already checked this when creating flat_model
     # but we may need to complete it
     lavpartable <- as.list(flat_model) # in case model is a data.frame
     # complete table

--- a/R/lav_partable.R
+++ b/R/lav_partable.R
@@ -1372,8 +1372,42 @@ lavParTable <- lavaanify <- function(              # synonym # nolint start
                                debug = FALSE,
                                warn = TRUE,
                                as.data.frame. = TRUE) {    # nolint end
-  sc <- sys.call()
-  names(sc) <- lav_snake_case(names(sc))
-  sc[[1L]] <- quote(lavaan:::lav_model_pt)
-  eval(sc, parent.frame())
+  lav_model_pt(
+              model = model,
+              meanstructure = meanstructure,
+              int_ov_free = int.ov.free,
+              int_lv_free = int.lv.free,
+              marker_int_zero = marker.int.zero,
+              orthogonal = orthogonal,
+              orthogonal_y = orthogonal.y,
+              orthogonal_x = orthogonal.x,
+              orthogonal_efa = orthogonal.efa,
+              std_lv = std.lv,
+              correlation = correlation,
+              composites = composites,
+              effect_coding = effect.coding,
+              conditional_x = conditional.x,
+              fixed_x = fixed.x,
+              parameterization = parameterization,
+              constraints = constraints,
+              ceq_simple = ceq.simple,
+              auto = auto,
+              model_type = model.type,
+              auto_fix_first = auto.fix.first,
+              auto_fix_single = auto.fix.single,
+              auto_var = auto.var,
+              auto_cov_lv_x = auto.cov.lv.x,
+              auto_cov_y = auto.cov.y,
+              auto_th = auto.th,
+              auto_delta = auto.delta,
+              auto_efa = auto.efa,
+              var_table = varTable,
+              ngroups = ngroups,
+              nthresholds = nthresholds,
+              group_equal = group.equal,
+              group_partial = group.partial,
+              group_w_free = group.w.free,
+              debug = debug,
+              warn = warn,
+              as_data_frame = as.data.frame.)
 }

--- a/R/lav_scores.R
+++ b/R/lav_scores.R
@@ -141,10 +141,10 @@ lavScores <- estfun.lavaan <- function(               # nolint start
                        ignore.constraints = FALSE,
                        remove.duplicated = TRUE,
                        remove.empty.cases = TRUE) {   # nolint end
-  sc <- sys.call()
-  names(sc) <- lav_snake_case(names(sc))
-  sc[[1L]] <- quote(lavaan:::lav_sc)
-  eval(sc, parent.frame())
+  lav_sc(object, scaling = scaling,
+        ignore_constraints = ignore.constraints,
+        remove_duplicated = remove.duplicated,
+        remove_empty_cases = remove.empty.cases)
 }
 
 lav_sc_ml <- function(ntab = 0L,

--- a/R/lav_simulate_old.R
+++ b/R/lav_simulate_old.R
@@ -47,7 +47,7 @@ lav_data_simulate_old <- function( # user-specified model    # nolint start
   #    runif(1)               # initialize the RNG if necessary
   # RNGstate <- .Random.seed
 
-  # lav_model_partable
+  # lav_model_pt
   if (is.list(model)) {
     # two possibilities: either model is already lavaanified
     # or it is something else...

--- a/R/xxx_lavaan.R
+++ b/R/xxx_lavaan.R
@@ -112,13 +112,13 @@ lavaan <- function(
   )
   data <- temp$data
   dotdotdot <- temp$dotdotdot
-  sample_cov <- temp$sample.cov
-  sample_nobs <- temp$sample.nobs
-  sample_mean <- temp$sample.mean
-  sample_th <- temp$sample.th
-  nacov <- temp$NACOV
-  wls_v <- temp$WLS.V
-  ov_order <- temp$ov.order
+  sample_cov <- temp$sample_cov
+  sample_nobs <- temp$sample_nobs
+  sample_mean <- temp$sample_mean
+  sample_th <- temp$sample_th
+  nacov <- temp$nacov
+  wls_v <- temp$wls_v
+  ov_order <- temp$ov_order
 
   timing <- lav_add_timing(timing, "init")
 
@@ -158,12 +158,12 @@ lavaan <- function(
     flat_model = flat_model,
     ngroups    = ngroups
   )
-  flat_model <- temp$flat.model
-  ov_names <- temp$ov.names
-  ov_names_x <- temp$ov.names.x
-  ov_names_y <- temp$ov.names.y
-  lv_names <- temp$lv.names
-  group_values <- temp$group.values
+  flat_model <- temp$flat_model
+  ov_names <- temp$ov_names
+  ov_names_x <- temp$ov_names_x
+  ov_names_y <- temp$ov_names_y
+  lv_names <- temp$lv_names
+  group_values <- temp$group_values
   ngroups <- temp$ngroups
 
   # ------------ ov.names 4 ------ sanity checks ------------------
@@ -184,8 +184,8 @@ lavaan <- function(
     group_values = group_values,
     ngroups      = ngroups
   )
-  flat_model <- temp$flat.model
-  ov_names_l <- temp$ov.names.l
+  flat_model <- temp$flat_model
+  ov_names_l <- temp$ov_names_l
 
   # ------------ ov.names 6 ------ sanity check ordered --------------
   ordered_orig <- ordered

--- a/R/zzz_old_long_names.R
+++ b/R/zzz_old_long_names.R
@@ -422,50 +422,6 @@ lav_partable_merge <- function(
   sc[[1L]] <- quote(lavaan::lav_pt_merge)
   eval(sc, parent.frame())
 }
-lav_model_partable <- function(
-                               model = NULL,
-                               meanstructure = FALSE,
-                               int.ov.free = FALSE,
-                               int.lv.free = FALSE,
-                               marker.int.zero = FALSE,
-                               orthogonal = FALSE,
-                               orthogonal.y = FALSE,
-                               orthogonal.x = FALSE,
-                               orthogonal.efa = FALSE,
-                               std.lv = FALSE,
-                               correlation = FALSE,
-                               composites = TRUE,
-                               effect.coding = "",
-                               conditional.x = FALSE,
-                               fixed.x = FALSE,
-                               parameterization = "delta",
-                               constraints = NULL,
-                               ceq.simple = FALSE,
-                               auto = FALSE,
-                               model.type = "sem",
-                               auto.fix.first = FALSE,
-                               auto.fix.single = FALSE,
-                               auto.var = FALSE,
-                               auto.cov.lv.x = FALSE,
-                               auto.cov.y = FALSE,
-                               auto.th = FALSE,
-                               auto.delta = FALSE,
-                               auto.efa = FALSE,
-                               varTable = NULL,
-                               ngroups = 1L,
-                               nthresholds = NULL,
-                               group.equal = NULL,
-                               group.partial = NULL,
-                               group.w.free = FALSE,
-                               debug = FALSE,
-                               warn = TRUE,
-                               as.data.frame. = TRUE) {
-  lav_deprecated("lavaanify", times = 0L) # --> for now no warning
-  sc <- sys.call()
-  names(sc) <- lav_snake_case(names(sc))
-  sc[[1L]] <- quote(lavaan::lavaanify)
-  eval(sc, parent.frame())
-}
 lav_matrix_vec <- function(A) {
   lav_deprecated("lav_mat_vec", times = 0L) # --> for now no warning
   sc <- sys.call()
@@ -521,16 +477,4 @@ lav_partable_df <- function(partable) {
   names(sc) <- lav_snake_case(names(sc))
   sc[[1L]] <- quote(lavaan::lav_pt_df)
   eval(sc, parent.frame())
-}
-lav_scores <- function(
-                       object,
-                       scaling = FALSE,
-                       ignore.constraints = FALSE,
-                       remove.duplicated = TRUE,
-                       remove.empty.cases = TRUE) {
-  lav_deprecated("lavScores", times = 0L) # --> for now no warning
-  sc <- sys.call()
-  names(sc) <- lav_snake_case(names(sc))
-  sc[[1L]] <- quote(lavaan::lavScores)
-  eval(sc, parent.frame())
-}                                                               # nolint end
+}                                                             # nolint end

--- a/man/lav_long_names.Rd
+++ b/man/lav_long_names.Rd
@@ -49,7 +49,6 @@
 \alias{lav_matrix_vecr}
 \alias{lav_matrix_vech}
 \alias{lav_partable_merge}
-\alias{lav_model_partable}
 \alias{lav_matrix_vec}
 \alias{lav_matrix_duplication}
 \alias{lav_matrix_commutation}
@@ -58,7 +57,6 @@
 \alias{lav_partable_npar}
 \alias{lav_partable_add}
 \alias{lav_partable_df}
-\alias{lav_scores}
 
 \title{deprecated functions with long names}
 \description{Functions which are deprecated because of adaption of shorter names in May, 2026}
@@ -185,44 +183,6 @@ lav_partable_merge(
                    remove.duplicated = FALSE,
                    fromLast = FALSE,
                    warn = TRUE)
-lav_model_partable(
-                   model = NULL,
-                   meanstructure = FALSE,
-                   int.ov.free = FALSE,
-                   int.lv.free = FALSE,
-                   marker.int.zero = FALSE,
-                   orthogonal = FALSE,
-                   orthogonal.y = FALSE,
-                   orthogonal.x = FALSE,
-                   orthogonal.efa = FALSE,
-                   std.lv = FALSE,
-                   correlation = FALSE,
-                   composites = TRUE,
-                   effect.coding = "",
-                   conditional.x = FALSE,
-                   fixed.x = FALSE,
-                   parameterization = "delta",
-                   constraints = NULL,
-                   ceq.simple = FALSE,
-                   auto = FALSE,
-                   model.type = "sem",
-                   auto.fix.first = FALSE,
-                   auto.fix.single = FALSE,
-                   auto.var = FALSE,
-                   auto.cov.lv.x = FALSE,
-                   auto.cov.y = FALSE,
-                   auto.th = FALSE,
-                   auto.delta = FALSE,
-                   auto.efa = FALSE,
-                   varTable = NULL,
-                   ngroups = 1L,
-                   nthresholds = NULL,
-                   group.equal = NULL,
-                   group.partial = NULL,
-                   group.w.free = FALSE,
-                   debug = FALSE,
-                   warn = TRUE,
-                   as.data.frame. = TRUE)
 lav_matrix_vec(A)
 lav_matrix_duplication(n = 1L)
 lav_matrix_commutation(m = 1L, n = 1L)
@@ -231,50 +191,25 @@ lav_partable_ndat(partable)
 lav_partable_npar(partable)
 lav_partable_add(partable = NULL, add = list())
 lav_partable_df(partable)
-lav_scores(
-           object,
-           scaling = FALSE,
-           ignore.constraints = FALSE,
-           remove.duplicated = TRUE,
-           remove.empty.cases = TRUE)
 }
 \arguments{
 \item{...}{See argument \code{...} in the corresponding function with shortened name.}
 \item{A}{See argument \code{a} in the corresponding function with shortened name.}
 \item{add}{See argument \code{add} in the corresponding function with shortened name.}
 \item{as.data.frame.}{See argument \code{as_data_frame} in the corresponding function with shortened name.}
-\item{auto}{See argument \code{auto} in the corresponding function with shortened name.}
-\item{auto.cov.lv.x}{See argument \code{auto_cov_lv_x} in the corresponding function with shortened name.}
-\item{auto.cov.y}{See argument \code{auto_cov_y} in the corresponding function with shortened name.}
-\item{auto.delta}{See argument \code{auto_delta} in the corresponding function with shortened name.}
-\item{auto.efa}{See argument \code{auto_efa} in the corresponding function with shortened name.}
-\item{auto.fix.first}{See argument \code{auto_fix_first} in the corresponding function with shortened name.}
-\item{auto.fix.single}{See argument \code{auto_fix_single} in the corresponding function with shortened name.}
-\item{auto.th}{See argument \code{auto_th} in the corresponding function with shortened name.}
-\item{auto.var}{See argument \code{auto_var} in the corresponding function with shortened name.}
 \item{blocks}{See argument \code{blocks} in the corresponding function with shortened name.}
-\item{ceq.simple}{See argument \code{ceq_simple} in the corresponding function with shortened name.}
 \item{check}{See argument \code{check} in the corresponding function with shortened name.}
-\item{composites}{See argument \code{composites} in the corresponding function with shortened name.}
 \item{con}{See argument \code{con} in the corresponding function with shortened name.}
-\item{conditional.x}{See argument \code{conditional_x} in the corresponding function with shortened name.}
 \item{constraints}{See argument \code{constraints} in the corresponding function with shortened name.}
-\item{correlation}{See argument \code{correlation} in the corresponding function with shortened name.}
 \item{debug}{See argument \code{debug} in the corresponding function with shortened name.}
 \item{diagonal}{See argument \code{diagonal} in the corresponding function with shortened name.}
-\item{effect.coding}{See argument \code{effect_coding} in the corresponding function with shortened name.}
 \item{est}{See argument \code{est} in the corresponding function with shortened name.}
 \item{fallback.simple}{See argument \code{fallback_simple} in the corresponding function with shortened name.}
-\item{fixed.x}{See argument \code{fixed_x} in the corresponding function with shortened name.}
 \item{fromLast}{See argument \code{from_last} in the corresponding function with shortened name.}
 \item{func}{See argument \code{func} in the corresponding function with shortened name.}
 \item{group.equal}{See argument \code{group_equal} in the corresponding function with shortened name.}
 \item{group.partial}{See argument \code{group_partial} in the corresponding function with shortened name.}
-\item{group.w.free}{See argument \code{group_w_free} in the corresponding function with shortened name.}
 \item{h}{See argument \code{h} in the corresponding function with shortened name.}
-\item{ignore.constraints}{See argument \code{ignore_constraints} in the corresponding function with shortened name.}
-\item{int.lv.free}{See argument \code{int_lv_free} in the corresponding function with shortened name.}
-\item{int.ov.free}{See argument \code{int_ov_free} in the corresponding function with shortened name.}
 \item{label}{See argument \code{label} in the corresponding function with shortened name.}
 \item{lavdata}{See argument \code{lavdata} in the corresponding function with shortened name.}
 \item{lavh1}{See argument \code{lavh1} in the corresponding function with shortened name.}
@@ -283,27 +218,15 @@ lav_scores(
 \item{lavpta}{See argument \code{lavpta} in the corresponding function with shortened name.}
 \item{lavsamplestats}{See argument \code{lavsamplestats} in the corresponding function with shortened name.}
 \item{m}{See argument \code{m} in the corresponding function with shortened name.}
-\item{marker.int.zero}{See argument \code{marker_int_zero} in the corresponding function with shortened name.}
-\item{meanstructure}{See argument \code{meanstructure} in the corresponding function with shortened name.}
-\item{model}{See argument \code{model} in the corresponding function with shortened name.}
-\item{model.type}{See argument \code{model_type} in the corresponding function with shortened name.}
 \item{Mu}{See argument \code{mu} in the corresponding function with shortened name.}
 \item{n}{See argument \code{n} in the corresponding function with shortened name.}
 \item{NACOV}{See argument \code{nacov} in the corresponding function with shortened name.}
-\item{ngroups}{See argument \code{ngroups} in the corresponding function with shortened name.}
-\item{nthresholds}{See argument \code{nthresholds} in the corresponding function with shortened name.}
 \item{object}{See argument \code{object} in the corresponding function with shortened name.}
-\item{orthogonal}{See argument \code{orthogonal} in the corresponding function with shortened name.}
-\item{orthogonal.efa}{See argument \code{orthogonal_efa} in the corresponding function with shortened name.}
-\item{orthogonal.x}{See argument \code{orthogonal_x} in the corresponding function with shortened name.}
-\item{orthogonal.y}{See argument \code{orthogonal_y} in the corresponding function with shortened name.}
-\item{parameterization}{See argument \code{parameterization} in the corresponding function with shortened name.}
 \item{partable}{See argument \code{partable} in the corresponding function with shortened name.}
 \item{pt1}{See argument \code{pt1} in the corresponding function with shortened name.}
 \item{pt2}{See argument \code{pt2} in the corresponding function with shortened name.}
 \item{pta}{See argument \code{pta} in the corresponding function with shortened name.}
 \item{remove.duplicated}{See argument \code{remove_duplicated} in the corresponding function with shortened name.}
-\item{remove.empty.cases}{See argument \code{remove_empty_cases} in the corresponding function with shortened name.}
 \item{S}{See argument \code{s} in the corresponding function with shortened name.}
 \item{sample.cov}{See argument \code{sample_cov} in the corresponding function with shortened name.}
 \item{sample.cov.x}{See argument \code{sample_cov_x} in the corresponding function with shortened name.}
@@ -312,13 +235,10 @@ lav_scores(
 \item{sample.slopes}{See argument \code{sample_slopes} in the corresponding function with shortened name.}
 \item{sample.th}{See argument \code{sample_th} in the corresponding function with shortened name.}
 \item{sample.th.idx}{See argument \code{sample_th_idx} in the corresponding function with shortened name.}
-\item{scaling}{See argument \code{scaling} in the corresponding function with shortened name.}
 \item{start}{See argument \code{start} in the corresponding function with shortened name.}
-\item{std.lv}{See argument \code{std_lv} in the corresponding function with shortened name.}
 \item{theta}{See argument \code{theta} in the corresponding function with shortened name.}
 \item{txtOnly}{See argument \code{txt_only} in the corresponding function with shortened name.}
 \item{type}{See argument \code{type} in the corresponding function with shortened name.}
-\item{varTable}{See argument \code{var_table} in the corresponding function with shortened name.}
 \item{warn}{See argument \code{warn} in the corresponding function with shortened name.}
 \item{WLS.V}{See argument \code{wls_v} in the corresponding function with shortened name.}
 \item{x}{See argument \code{x} in the corresponding function with shortened name.}


### PR DESCRIPTION
remove not-needed old long-name wrappers,
for lavaanify()/lavScores() explicit call of lav_model_pt()/lav_sc() to avoid warning in devtools:check() for usage of ':::',
add median to stats import.