### PR TITLE
Model syntax new operator ':~'. Modify default parser lavParseModelst…

### DIFF
--- a/R/lav_model_plotinfo.R
+++ b/R/lav_model_plotinfo.R
@@ -4,6 +4,7 @@ lav_model_plotinfo <- function(model = NULL, infile = NULL, varlv = FALSE) {
     lav_msg_stop(gettext("either model or infile must be specified"))
   }
   edge_label <- function(label, fix) {
+    if (is.null(fix)) fix <- ""
     if (label == "" && fix == "") {
       return("")
     }
@@ -301,7 +302,9 @@ lav_model_plotinfo <- function(model = NULL, infile = NULL, varlv = FALSE) {
       edges$id[curedge] <- curedge
       edges$label[curedge] <- edge_label(tbl$label[i], tbl$fixed[i])
       if (varlv && jl == jr) { # prepare for handling varlv
-        edges$label[curedge] <- paste(tbl$label[i], tbl$fixed[i], sep = "=")
+        edges$label[curedge] <- paste(tbl$label[i], 
+          if (is.null(tbl$fixed)) "" else tbl$fixed[i],
+          sep = "=")
       }
       edges$van[curedge] <- nodes$id[jr]
       edges$naar[curedge] <- nodes$id[jl]

--- a/R/lav_syntax.R
+++ b/R/lav_syntax.R
@@ -5,7 +5,7 @@
 # LDW 9 Jan 2026: remove c.r option
 
 lavParseModelString <- function(model.syntax = "", as.data.frame. = FALSE,   # nolint
-                                parser = "new", warn = TRUE, debug = FALSE) {
+                                parser = "open", warn = TRUE, debug = FALSE) {
   if (!missing(debug)) {
     current_debug <- lav_debug()
     if (lav_debug(debug))

--- a/R/lav_syntax_parser_open.R
+++ b/R/lav_syntax_parser_open.R
@@ -20,7 +20,7 @@ lav_parse_options <- function(
   if (is.null(config)) {
     ops = data.frame(
       op = c("=~", "<~", "~*~", "~~", "~", "|~", "==",
-      "<", ">", ":=", ":", "|", "%"),
+      "<", ">", ":=", ":", "|", "%", ":~"),
       pkg = "lavaan"
     )
     mods = data.frame(
@@ -355,7 +355,7 @@ lav_parse_formula_numbers <- function(list_before_numbering, types) {
     frm_hasefa <- TRUE
   }
   if (any(elem_text[i] ==
-          c("+", "*", "=~", "-", "<~", "~*~", "~~", "~", "|~", "|", "%"))) {
+      c("+", "*", "=~", "-", "<~", "~*~", "~~", "~", "|~", "|", "%", ":~"))) {
     if (frm_incremented) {
       frm_number <- frm_number - 1L
       elem_formula_number[i] <- frm_number
@@ -808,8 +808,9 @@ lav_parse_handle_formule <- function(formule, tmplist, types, modelsrc,
   lhs <- formule$elem_text[opi - 1L]
   rhs <- formule$elem_text[nelem]
   already <- which(flat$lhs == lhs & flat$op == op & flat$block == block &
-            (flat$rhs == rhs | (flat$rhs == "" & (op == "~" | op == "|~") &
-                            formule$elem_type[nelem] == types$numliteral)))
+            (flat$rhs == rhs | (flat$rhs == "" & 
+              (op == "~" | op == "|~" | op == ":~") &
+              formule$elem_type[nelem] == types$numliteral)))
   if (length(already) == 1L) {
     idx <- already
   } else {
@@ -820,7 +821,7 @@ lav_parse_handle_formule <- function(formule, tmplist, types, modelsrc,
     flat$rhs[idx] <- rhs
     flat$block[idx] <- block
     if (formule$elem_type[nelem] == types$numliteral) {
-      if (op == "~" || op == "|~") flat$rhs[idx] <- ""
+      if (op == "~" || op == "|~"| op == ":~") flat$rhs[idx] <- ""
     }
   }
   # modifiers always come before an asterix or a question mark
@@ -883,7 +884,7 @@ lav_parse_handle_formule <- function(formule, tmplist, types, modelsrc,
     }
   }
   # check for variable regressed on itself
-  if (formule$elem_text[opi] == "~" &&
+  if (formule$elem_text[opi] %in% c("~", ":~") &&
       formule$elem_text[opi - 1L] == formule$elem_text[nelem]) {
     if (!grepl("^0\\.?0*$", flat$fixed[idx])) {
       tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[opi])
@@ -931,11 +932,11 @@ lav_parse_check_relational <- function(formule, modelsrc, types, opi,
   }
   if (formule$elem_type[nelem] != types$identifier &&
       (formule$elem_type[nelem] != types$numliteral ||
-        all(op != c("~", "|~", "=~")))) {
+        all(op != c("~", "|~", "=~", ":~")))) {
     tl <- lav_parse_txtloc(modelsrc, formule$elem_pos[nelem])
     lav_msg_stop(
       gettext("Last element of rhs part expected to be an identifier or,
-              for operator ~, |~ or =~, a numeric literal!"),
+              for operator ~, |~, =~ or :~, a numeric literal!"),
       tl[1L],
       footer = tl[2L]
     )

--- a/man/model.syntax.Rd
+++ b/man/model.syntax.Rd
@@ -43,7 +43,7 @@ lavParTable(model = NULL, meanstructure = FALSE, int.ov.free = FALSE,
     debug = FALSE, warn = TRUE, as.data.frame. = TRUE)
 
 lavParseModelString(model.syntax = '', as.data.frame. = FALSE,
-                    parser = "new", warn = TRUE, debug = FALSE)
+                    parser = "open", warn = TRUE, debug = FALSE)
 
 }
 \arguments{
@@ -179,8 +179,9 @@ the model for both observed and latent variables.}
 \item{as.data.frame.}{If \code{TRUE}, return the list of model parameters
     as a \code{data.frame}.}
 \item{parser}{Character. If \code{"old"}, use the original/classic parser.
-    If \code{"new"}, use the new/ldw parser. The default (as of version 0.6-18)
-    is \code{"new"}.}
+    If \code{"new"}, use the new/ldw parser. 
+    If \code{"open"}, use the newest, extensible parser.
+    The default (as of version 0.7-1) is \code{"open"}.}
 \item{warn}{If \code{TRUE}, some (possibly harmless) warnings are printed
     out.}
 \item{debug}{If \code{TRUE}, debugging information is printed out.}


### PR DESCRIPTION
…ring. Check for missing 'fixed' column in lav_model_plotinfo().