### PR TITLE
Refactor lav syntax parser open: forbid reserved modifier names; extr…

### DIFF
--- a/R/lav_syntax_parser_open.R
+++ b/R/lav_syntax_parser_open.R
@@ -84,6 +84,11 @@ lav_parse_options <- function(
       lav_msg_stop(gettext(
         "Modifiers$expect must contain 'char', 'num' or 'raw'."))
     }
+    forbidden <- c("lhs", "op", "rhs", "block")
+    if (any(modifiers %in% forbidden)) {
+      lav_msg_stop(gettextf("Modifiers cannot be %s.",
+                    lav_msg_view(forbidden, "or")))
+    }
     if (any(modifiers %in% mods$mod)) {
       lav_msg_stop(gettext("Some modifiers already defined."))
     }
@@ -154,7 +159,7 @@ lav_parse_tokens_open <- function(modelsrc, types) {
   elem_text <- vector("character", nmax)
   elem_i <- 1L
   modelsrcw <- paste0(modelsrc, "\n") # working model, must end
-  # with a newline for tests via regexpr
+                                      # with a newline for tests via regexpr
   stringliterals <- gregexpr("\"[^\"]*?[\"\n]", modelsrcw)[[1L]]
   if (stringliterals[1L] > -1L) {
     stringliteral_lengths <- attr(stringliterals, "match.length")
@@ -197,20 +202,18 @@ lav_parse_tokens_open <- function(modelsrc, types) {
   }
   # --------------------- handling spaces in operators ----------------------- #
   config <- lav_parse_options()
-  for (opr in config$operators$op) {
-    if (nchar(opr) == 2L) {
-      oprre <- paste0("([^=~%])[", substr(opr, 1L, 1L), "]( +)[",
-                                              substr(opr, 2L, 2L), "]([^=~%])")
-      oprsub <- paste0("\\1", opr, "\\2\\3")
-      if (grepl(oprre, modelsrcw)) {
-        waar <- regexpr(oprre, modelsrcw)[1] + 1L
-        modelsrcw <- gsub(oprre, oprsub, modelsrcw)
-        tl <- lav_parse_txtloc(modelsrc, waar)
-        lav_msg_warn(gettextf("splitting of operator '%s' deprecated", opr),
-                    tl[1L],
-                    footer = tl[2L]
-        )
-      }
+  for (opr in config$operators$op[nchar(config$operators$op) == 2L]) {
+    oprre <- paste0("([^=~%])[", substr(opr, 1L, 1L), "]( +)[",
+                                            substr(opr, 2L, 2L), "]([^=~%])")
+    oprsub <- paste0("\\1", opr, "\\2\\3")
+    if (grepl(oprre, modelsrcw)) {
+      waar <- regexpr(oprre, modelsrcw)[1] + 1L
+      modelsrcw <- gsub(oprre, oprsub, modelsrcw)
+      tl <- lav_parse_txtloc(modelsrc, waar)
+      lav_msg_warn(gettextf("splitting of operator '%s' deprecated", opr),
+                  tl[1L],
+                  footer = tl[2L]
+      )
     }
   }
   # -------------------------------------------------------------------------- #
@@ -346,6 +349,22 @@ lav_parse_tokens_open <- function(modelsrc, types) {
     elem_text <- elem_text[elements]
   }
 
+  list_before_numbering <-  list(
+    elem_pos = elem_pos, elem_type = elem_type,
+    elem_text = elem_text
+  )
+
+  lav_parse_formula_numbers(list_before_numbering, types)
+}
+
+
+# ------------------------ lav_parse_formula_numbers ------------------------- #
+# help function to add formula numbers to tokens
+# ---------------------------------------------------------------------------- #
+lav_parse_formula_numbers <- function(list_before_numbering, types) {
+  elem_pos <- list_before_numbering$elem_pos
+  elem_type <- list_before_numbering$elem_type
+  elem_text <- list_before_numbering$elem_text
   # to set formula number
   elem_formula_number <- rep(0L, length(elem_type))
   frm_number <- 1L
@@ -353,48 +372,48 @@ lav_parse_tokens_open <- function(modelsrc, types) {
   frm_lastplus <- FALSE
   frm_incremented <- FALSE
   for (i in seq_along(elem_type)) {
-    elem_formula_number[i] <- frm_number
-    if (elem_type[i] == types$identifier && elem_text[i] == "efa") {
-      frm_hasefa <- TRUE
+  elem_formula_number[i] <- frm_number
+  if (elem_type[i] == types$identifier && elem_text[i] == "efa") {
+    frm_hasefa <- TRUE
+  }
+  if (any(elem_text[i] ==
+          c("+", "*", "=~", "-", "<~", "~*~", "~~", "~", "|~", "|", "%"))) {
+    if (frm_incremented) {
+      frm_number <- frm_number - 1L
+      elem_formula_number[i] <- frm_number
+      frm_incremented <- FALSE
     }
-    if (any(elem_text[i] ==
-            c("+", "*", "=~", "-", "<~", "~*~", "~~", "~", "|~", "|", "%"))) {
-      if (frm_incremented) {
-        frm_number <- frm_number - 1L
-        elem_formula_number[i] <- frm_number
-        frm_incremented <- FALSE
-      }
-      frm_lastplus <- TRUE
-    } else {
-      if (any(elem_type[i] == c(
-        types$stringliteral, types$identifier, types$numliteral,
-        types$stringliteral, types$symbol
-      ))) {
-        frm_lastplus <- FALSE
-      }
-      if (i > 1 && elem_type[i] != types$newline &&
-          elem_type[i - 1L] == types$lavaanoperator) {
+    frm_lastplus <- TRUE
+  } else {
+    if (any(elem_type[i] == c(
+      types$stringliteral, types$identifier, types$numliteral,
+      types$stringliteral, types$symbol
+    ))) {
+      frm_lastplus <- FALSE
+    }
+    if (i > 1 && elem_type[i] != types$newline &&
+        elem_type[i - 1L] == types$lavaanoperator) {
+      frm_hasefa <- FALSE
+    }
+  }
+  if (elem_type[i] == types$newline) {
+    if (i > 1 && elem_type[i - 1L] != types$newline) { # ignore multiple nl's
+      if (!frm_hasefa && !frm_lastplus) {
+        frm_number <- frm_number + 1L
+        frm_incremented <- TRUE
+      } else {
         frm_hasefa <- FALSE
       }
     }
-    if (elem_type[i] == types$newline) {
-      if (i > 1 && elem_type[i - 1L] != types$newline) { # ignore multiple nl's
-        if (!frm_hasefa && !frm_lastplus) {
-          frm_number <- frm_number + 1L
-          frm_incremented <- TRUE
-        } else {
-          frm_hasefa <- FALSE
-        }
-      }
-    } else {
-      frm_incremented <- FALSE
-    }
+  } else {
+    frm_incremented <- FALSE
+  }
   }
   list(
-    elem_pos = elem_pos, elem_type = elem_type,
-    elem_text = elem_text, elem_formula_number = elem_formula_number
+  elem_pos = elem_pos, elem_type = elem_type,
+  elem_text = elem_text, elem_formula_number = elem_formula_number
   )
-}
+ }
 
 # ------------------------ lav_parse_formulas_open ------------------------- #
 # function to group the modellist tokens in 'mono' formulas.
@@ -509,23 +528,27 @@ lav_parse_formulas_open <- function(modellist, modelsrc, types) {
 #     types : the types of tokens
 #       rme : index of last element of modifier in formula (*)
 #   rmeprev : index of first element of modifier in formula - 1L (*)
-# The function return the modifier detected as element of a list
-#  with name the modifier type (efa, fixed, start, label, lower, upper, prior or
-#   rv) and value an array of values (length > 1 if vector via c(...)) for the
-#   modifier value.
-# (*) if rme > remprev the rhs is limited to the elements with index
-#     rmeprev+1:rme, this is to support multiple modifiers for the same element.
+# The function returns the modifier detected as element of a list
+#  with name the modifier type and value an array of values
+#   (length > 1 if vector via c(...)) for the modifier value.
+# The lhs or rhs is limited to the elements with index
+#   rmeprev+1:rme, this is to support multiple modifiers for the same element.
 # An error message is produced when no modifier can be determined.
 # ---------------------------------------------------------------------------- #
-lav_parse_modifier_open <- function(formul1, lhs, opi, modelsrc, types,
-                               rme = 0L, rmeprev = 0L, modenv) {
-  config <- lav_parse_options()
-  if (rme > rmeprev) {
+lav_parse_modifier_open <- function(formul, opi, modelsrc, types,
+                                    rme, rmeprev, modenv, config) {
+  if (rme < opi) { # lhs modifier
+    lhs <- TRUE
+    welke <- c(seq.int(rmeprev + 1L, rme),
+               seq.int(opi - 1L, length(formul$elem_type)))
+  } else {
+    lhs <- FALSE
     welke <- c(seq.int(1L, opi), seq.int(rmeprev + 1L, rme),
-               length(formul1$elem_type))
-    formul1 <- lav_parse_sublist(formul1, welke)
+               length(formul$elem_type))
   }
+  formul1 <- lav_parse_sublist(formul, welke)
   nelem <- length(formul1$elem_type)
+  opi <- which(formul1$elem_type == types$lavaanoperator)
   # remove unnecessary parentheses (one element between parentheses, previous
   # no identifier)
   check_more <- TRUE
@@ -545,103 +568,68 @@ lav_parse_modifier_open <- function(formul1, lhs, opi, modelsrc, types,
       nelem <- length(formul1$elem_type)
     }
   }
-  if (lhs) {
-    # modifier on left hand side
-    # only 1 allowed from the modifiers with side 'l':
-    #  modifier ( expression-resulting-in-expected-type ) *
-    #                                    identifier operator ... (rhs) ...
-    leftmods_ind <- which(config$modifiers$side == "l")
-    if (formul1$elem_text[1L] %in% config$modifiers$mod[leftmods_ind]
-      && formul1$elem_text[2L] == "(" && formul1$elem_text[opi - 3L] == ")" &&
-      formul1$elem_text[opi - 2L] == "*") {
-      curmod_ind <- which(config$modifiers$mod ==
-                                              formul1$elem_text[1L])
-      curmod_expect <- config$modifiers$expect[curmod_ind]
-      temp <- lav_parse_eval_r_expr_open(formul1, 3L, opi - 4L, types, curmod_expect == "raw")
-      if (((curmod_expect == "raw") ||
-           (is.character(temp) && curmod_expect == "char") ||
-           (is.numeric(temp) && curmod_expect == "num")) &&
-            temp[1] != "_error_") {
-        return(setNames(list(temp), config$modifiers$mod[curmod_ind]))
-      }
+  getmodifier <- function(s) {
+    if (s %in% c("c", "t")) {
+      tmp <- s
+      attr(tmp, "tiepe") <- "label"
+      return(tmp)
     }
-    tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[1L])
-    lav_msg_stop(gettext("invalid left hand side modifier"),
-                 tl[1L],
-                 footer = tl[2L]
-    )
-  } else {
-    getmodifier <- function(s) {
-      if (s %in% c("c", "t")) {
-        tmp <- s
-        attr(tmp, "tiepe") <- "label"
-        return(tmp)
-      }
-      v <- all.vars(str2expression(s))
-      for (v1 in v) {
-        if (v1 != "pi") assign(v1, v1, modenv)
-      }
-      tmp <- eval(str2expression(s), modenv)
-      suppressWarnings(rm(list = v, pos = modenv))
-      if (is.null(attr(tmp, "tiepe"))) {
-        if (is.numeric(tmp) || is.logical(tmp)) {
-          attr(tmp, "tiepe") <- "fixed"
-        } else {
-          attr(tmp, "tiepe") <- "label"
-        }
-      }
-      tmp
+    v <- all.vars(str2expression(s))
+    for (v1 in v) {
+      if (v1 != "pi") assign(v1, v1, modenv)
     }
-    strings <- vapply(seq.int(opi + 1L, nelem - 2L), function(x) {
-      if (formul1$elem_type[x] == types$stringliteral) {
-        paste0('"', formul1$elem_text[x], '"')
+    tmp <- eval(str2expression(s), modenv)
+    suppressWarnings(rm(list = v, pos = modenv))
+    if (is.null(attr(tmp, "tiepe"))) {
+      if (is.numeric(tmp) || is.logical(tmp)) {
+        attr(tmp, "tiepe") <- "fixed"
       } else {
-        formul1$elem_text[x]
-      }
-    }, "")
-    txt <- paste(strings, collapse = "")
-    if (formul1$elem_text[nelem - 1L] == "?") {
-      formul1$elem_text[nelem - 1L] <- "*"
-      txt <- paste0("start(", txt, ")")
-    }
-    if (formul1$elem_text[nelem - 1L] != "*") {
-      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[nelem - 1L])
-      lav_msg_stop(gettext("invalid modifier symbol (should be '*' or '?')"),
-                   tl[1L],
-                   footer = tl[2L]
-      )
-    }
-    modifier <- tryCatch(getmodifier(txt), error = function(e) "__error__")
-    if (modifier[1L] == "__error__") {
-      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi + 1L])
-      lav_msg_stop(gettext("invalid modifier specification"),
-                   tl[1L],
-                   footer = tl[2L]
-      )
-    }
-    mdtype <- attr(modifier, "tiepe")
-    mdind <- which(config$modifiers$mod == mdtype)[1L]
-    if (config$modifiers$expect[mdind] == "char") {
-      if (!is.character(modifier)) {
-        tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi + 1L])
-        lav_msg_stop(gettextf("invalid %s modifier (should be character)", mdtype),
-                     tl[1L],
-                     footer = tl[2L]
-        )
-      }
-    } else if (config$modifiers$expect[mdind] == "num") {
-      if (!is.numeric(modifier) && !all(is.na(modifier))) {
-        tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi + 1L])
-        lav_msg_stop(gettextf("invalid %s modifier (should be numeric)", mdtype),
-                     tl[1L],
-                     footer = tl[2L]
-        )
+        attr(tmp, "tiepe") <- "label"
       }
     }
-    modifierlist <- list(as.vector(modifier))
-    names(modifierlist) <- attr(modifier, "tiepe")
-    modifierlist
+    tmp
   }
+  strings <- vapply(seq.int(
+    if (lhs) 1L else opi + 1L,
+    if (lhs) opi - 3L else nelem - 2L
+    ), function(x) {
+    if (formul1$elem_type[x] == types$stringliteral) {
+      paste0('"', formul1$elem_text[x], '"')
+    } else {
+      formul1$elem_text[x]
+    }
+  }, "")
+  txt <- paste(strings, collapse = "")
+  if (!lhs && formul1$elem_text[nelem - 1L] == "?") {
+    formul1$elem_text[nelem - 1L] <- "*"
+    txt <- paste0("start(", txt, ")")
+  }
+   modifier <- tryCatch(getmodifier(txt), error = function(e) "__error__")
+  if (!is.na(modifier[1L]) && modifier[1L] == "__error__") {
+    tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi + 1L])
+    lav_msg_stop(gettext("invalid modifier specification"),
+                  tl[1L],
+                  footer = tl[2L]
+    )
+  }
+  mdtype <- attr(modifier, "tiepe")
+  mdind <- which(config$modifiers$mod == mdtype)[1L]
+  if (config$modifiers$expect[mdind] == "char") {
+    if (!is.character(modifier)) {
+      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi + 1L])
+      lav_msg_stop(gettextf("invalid %s modifier (should be character)",
+        mdtype), tl[1L], footer = tl[2L])
+    }
+  } else if (config$modifiers$expect[mdind] == "num") {
+    if (!is.numeric(modifier) && !all(is.na(modifier))) {
+      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi + 1L])
+      lav_msg_stop(gettextf("invalid %s modifier (should be numeric)",
+        mdtype), tl[1L], footer = tl[2L])
+    }
+  }
+  modifierlist <- list(as.vector(modifier))
+  names(modifierlist) <- attr(modifier, "tiepe")
+  modifierlist
 }
 
 # -------------------- create environment for evaluating modifiers ----------- #
@@ -674,7 +662,7 @@ lav_parse_model_string_open <- function(model_syntax = "",
     replacement = "~",
     paste(unlist(model_syntax), "", collapse = "\n")
   )
-  hashstring <- paste0("mdl_", lav_char2hash(paste0(modelsrc, as_data_frame)))
+  hashstring <- paste0("mdl_o_", lav_char2hash(paste0(modelsrc, as_data_frame)))
   if (exists(hashstring, envir = lavaan_cache_env)) {
     return(get(hashstring, envir = lavaan_cache_env))
   }
@@ -697,344 +685,390 @@ lav_parse_model_string_open <- function(model_syntax = "",
   formulalist <- lav_parse_formulas_open(modellist, modelsrc, types)
   #---- analyse syntax formulas and put in flat_-----
   max.mono.formulas <- length(formulalist)
-  flat_lhs <- character(max.mono.formulas)
-  flat_op <- character(max.mono.formulas)
-  flat_rhs <- character(max.mono.formulas)
-  flat_rhs_mod_idx <- integer(max.mono.formulas)
-  flat_block <- integer(max.mono.formulas) # keep track of groups using ":" opr
-  flatmod <- list()
-  for (mod1 in unique(config$modifiers$mod)) {
-    flatmod[[mod1]] <- character(max.mono.formulas) # only for display purposes!
+  flat <- list()
+  flat$lhs <- character(max.mono.formulas)
+  flat$op <- character(max.mono.formulas)
+  flat$rhs <- character(max.mono.formulas)
+  flat$mod_idx <- integer(max.mono.formulas)
+  flat$block <- integer(max.mono.formulas) # keep track of groups using ":" opr
+  for (mod1 in config$modifiers$mod) {
+    flat[[mod1]] <- character(max.mono.formulas) # only for display purposes!
   }
-  flat_idx <- 0L
-  mod_idx <- 0L
-  constraints <- list()
-  mod <- list()
-  block <- 1L
-  block_op <- FALSE
+  tmplist <- list(
+    flat = flat,
+    flat_idx = 0L,
+    mod_idx = 0L,
+    constraints = list(),
+    modlist = list(),
+    block = 1L,
+    block_op = FALSE
+  )
   if (lav_debug()) {
     cat("formula to analyse:\n")
   }
-  constraint_operators <- c("==", "<", ">", ":=")
   for (s in seq_along(formulalist)) {
-    formul1 <- formulalist[[s]]
-    if (lav_debug()) {
-      cat(vapply(seq_along(formul1$elem_type), function(j) {
-        if (formul1$elem_type[j] == types$stringliteral) {
-          return(dQuote(formul1$elem_text[j], FALSE))
-        }
-        formul1$elem_text[j]
-      }, ""), "\n")
+    formule <- formulalist[[s]]
+    tmplist <- lav_parse_handle_formule(formule, tmplist, types, modelsrc,
+                                        modenvl, modenvr, config)
+  }
+  lav_parse_final_operations(tmplist$flat, tmplist$modlist, config,
+    tmplist$constraints, as_data_frame, hashstring)
+}
+
+lav_parse_handle_formule <- function(formule, tmplist, types, modelsrc,
+                                     modenvl, modenvr, config) {
+  flat <- tmplist$flat
+  flat_idx <- tmplist$flat_idx
+  mod_idx <- tmplist$mod_idx
+  constraints <- tmplist$constraints
+  modlist <- tmplist$modlist
+  block <- tmplist$block
+  block_op <- tmplist$block_op
+  constraint_operators <- c("==", "<", ">", ":=")
+  if (lav_debug()) {
+    cat(vapply(seq_along(formule$elem_type), function(j) {
+      if (formule$elem_type[j] == types$stringliteral) {
+        return(dQuote(formule$elem_text[j], FALSE))
+      }
+      formule$elem_text[j]
+    }, ""), "\n")
+  }
+  nelem <- length(formule$elem_type)
+  # where is the operator
+  opi <- which(formule$elem_type == types$lavaanoperator)
+  if (length(opi) > 1L) { # if more then 1 operator skip operators ':'
+    opii <- 1L
+    while (formule$elem_text[opi[opii]] == ":" && opii < length(opi)) {
+      opii <- opii + 1L
     }
-    nelem <- length(formul1$elem_type)
-    # where is the operator
-    opi <- which(formul1$elem_type == types$lavaanoperator)
-    if (length(opi) > 1L) { # if more then 1 operator skip operators ':'
-      opii <- 1L
-      while (formul1$elem_text[opi[opii]] == ":" && opii < length(opi)) {
-        opii <- opii + 1L
-      }
-      opi <- opi[opii]
-    }
-    op <- formul1$elem_text[opi]
-    if (any(op == constraint_operators)) { # ----- constraints -------
-      lhs <- paste(formul1$elem_text[seq.int(1L, opi - 1L)], collapse = "")
-      rhs <- paste(formul1$elem_text[seq.int(opi + 1L, nelem)], collapse = "")
-      constraints <- c(
-        constraints,
-        list(list(
-          op = op,
-          lhs = lhs,
-          rhs = rhs,
-          user = 1L
-        ))
-      )
-      next
-    }
-    if (op == ":") { # ------------------------- block start ----------------- #
-      correct_syntax <- gettextf("The correct syntax is: \"LHS : RHS\", where
-      LHS is  block identifier (%s) and RHS is the block number or label.",
-      lav_msg_view(config$groupings$group, "or"))
-      if (opi == 1L) {
-        tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[1])
-        lav_msg_stop(
-          gettextf(
-            "Missing block identifier. %s", correct_syntax
-          ), tl[1L], footer = tl[2L]
-        )
-      }
-      if (opi > 2L || all(tolower(formul1$elem_text[1]) !=
-                          config$groupings$group)) {
-        tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[1])
-        lav_msg_stop(
-          gettextf(
-            "Invalid block identifier. %s", correct_syntax
-          ),
-          tl[1L], footer = tl[2L]
-        )
-      }
-      if (nelem != 3 || all(formul1$elem_type[3] !=
-             c(types$stringliteral, types$identifier, types$numliteral))) {
-        tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[1])
-        lav_msg_stop(
-          gettextf("Syntax contains block identifier with missing or
-                invalid number/label. %s", correct_syntax),
-          tl[1L],
-          footer = tl[2L]
-        )
-      }
-      flat_idx <- flat_idx + 1L
-      flat_lhs[flat_idx] <- formul1$elem_text[1]
-      flat_op[flat_idx] <- op
-      flat_rhs[flat_idx] <- formul1$elem_text[3]
-      flat_rhs_mod_idx[flat_idx] <- 0L
-      if (block_op) {
-        block <- block + 1L
-      } else {
-        if (flat_idx != 1) {
-          tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[1])
-          lav_msg_warn(
-            gettext("First block defined after other formula's"),
-            tl[1L],
-            footer = tl[2L]
-          )
-        }
-      }
-      flat_block[flat_idx] <- block
-      block_op <- TRUE
-      next
-    }
-    # ------------------ relational operators -------------------------------- #
-    # warn if some identifiers contain spaces
-    contsp <- which(formul1$elem_type == types$identifier &
-                      grepl(" ", formul1$elem_text, fixed = TRUE))
-    if (length(contsp) > 0L) {
-      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[contsp[1L]])
-      lav_msg_warn(
+    opi <- opi[opii]
+  }
+  op <- formule$elem_text[opi]
+  if (any(op == constraint_operators)) {         # ----- constraints ------- #
+    lhs <- paste(formule$elem_text[seq.int(1L, opi - 1L)], collapse = "")
+    rhs <- paste(formule$elem_text[seq.int(opi + 1L, nelem)], collapse = "")
+    constraints <- c(
+      constraints,
+      list(list(
+        op = op,
+        lhs = lhs,
+        rhs = rhs,
+        user = 1L
+      ))
+    )
+    tmplist$constraints <- constraints
+    return(tmplist)
+  }
+  if (op == ":") {           # --------------- block start ----------------- #
+    correct_syntax <- gettextf("The correct syntax is: \"LHS : RHS\", where
+    LHS is  block identifier (%s) and RHS is the block number or label.",
+                             lav_msg_view(config$groupings$group, "or"))
+    if (opi == 1L) {
+      tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[1])
+      lav_msg_stop(
         gettextf(
-          "having identifiers with spaces ('%s') is deprecated",
-          formul1$elem_text[contsp[1]]
-        ),
-        tl[1L],
-        footer = tl[2L]
-      )
-    }
-    # checks for valid names in lhs and rhs
-    lav_parse_check_name(formul1, opi - 1L, modelsrc) # valid name lhs
-    for (j in seq.int(opi + 1L, nelem)) { # valid names rhs
-      if (formul1$elem_type[j] == types$identifier &&
-          formul1$elem_text[j] != "NA") {
-        lav_parse_check_name(formul1, j, modelsrc)
-      }
-    }
-    if (formul1$elem_type[nelem] != types$identifier &&
-        (formul1$elem_type[nelem] != types$numliteral ||
-         all(op != c("~", "|~", "=~")))) {
-      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[nelem])
-      lav_msg_stop(
-        gettext("Last element of rhs part expected to be an identifier or,
-                for operator ~, |~ or =~, a numeric literal!"),
-        tl[1L],
-        footer = tl[2L]
-      )
-    }
-    # intercept fixed on 0
-    # replace 'lhs ~ 0' => 'lhs ~ 0 * 1' - intercept fixed on zero
-    if (formul1$elem_text[nelem] == "0" && op == "~" && opi == nelem - 1L) {
-      formul1$elem_type <- c(formul1$elem_type, types$symbol, types$numliteral)
-      formul1$elem_text <- c(formul1$elem_text, "*", "1")
-      formul1$elem_pos <- c(formul1$elem_pos, rep(formul1$elem_pos[nelem], 2))
-      nelem <- length(formul1$elem_type)
-    }
-    # phantom latent variable
-    # replace 'lhs =~ 0' => 'lhs =~ fixed(0)*lhs', 0 can be other numliteral
-    #          also, lhs is last element before '=~'
-    if (formul1$elem_type[nelem] == types$numliteral && op == "=~") {
-      formul1$elem_type <- c(
-        formul1$elem_type[seq.int(1L, nelem - 1L)], types$identifier,
-        types$symbol, types$numliteral, types$symbol, types$symbol,
-        types$identifier
-      )
-      formul1$elem_text <- c(
-        formul1$elem_text[seq.int(1L, nelem - 1L)], "fixed", "(",
-        formul1$elem_text[nelem], ")", "*", formul1$elem_text[opi - 1L]
-      )
-      formul1$elem_pos <- c(
-        formul1$elem_pos[seq.int(1L, nelem - 1L)],
-        rep(formul1$elem_pos[nelem], 6)
-      )
-      nelem <- length(formul1$elem_type)
-    }
-    # handling interaction variable types
-    colons <- which(formul1$elem_text[seq.int(1L, nelem - 1L)] == ":" &
-                      formul1$elem_type[seq.int(2L, nelem)] == types$identifier)
-    # check at most 1 colon
-    if (length(colons) > 2L ||
-        (length(colons) == 2L && (colons[1L] > opi || colons[2L] < opi))) {
-      tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[colons[2]])
-      lav_msg_stop(
-        gettext(
-          "Three-way or higher-order interaction terms (using multiple
-         colons) are not supported in the lavaan syntax; please manually
-         construct the product terms yourself in the data.frame, give
-         them an appropriate name, and then you can use these interaction
-         variables as any other (observed) variable in the model syntax."
+          "Missing block identifier. %s", correct_syntax
         ), tl[1L], footer = tl[2L]
       )
     }
-    if (length(colons) > 0L) {
-      # collapse items around colon "a" ":" "b" => "a:b"
-      formul1$elem_text[colons[1L] - 1L] <-
-        paste(formul1$elem_text[seq.int(colons[1L] - 1L, colons[1L] + 1L)],
-              collapse = ""
-        )
-      formul1 <- lav_parse_sublist(formul1,
-            setdiff(seq.int(1L, nelem), seq.int(colons[1L], colons[1L] + 1L)))
-      nelem <- length(formul1$elem_type)
-      if (colons[1L] < opi) {
-        opi <- opi - 2L # is in LHS
-        if (length(colons) == 2L) colons[2L] <- colons[2L] - 2L
-      }
+    if (opi > 2L || all(tolower(formule$elem_text[1]) !=
+                        config$groupings$group)) {
+      tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[1])
+      lav_msg_stop(
+        gettextf(
+          "Invalid block identifier. %s", correct_syntax
+        ),
+        tl[1L], footer = tl[2L]
+      )
     }
-    if (length(colons) == 2L) {
-      # collapse items around colon "a" ":" "b" => "a:b"
-      formul1$elem_text[colons[2L] - 1L] <-
-        paste(formul1$elem_text[seq.int(colons[2L] - 1L, colons[2L] + 1L)],
-              collapse = ""
-        )
-      formul1 <- lav_parse_sublist(formul1,
-            setdiff(seq.int(1L, nelem), seq.int(colons[2L], colons[2L] + 1L)))
-      nelem <- length(formul1$elem_type)
+    if (nelem != 3 || all(formule$elem_type[3] !=
+            c(types$stringliteral, types$identifier, types$numliteral))) {
+      tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[1])
+      lav_msg_stop(
+        gettextf("Syntax contains block identifier with missing or
+              invalid number/label. %s", correct_syntax),
+        tl[1L],
+        footer = tl[2L]
+      )
     }
-    # modifiers
-    rhsmodelems <- which(seq_along(formul1$elem_type) > opi &
-                           formul1$elem_type == types$symbol &
-                (formul1$elem_text == "*" | formul1$elem_text == "?"))
-    for (j in seq_along(rhsmodelems)) {
-      if (sum(formul1$elem_text[seq.int(opi, rhsmodelems[j])] == "(") !=
-          sum(formul1$elem_text[seq.int(opi, rhsmodelems[j])] == ")"))
-        rhsmodelems[j] <- 0L
-    }
-    rhsmodelems <- rhsmodelems[rhsmodelems != 0L]
-    if (length(rhsmodelems) == 0L) rhsmodelems <- opi
-    lhs <- formul1$elem_text[opi - 1L]
-    rhs <- formul1$elem_text[nelem]
-    for (rmei in seq_along(rhsmodelems)) {
-      rme <- rhsmodelems[rmei]
-      rmeprev <- if (rmei == 1L) opi else rhsmodelems[rmei - 1L]
-      already <- which(flat_lhs == lhs & flat_op == op & flat_block == block &
-               (flat_rhs == rhs | (flat_rhs == "" & (op == "~" | op == "|~") &
-                               formul1$elem_type[nelem] == types$numliteral)))
-      if (length(already) == 1L) {
-        idx <- already
-      } else {
-        flat_idx <- flat_idx + 1L
-        idx <- flat_idx
-        flat_lhs[idx] <- lhs
-        flat_op[idx] <- op
-        flat_rhs[idx] <- rhs
-        flat_block[idx] <- block
-        if (formul1$elem_type[nelem] == types$numliteral) {
-          if (op == "~" || op == "|~") flat_rhs[idx] <- ""
-        }
-      }
-      lhsmod <- list()
-      if (opi > 2 && rmei == 1L) {
-        lhsmod <- lav_parse_modifier_open(
-          formul1,
-          TRUE, opi, modelsrc, types, modenv = modenvl
-        )
-      }
-      rhsmod <- list()
-      if (nelem - opi > 1) {
-        rhsmod <- lav_parse_modifier_open(
-          formul1,
-          FALSE, opi, modelsrc, types, rme, rmeprev, modenv = modenvr
-        )
-      }
-      for (j in seq_along(config$modifiers$mod)) {
-        mod1 <- config$modifiers$mod[j]
-        if (config$modifiers$side[j] == 'l') {
-            flatmod[[mod1]][idx] <-
-              if (is.null(lhsmod[[mod1]])) {
-                flatmod[[mod1]][idx]
-              } else {
-                paste(lhsmod[[mod1]], collapse = ";")
-              }
-        } else {
-            flatmod[[mod1]][idx] <-
-              if (is.null(rhsmod[[mod1]])) {
-                flatmod[[mod1]][idx]
-              } else {
-                paste(rhsmod[[mod1]], collapse = ";")
-              }
-        }
-      }
-      modnu <- c(lhsmod, rhsmod)
-      if (length(modnu) > 0L) { # there is a modifier here
-        if (length(already) == 0) { # unknown element
-          mod_idx <- mod_idx + 1L
-          cur_mod_idx <- mod_idx
-          mod[[cur_mod_idx]] <- modnu
-          flat_rhs_mod_idx[idx] <- cur_mod_idx
-        } else { # known element
-          if (flat_rhs_mod_idx[idx] == 0) { # not yet modifier
-            mod_idx <- mod_idx + 1L
-            cur_mod_idx <- mod_idx
-            mod[[cur_mod_idx]] <- modnu
-            flat_rhs_mod_idx[idx] <- cur_mod_idx
-          } else { # use existing modifier index
-            cur_mod_idx <- flat_rhs_mod_idx[idx]
-            overwrite <- names(modnu)[names(modnu) %in%
-                                        names(mod[[cur_mod_idx]])]
-            if (length(overwrite) > 0) {
-              tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[rmeprev + 1L])
-              lav_msg_warn(
-                gettextf(
-                  "modifier %s specified multiple times, overwritten",
-                  overwrite[1L]
-                ), tl[1L],
-                footer = tl[2L]
-              )
-            }
-            mod[[cur_mod_idx]] <- modifyList(mod[[cur_mod_idx]], modnu)
-          }
-        }
-      }
-    }
-    # check for variable regressed on itself
-    if (formul1$elem_text[opi] == "~" &&
-        formul1$elem_text[opi - 1L] == formul1$elem_text[nelem]) {
-      if (!grepl("^0\\.?0*$", flatmod$fixed[idx])) {
-        tl <- lav_parse_txtloc(modelsrc, formul1$elem_pos[opi])
-        lav_msg_stop(
-          gettext("a variable cannot be regressed on itself"),
+    flat_idx <- flat_idx + 1L
+    flat$lhs[flat_idx] <- formule$elem_text[1]
+    flat$op[flat_idx] <- op
+    flat$rhs[flat_idx] <- formule$elem_text[3]
+    flat$mod_idx[flat_idx] <- 0L
+    if (block_op) {
+      block <- block + 1L
+    } else {
+      if (flat_idx != 1) {
+        tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[1])
+        lav_msg_warn(
+          gettext("First block defined after other formula's"),
           tl[1L],
           footer = tl[2L]
         )
       }
     }
+    flat$block[flat_idx] <- block
+    tmplist$flat <- flat
+    tmplist$flat_idx <- flat_idx
+    tmplist$block <- block
+    tmplist$block_op <- TRUE
+    return(tmplist)
   }
-  # create flat (omit items without operator)
-  filled_ones <- which(flat_op != "")
-  flat <- list(
-    lhs = flat_lhs[filled_ones],
-    op = flat_op[filled_ones],
-    rhs = flat_rhs[filled_ones],
-    mod.idx = flat_rhs_mod_idx[filled_ones],
-    block = flat_block[filled_ones]
+  # ------------------ relational operators -------------------------------- #
+  lav_parse_check_relational(formule, modelsrc, types, opi, nelem, op)
+  tmpenv <- list2env(list(
+    formule = formule,
+    opi = opi,
+    nelem = nelem
+  ))
+  lav_parse_update_relational(tmpenv, modelsrc, types, op)
+  formule <- get("formule", tmpenv)
+  opi <- get("opi", tmpenv)
+  nelem <- get("nelem", tmpenv)
+  rm(tmpenv)
+  lhs <- formule$elem_text[opi - 1L]
+  rhs <- formule$elem_text[nelem]
+  already <- which(flat$lhs == lhs & flat$op == op & flat$block == block &
+            (flat$rhs == rhs | (flat$rhs == "" & (op == "~" | op == "|~") &
+                            formule$elem_type[nelem] == types$numliteral)))
+  if (length(already) == 1L) {
+    idx <- already
+  } else {
+    flat_idx <- flat_idx + 1L
+    idx <- flat_idx
+    flat$lhs[idx] <- lhs
+    flat$op[idx] <- op
+    flat$rhs[idx] <- rhs
+    flat$block[idx] <- block
+    if (formule$elem_type[nelem] == types$numliteral) {
+      if (op == "~" || op == "|~") flat$rhs[idx] <- ""
+    }
+  }
+  # modifiers always come before an asterix or a question mark
+  modelems <- which(formule$elem_type == types$symbol &
+              (formule$elem_text == "*" | formule$elem_text == "?"))
+  for (j in seq_along(modelems)) {
+    if (sum(formule$elem_text[seq.int(opi, modelems[j])] == "(") !=
+        sum(formule$elem_text[seq.int(opi, modelems[j])] == ")"))
+      modelems[j] <- 0L
+  }
+  modelems <- modelems[modelems != 0L]
+  if (length(modelems) != 0L) {
+    modleftfirst <- TRUE
+    modrightfirst <- TRUE
+    for (rmei in seq_along(modelems)) {
+      rme <- modelems[rmei]
+      if (rme < opi) {
+        rmeprev <- if (modleftfirst) 0L else modelems[rmei - 1L]
+        modleftfirst <- FALSE
+      } else {
+        rmeprev <- if (modrightfirst) opi else modelems[rmei - 1L]
+        modrightfirst <- FALSE
+      }
+      modnu <- lav_parse_modifier_open(
+        formule,
+        opi, modelsrc, types, rme, rmeprev,
+        modenv = if (rme < opi) modenvl else modenvr,
+        config
+      )
+      for (j in seq_along(config$modifiers$mod)) {
+        mod1 <- config$modifiers$mod[j]
+        flat[[mod1]][idx] <-
+          if (is.null(modnu[[mod1]])) {
+            flat[[mod1]][idx]
+          } else {
+            paste(modnu[[mod1]], collapse = ";")
+          }
+      }
+      if (flat$mod_idx[idx] == 0) { # not yet modifier
+        mod_idx <- mod_idx + 1L
+        cur_mod_idx <- mod_idx
+        modlist[[cur_mod_idx]] <- modnu
+        flat$mod_idx[idx] <- cur_mod_idx
+      } else { # use existing modifier index
+        cur_mod_idx <- flat$mod_idx[idx]
+        overwrite <- names(modnu)[names(modnu) %in%
+                                    names(modlist[[cur_mod_idx]])]
+        if (length(overwrite) > 0) {
+          tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[rmeprev + 1L])
+          lav_msg_warn(
+            gettextf(
+              "modifier %s specified multiple times, overwritten",
+              overwrite[1L]
+            ), tl[1L],
+            footer = tl[2L]
+          )
+        }
+        modlist[[cur_mod_idx]] <- modifyList(modlist[[cur_mod_idx]], modnu)
+      }
+    }
+  }
+  # check for variable regressed on itself
+  if (formule$elem_text[opi] == "~" &&
+      formule$elem_text[opi - 1L] == formule$elem_text[nelem]) {
+    if (!grepl("^0\\.?0*$", flat$fixed[idx])) {
+      tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[opi])
+      lav_msg_stop(
+        gettext("a variable cannot be regressed on itself"),
+        tl[1L],
+        footer = tl[2L]
+      )
+    }
+  }
+  list(
+    flat = flat,
+    flat_idx = flat_idx,
+    mod_idx = mod_idx,
+    constraints = constraints,
+    modlist = modlist,
+    block = block,
+    block_op = block_op
   )
-  for (mod1 in unique(config$modifiers$mod)) {
-    flat[[mod1]] <- flatmod[[mod1]][filled_ones]
+}
+
+lav_parse_check_relational <- function(formule, modelsrc, types, opi,
+                                       nelem, op) {
+  # warn if some identifiers contain spaces
+  contsp <- which(formule$elem_type == types$identifier &
+                    grepl(" ", formule$elem_text, fixed = TRUE))
+  if (length(contsp) > 0L) {
+    tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[contsp[1L]])
+    lav_msg_warn(
+      gettextf(
+        "having identifiers with spaces ('%s') is deprecated",
+        formule$elem_text[contsp[1]]
+      ),
+      tl[1L],
+      footer = tl[2L]
+    )
   }
+  # checks for valid names in lhs and rhs
+  lav_parse_check_name(formule, opi - 1L, modelsrc) # valid name lhs
+  for (j in seq.int(opi + 1L, nelem)) { # valid names rhs
+    if (formule$elem_type[j] == types$identifier &&
+        formule$elem_text[j] != "NA") {
+      lav_parse_check_name(formule, j, modelsrc)
+    }
+  }
+  if (formule$elem_type[nelem] != types$identifier &&
+      (formule$elem_type[nelem] != types$numliteral ||
+        all(op != c("~", "|~", "=~")))) {
+    tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[nelem])
+    lav_msg_stop(
+      gettext("Last element of rhs part expected to be an identifier or,
+              for operator ~, |~ or =~, a numeric literal!"),
+      tl[1L],
+      footer = tl[2L]
+    )
+  }
+   if (nelem < opi + 1L &&
+     !(formule$elem_text[nelem - 1L] %in% c("*", "?"))) {
+    tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[nelem - 1L])
+    lav_msg_stop(gettext("invalid modifier symbol (should be '*' or '?')"),
+                  tl[1L],
+                  footer = tl[2L]
+    )
+  }
+  invisible(NULL)
+}
+
+lav_parse_update_relational <- function(tmpenv, modelsrc, types, op) {
+  formule <- tmpenv$formule
+  opi <- tmpenv$opi
+  nelem <- tmpenv$nelem
+  # intercept fixed on 0
+  # replace 'lhs ~ 0' => 'lhs ~ 0 * 1' - intercept fixed on zero
+  if (formule$elem_text[nelem] == "0" && op == "~" && opi == nelem - 1L) {
+    formule$elem_type <- c(formule$elem_type, types$symbol, types$numliteral)
+    formule$elem_text <- c(formule$elem_text, "*", "1")
+    formule$elem_pos <- c(formule$elem_pos, rep(formule$elem_pos[nelem], 2))
+    nelem <- length(formule$elem_type)
+  }
+  # phantom latent variable
+  # replace 'lhs =~ 0' => 'lhs =~ fixed(0)*lhs', 0 can be other numliteral
+  #          also, lhs is last element before '=~'
+  if (formule$elem_type[nelem] == types$numliteral && op == "=~") {
+    formule$elem_type <- c(
+      formule$elem_type[seq.int(1L, nelem - 1L)], types$identifier,
+      types$symbol, types$numliteral, types$symbol, types$symbol,
+      types$identifier
+    )
+    formule$elem_text <- c(
+      formule$elem_text[seq.int(1L, nelem - 1L)], "fixed", "(",
+      formule$elem_text[nelem], ")", "*", formule$elem_text[opi - 1L]
+    )
+    formule$elem_pos <- c(
+      formule$elem_pos[seq.int(1L, nelem - 1L)],
+      rep(formule$elem_pos[nelem], 6)
+    )
+    nelem <- length(formule$elem_type)
+  }
+  # handling interaction variable types
+  colons <- which(formule$elem_text[seq.int(1L, nelem - 1L)] == ":" &
+                    formule$elem_type[seq.int(2L, nelem)] == types$identifier)
+  # check at most 1 colon
+  if (length(colons) > 2L ||
+      (length(colons) == 2L && (colons[1L] > opi || colons[2L] < opi))) {
+    tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[colons[2]])
+    lav_msg_stop(
+      gettext(
+        "Three-way or higher-order interaction terms (using multiple
+        colons) are not supported in the lavaan syntax; please manually
+        construct the product terms yourself in the data.frame, give
+        them an appropriate name, and then you can use these interaction
+        variables as any other (observed) variable in the model syntax."
+      ), tl[1L], footer = tl[2L]
+    )
+  }
+  if (length(colons) > 0L) {
+    # collapse items around colon "a" ":" "b" => "a:b"
+    formule$elem_text[colons[1L] - 1L] <-
+      paste(formule$elem_text[seq.int(colons[1L] - 1L, colons[1L] + 1L)],
+            collapse = ""
+      )
+    formule <- lav_parse_sublist(formule,
+          setdiff(seq.int(1L, nelem), seq.int(colons[1L], colons[1L] + 1L)))
+    nelem <- length(formule$elem_type)
+    if (colons[1L] < opi) {
+      opi <- opi - 2L # is in LHS
+      if (length(colons) == 2L) colons[2L] <- colons[2L] - 2L
+    }
+  }
+  if (length(colons) == 2L) {
+    # collapse items around colon "a" ":" "b" => "a:b"
+    formule$elem_text[colons[2L] - 1L] <-
+      paste(formule$elem_text[seq.int(colons[2L] - 1L, colons[2L] + 1L)],
+            collapse = ""
+      )
+    formule <- lav_parse_sublist(formule,
+          setdiff(seq.int(1L, nelem), seq.int(colons[2L], colons[2L] + 1L)))
+    nelem <- length(formule$elem_type)
+  }
+  assign("formule", formule, tmpenv)
+  assign("opi", opi, tmpenv)
+  assign("nelem", nelem, tmpenv)
+  invisible(NULL)
+}
+
+lav_parse_final_operations <- function(flat, modlist, config,
+                        constraints, as_data_frame, hashstring) {
+  # update flat (omit items without operator)
+  filled_ones <- which(flat$op != "")
+  flat$lhs <- flat$lhs[filled_ones]
+  flat$op <- flat$op[filled_ones]
+  flat$rhs <- flat$rhs[filled_ones]
+  flat$mod.idx <- flat$mod_idx[filled_ones]
+  flat$mod_idx <- NULL
+  flat$block <- flat$block[filled_ones]
 
   # change op for intercepts (for convenience only)
-  int_idx <- which(flat_op == "~" & flat_rhs == "")
+  int_idx <- which(flat$op == "~" & flat$rhs == "")
   if (length(int_idx) > 0L) {
     flat$op[int_idx] <- "~1"
   }
   # change op for instruments (for convenience only)
-  int_idx <- which(flat_op == "|~" & flat_rhs == "")
+  int_idx <- which(flat$op == "|~" & flat$rhs == "")
   if (length(int_idx) > 0L) {
     flat$op[int_idx] <- "|~1"
   }
@@ -1060,19 +1094,19 @@ lav_parse_model_string_open <- function(model_syntax = "",
         if (!is.na(numbound)) {
           nrs <- which(flat$label == constraints[[j]]$lhs)
           for (nr in nrs) {
-            nrm <- length(mod) + 1L
+            nrm <- length(modlist) + 1L
             if (flat$mod.idx[nr] > 0L) {
               nrm <- flat$mod.idx[nr]
             } else {
               flat$mod.idx[nr] <- nrm
-              mod <- c(mod, list(label = constraints[[j]]$lhs))
+              modlist <- c(modlist, list(label = constraints[[j]]$lhs))
             }
             if (constraints[[j]]$op == "<") {
               flat$upper[nr] <- as.character(numbound)
-              mod[[nrm]]$upper <- numbound
+              modlist[[nrm]]$upper <- numbound
             } else {
               flat$lower[nr] <- as.character(numbound)
-              mod[[nrm]]$lower <- numbound
+              modlist[[nrm]]$lower <- numbound
             }
           }
           constraints <- constraints[-j]
@@ -1082,25 +1116,31 @@ lav_parse_model_string_open <- function(model_syntax = "",
   }
   # new in 0.6, reorder covariances here!
   flat <- lav_pt_covariance_reorder(flat)
+  # remove empty modifier columns
+  for (mod1 in config$modifiers$mod) {
+    flat[[mod1]] <- flat[[mod1]][filled_ones]
+    if (all(flat[[mod1]] == "")) flat[[mod1]] <- NULL
+  }
+  # transform to data.frame is asked
   if (as_data_frame) {
     flat <- as.data.frame(flat, stringsAsFactors = FALSE)
   }
   # new in 0.6-4: check for 'group' within 'level'
-  if (any(flat_op == ":")) {
-    op_idx <- which(flat_op == ":")
+  if (any(flat$op == ":")) {
+    op_idx <- which(flat$op == ":")
     if (length(op_idx) < 2L) {
       # only 1 block identifier? this is weird -> give warning
       lav_msg_warn(gettext("syntax contains only a single block identifier!"))
     } else {
-      first_block <- flat_lhs[op_idx[1L]]
-      second_block <- flat_lhs[op_idx[2L]]
+      first_block <- flat$lhs[op_idx[1L]]
+      second_block <- flat$lhs[op_idx[2L]]
       if (first_block == "level" && second_block == "group") {
         lav_msg_stop(gettext("groups can not be nested within levels!"))
       }
     }
   }
   # create output
-  attr(flat, "modifiers") <- mod
+  attr(flat, "modifiers") <- modlist
   attr(flat, "constraints") <- constraints
   assign(hashstring, flat, envir = lavaan_cache_env)
   flat


### PR DESCRIPTION
…act lav_parse_formula_numbers; reorganize modifier/formula handling into smaller helpers (lav_parse_modifier_open, lav_parse_handle_formule, lav_parse_check_relational, lav_parse_update_relational, lav_parse_final_operations); convert flat/mod data structures to unified list(modlist), clean empty modifier columns; change cache key prefix to "mdl_o_"; various message/error handling and minor formatting tweaks.