### PR TITLE
Reduced Bias M-Estimation

### DIFF
--- a/R/lav_lavaan_step11_optim.R
+++ b/R/lav_lavaan_step11_optim.R
@@ -102,8 +102,9 @@ lav_step11_estoptim <- function(lavdata = NULL,
         silent = TRUE
       )
 
-      # reduced-bias M-estimation (RBM)
-    } else if (lavoptions$optim.method == "rbm") {
+      # reduced-bias M-estimation (RBM); optim.method is nlminb, so this is
+      # keyed on the estimator.args marker instead
+    } else if (!is.null(lavoptions$estimator.args$rbm.method)) {
       x <- try(
         lav_model_est_rbm(
           lavmodel = lavmodel,

--- a/R/lav_lavaan_step11_optim.R
+++ b/R/lav_lavaan_step11_optim.R
@@ -102,6 +102,20 @@ lav_step11_estoptim <- function(lavdata = NULL,
         silent = TRUE
       )
 
+      # reduced-bias M-estimation (RBM)
+    } else if (lavoptions$optim.method == "rbm") {
+      x <- try(
+        lav_model_est_rbm(
+          lavmodel = lavmodel,
+          lavpartable = lavpartable,
+          lavsamplestats = lavsamplestats,
+          lavdata = lavdata,
+          lavoptions = lavoptions,
+          lavcache = lavcache
+        ),
+        silent = TRUE
+      )
+
       # Quasi-Newton
     } else {
       # for backwards compatibility (<0.6)

--- a/R/lav_model_estimate_rbm.R
+++ b/R/lav_model_estimate_rbm.R
@@ -18,7 +18,7 @@
 # Reference: 
 # - Jamil, H., Rosseel, Y., Kemp, O., & Kosmidis, I. (2026). Bias-Reduced 
 #   Estimation of Structural Equation Models. Structural Equation Modeling: A 
-#   Multidisciplinary Journal, 33(3), 376–392. 
+#   Multidisciplinary Journal, 33(3), 376-392.
 #   https://doi.org/10.1080/10705511.2025.2610462
 # - ported from the brlavaan package (github.com/haziqj/brlavaan)
 

--- a/R/lav_model_estimate_rbm.R
+++ b/R/lav_model_estimate_rbm.R
@@ -1,0 +1,262 @@
+# Reduced-bias M-estimation (RBM) for continuous-outcome SEM.
+#
+# RBM is a penalized maximum likelihood method (Firth/Kosmidis-style). The
+# discrepancy function, implied moments, loglik, test statistic and information
+# matrices are all the ML ones, so the estimator is kept as "ML" internally
+# (see lav_options_est_rbm) and only the point estimate differs:
+#
+#   penalty  P(theta) = -1/2 * tr( J(theta)^-1 E(theta) )
+#     J = observed information, E = first-order (outer-product) information.
+#
+#   implicit (iRBM): maximize  loglik(theta) + P(theta)
+#   explicit (eRBM): maximize  loglik(theta), then one-step bias-correct
+#                    theta <- theta - bias(theta), bias = -J^-1 dP/dtheta
+#
+# Standard errors use the sandwich estimator (se = "robust.huber.white"),
+# computed by lav_model_vcov() in the usual way.
+#
+# Reference: Jamil, Kosmidis, Rosseel (2025) <arXiv:2509.25419>; ported from
+# the brlavaan package.
+
+# check whether a matrix is non-positive-definite or has NAs
+lav_model_rbm_check_mat <- function(mat) {
+  if (anyNA(mat)) {
+    return(TRUE)
+  }
+  eig <- eigen(mat, symmetric = TRUE, only.values = TRUE)$values
+  any(eig < -1e-06 * eig[1])
+}
+
+# total (N-scaled) information matrix in the (free) parameter space
+# kind: "observed" (J) or "first.order" (E)
+lav_model_rbm_information <- function(x, lavmodel, lavsamplestats, lavdata,
+                                      lavoptions, kind = "observed") {
+  lavmodel <- lav_model_set_parameters(lavmodel, x)
+  if (kind == "observed") {
+    info <- lav_model_info_observed(
+      lavmodel = lavmodel, lavsamplestats = lavsamplestats,
+      lavdata = lavdata, lavoptions = lavoptions
+    )
+  } else {
+    info <- lav_model_info_firstorder(
+      lavmodel = lavmodel, lavsamplestats = lavsamplestats,
+      lavdata = lavdata, lavoptions = lavoptions
+    )
+  }
+  # the info functions return unit (per-observation) information
+  info <- lavsamplestats@ntotal * info
+
+  # reduce to the optimizer space for simple equality constraints
+  if (lavmodel@ceq.simple.only) {
+    k <- lavmodel@ceq.simple.K
+    info <- t(k) %*% info %*% k
+  }
+  info
+}
+
+# RBM penalty P(theta) = -1/2 * tr( J^-1 E ), evaluated on the loglik scale
+lav_model_rbm_penalty <- function(x, lavmodel, lavsamplestats, lavdata,
+                                  lavoptions, fallback = -1e8) {
+  e <- lav_model_rbm_information(x, lavmodel, lavsamplestats, lavdata,
+    lavoptions,
+    kind = "first.order"
+  )
+  j <- lav_model_rbm_information(x, lavmodel, lavsamplestats, lavdata,
+    lavoptions,
+    kind = "observed"
+  )
+  if (lav_model_rbm_check_mat(j)) {
+    return(fallback)
+  }
+  jinv <- try(solve(j), silent = TRUE)
+  if (inherits(jinv, "try-error")) {
+    fallback
+  } else {
+    # sum(jinv * e) == tr(jinv %*% e) for symmetric jinv
+    -sum(jinv * e) / 2
+  }
+}
+
+# one-step bias for the explicit method: bias = -J^-1 dP/dtheta
+lav_model_rbm_bias <- function(x, lavmodel, lavsamplestats, lavdata,
+                               lavoptions) {
+  j <- lav_model_rbm_information(x, lavmodel, lavsamplestats, lavdata,
+    lavoptions,
+    kind = "observed"
+  )
+  if (lav_model_rbm_check_mat(j)) {
+    return(rep(as.numeric(NA), length(x)))
+  }
+  jinv <- try(solve(j), silent = TRUE)
+  if (inherits(jinv, "try-error")) {
+    return(rep(as.numeric(NA), length(x)))
+  }
+  a <- numDeriv::grad(
+    func = lav_model_rbm_penalty, x = x,
+    lavmodel = lavmodel, lavsamplestats = lavsamplestats,
+    lavdata = lavdata, lavoptions = lavoptions
+  )
+  -drop(jinv %*% a)
+}
+
+# RBM estimation; returns the free parameter vector 'x' with the same
+# attributes as lav_model_est() so that lav_step11_estoptim() can use it.
+lav_model_est_rbm <- function(lavmodel = NULL,
+                              lavpartable = NULL,
+                              lavsamplestats = NULL,
+                              lavdata = NULL,
+                              lavoptions = NULL,
+                              lavcache = list()) {
+  rbm_method <- lavoptions$estimator.args$rbm.method
+  if (is.null(rbm_method)) {
+    rbm_method <- "implicit"
+  }
+
+  # general (non-simple) equality constraints are not supported yet
+  if (lavmodel@eq.constraints) {
+    lav_msg_stop(gettext(
+      "estimator \"rbm\" does not support general equality constraints yet;
+       use simple (label-based) equality constraints instead."))
+  }
+
+  ntotal <- lavsamplestats@ntotal
+
+  # ----- explicit / none: reuse the standard ML optimizer -----
+  if (rbm_method %in% c("explicit", "none")) {
+    # lav_model_est() dispatches on optim.method; restore the ML optimizer
+    lavoptions_ml <- lavoptions
+    lavoptions_ml$optim.method <- "nlminb"
+    x_ml <- lav_model_est(
+      lavmodel = lavmodel, lavpartable = lavpartable,
+      lavsamplestats = lavsamplestats, lavdata = lavdata,
+      lavoptions = lavoptions_ml, lavcache = lavcache
+    )
+    if (rbm_method == "none") {
+      return(x_ml)
+    }
+
+    # explicit: one-step bias correction
+    b <- lav_model_rbm_bias(
+      as.numeric(x_ml), lavmodel, lavsamplestats, lavdata, lavoptions
+    )
+    x <- as.numeric(x_ml) - b
+
+    lavmodel_x <- lav_model_set_parameters(lavmodel, x)
+    fx <- lav_model_objective(
+      lavmodel = lavmodel_x, lavsamplestats = lavsamplestats,
+      lavdata = lavdata, lavcache = lavcache
+    )
+
+    attr(x, "converged") <- attr(x_ml, "converged")
+    attr(x, "iterations") <- attr(x_ml, "iterations")
+    attr(x, "control") <- attr(x_ml, "control")
+    attr(x, "warn.txt") <- attr(x_ml, "warn.txt")
+    attr(x, "fx") <- fx
+    attr(x, "dx") <- numeric(0L)
+    attr(x, "parscale") <- attr(x_ml, "parscale")
+    return(x)
+  }
+
+  # ----- implicit: penalized-ML optimization -----
+
+  # starting values (in the optimizer/free space)
+  start_x <- lav_model_get_parameters(lavmodel)
+
+  # bounds (mirror lav_model_est; eq.constraints excluded above)
+  if (is.null(lavpartable$lower)) {
+    lower <- -Inf
+  } else if (lavmodel@ceq.simple.only) {
+    free_idx <- which(lavpartable$free > 0L & !duplicated(lavpartable$free))
+    lower <- lavpartable$lower[free_idx]
+  } else {
+    lower <- lavpartable$lower[lavpartable$free > 0L]
+  }
+  if (is.null(lavpartable$upper)) {
+    upper <- +Inf
+  } else if (lavmodel@ceq.simple.only) {
+    free_idx <- which(lavpartable$free > 0L & !duplicated(lavpartable$free))
+    upper <- lavpartable$upper[free_idx]
+  } else {
+    upper <- lavpartable$upper[lavpartable$free > 0L]
+  }
+  bad_idx <- which(lower > upper)
+  if (length(bad_idx) > 0L) {
+    lower[bad_idx] <- -Inf
+    upper[bad_idx] <- +Inf
+  }
+
+  # theta-independent part of the Gaussian loglik (loglik = const - N * fx_ML).
+  # Optimizing the penalized negative loglik on its natural scale (rather than
+  # the small N * fx_ML - P) is what lets nlminb reach 'relative convergence'
+  # (matching brlavaan); the constant does not affect the estimate.
+  log2pi <- log(2 * pi)
+  loglik_const <- 0
+  for (g in seq_len(lavsamplestats@ngroups)) {
+    ng <- lavsamplestats@nobs[[g]]
+    pg <- NROW(lavsamplestats@cov[[g]])
+    loglik_const <- loglik_const -
+      0.5 * ng * (pg * log2pi + lavsamplestats@cov.log.det[[g]] + pg)
+  }
+  if (!is.finite(loglik_const)) {
+    loglik_const <- 0
+  }
+
+  # penalized objective: minimize  -(loglik + P) = N * fx_ML - P - const
+  objective_function <- function(x) {
+    lavmodel_x <- lav_model_set_parameters(lavmodel, x)
+    fx <- lav_model_objective(
+      lavmodel = lavmodel_x, lavsamplestats = lavsamplestats,
+      lavdata = lavdata, lavcache = lavcache
+    )
+    if (!is.finite(fx)) {
+      return(1e20)
+    }
+    pen <- lav_model_rbm_penalty(
+      x, lavmodel, lavsamplestats, lavdata, lavoptions
+    )
+    val <- ntotal * as.numeric(fx) - pen - loglik_const
+    if (!is.finite(val)) 1e20 else val
+  }
+
+  # nlminb control (mirror lav_model_est)
+  control_nlminb <- list(
+    eval.max = 20000L, iter.max = 10000L, trace = 0L,
+    abs.tol = (.Machine$double.eps * 10), rel.tol = 1e-10,
+    step.min = 1.0, step.max = 1.0, x.tol = 1.5e-8, xf.tol = 2.2e-14
+  )
+  if (!is.null(lavoptions$control)) {
+    control_nlminb <- modifyList(control_nlminb, lavoptions$control)
+  }
+  control <- control_nlminb[c(
+    "eval.max", "iter.max", "trace", "step.min", "step.max",
+    "abs.tol", "rel.tol", "x.tol", "xf.tol"
+  )]
+
+  optim_out <- nlminb(
+    start = start_x, objective = objective_function, gradient = NULL,
+    lower = lower, upper = upper, control = control
+  )
+
+  x <- optim_out$par
+
+  # ML objective (with fx.group attribute) at the solution, for steps 12-14
+  lavmodel_x <- lav_model_set_parameters(lavmodel, x)
+  fx <- lav_model_objective(
+    lavmodel = lavmodel_x, lavsamplestats = lavsamplestats,
+    lavdata = lavdata, lavcache = lavcache
+  )
+
+  converged <- optim_out$convergence == 0L
+  attr(x, "converged") <- converged
+  attr(x, "iterations") <- optim_out$iterations
+  attr(x, "control") <- control
+  attr(x, "warn.txt") <- if (converged) {
+    ""
+  } else {
+    "the optimizer warns that a solution has NOT been found!"
+  }
+  attr(x, "fx") <- fx
+  attr(x, "dx") <- numeric(0L)
+  attr(x, "parscale") <- rep(1.0, length(x))
+  x
+}

--- a/R/lav_model_estimate_rbm.R
+++ b/R/lav_model_estimate_rbm.R
@@ -15,8 +15,12 @@
 # Standard errors use the sandwich estimator (se = "robust.huber.white"),
 # computed by lav_model_vcov() in the usual way.
 #
-# Reference: Jamil, Kosmidis, Rosseel (2025) <arXiv:2509.25419>; ported from
-# the brlavaan package.
+# Reference: 
+# - Jamil, H., Rosseel, Y., Kemp, O., & Kosmidis, I. (2026). Bias-Reduced 
+#   Estimation of Structural Equation Models. Structural Equation Modeling: A 
+#   Multidisciplinary Journal, 33(3), 376–392. 
+#   https://doi.org/10.1080/10705511.2025.2610462
+# - ported from the brlavaan package (github.com/haziqj/brlavaan)
 
 # check whether a matrix is non-positive-definite or has NAs
 lav_model_rbm_check_mat <- function(mat) {

--- a/R/lav_options.R
+++ b/R/lav_options.R
@@ -652,6 +652,7 @@ lav_options_set <- function(opt = NULL) {
     jsa = ,
     bentler1982 = lav_options_est_fabin(opt),
     iv = lav_options_est_iv(opt),
+    rbm = lav_options_est_rbm(opt),
     lav_options_est_none(opt) # estimator = none
   )
 

--- a/R/lav_options_default.R
+++ b/R/lav_options_default.R
@@ -344,7 +344,7 @@ lav_options_default <- function() {
     js = "js", jsa = "jsa", james.stein = "js",
     james.stein.aggregated = "jsa", bentler = "bentler1982",
     bentler1982 = "bentler1982", miiv = "iv", iv = "iv",
-    miiv.2sls = "iv"
+    miiv.2sls = "iv", rbm = "rbm"
   ))
   elmdup("estimator.orig", "estimator")
 

--- a/R/lav_options_estimator.R
+++ b/R/lav_options_estimator.R
@@ -749,8 +749,8 @@ lav_options_est_rbm <- function(opt) {
   #
   # penalized-ML point estimation; the discrepancy, implied moments, loglik,
   # test and information matrices are all the ML ones, so we keep the estimator
-  # as "ml" internally and trigger the dedicated fit function via optim.method =
-  # "rbm".
+  # as "ml" internally. The dedicated fit function is triggered in step 11 by
+  # the presence of estimator.args$rbm.method (the optimizer itself is nlminb).
 
   # estimator.args
   if (is.null(opt$estimator.args)) {
@@ -784,8 +784,9 @@ lav_options_est_rbm <- function(opt) {
     opt$missing <- "listwise" # for now
   }
 
-  # trigger the rbm fit function in step 11
-  opt$optim.method <- "rbm"
+  # the actual optimizer is nlminb (the rbm fit is triggered in step 11 by
+  # estimator.args$rbm.method)
+  opt$optim.method <- "nlminb"
 
   # internally, treat as ML for all downstream machinery
   opt$estimator <- "ml"

--- a/R/lav_options_estimator.R
+++ b/R/lav_options_estimator.R
@@ -723,6 +723,76 @@ lav_options_est_iv <- function(opt) {
   opt
 }
 
+# normalize the rbm.method estimator.arg (short forms allowed)
+# ("none" is an undocumented value that falls back to plain ML; kept for
+#  debugging / parity checks)
+lav_options_est_rbm_method <- function(x) {
+  if (length(x) == 0L) {
+    return("implicit")
+  }
+  x <- tolower(as.character(x)[1L])
+  if (x %in% c("none", "ml", "false")) {
+    "none"
+  } else if (startsWith(x, "e")) {
+    "explicit" # explicit, erbm, e
+  } else if (startsWith(x, "i")) {
+    "implicit" # implicit, irbm, i
+  } else {
+    lav_msg_stop(gettextf(
+      "estimator.args$rbm.method must be one of %s.",
+      lav_msg_view(c("implicit", "explicit"), log_sep = "or")))
+  }
+}
+
+lav_options_est_rbm <- function(opt) {
+  # RBM reduced-bias M-estimation (continuous SEM, for now)  # FIXME
+  #
+  # penalized-ML point estimation; the discrepancy, implied moments, loglik,
+  # test and information matrices are all the ML ones, so we keep the estimator
+  # as "ml" internally and trigger the dedicated fit function via optim.method =
+  # "rbm".
+
+  # estimator.args
+  if (is.null(opt$estimator.args)) {
+    opt$estimator.args <- list(rbm.method = "implicit")
+  } else {
+    opt$estimator.args$rbm.method <-
+      lav_options_est_rbm_method(opt$estimator.args$rbm.method)
+  }
+
+  # information: the penalty/bias need the observed information
+  opt$information[1] <- "observed"
+  if (length(opt$information) > 1L &&
+      opt$information[2] == "default") {
+    opt$information[2] <- "observed"
+  }
+
+  # se: sandwich by default
+  if (opt$se == "default") {
+    opt$se <- "robust.huber.white"
+  } else if (opt$se == "robust") {
+    opt$se <- "robust.huber.white"
+  }
+
+  # test
+  if (opt$test[1] == "default") {
+    opt$test <- "standard"
+  }
+
+  # missing
+  if (opt$missing == "default") {
+    opt$missing <- "listwise" # for now
+  }
+
+  # trigger the rbm fit function in step 11
+  opt$optim.method <- "rbm"
+
+  # internally, treat as ML for all downstream machinery
+  opt$estimator <- "ml"
+
+  opt
+}
+
 lav_options_est_none <- function(opt) {
   # NONE                                                           ####
   # se

--- a/R/lav_print.R
+++ b/R/lav_print.R
@@ -1061,6 +1061,15 @@ lav_summary_print <- function(x, ..., nd = 3L) {
       )
       tmp_est <- paste("DLS-", toupper(dls_first_letter), sep = "")
     }
+    # reduced-bias M-estimation: show IRBM / ERBM (estimator is ML internally)
+    if (!is.null(estimator_args$rbm.method)) {
+      tmp_est <- switch(estimator_args$rbm.method,
+        implicit = "IRB-ML",
+        explicit = "ERB-ML",
+        none = "ML",
+        "RBM"
+      )
+    }
     c2 <- tmp_est
 
     # additional estimator args

--- a/inst/rbm_sem.R
+++ b/inst/rbm_sem.R
@@ -23,9 +23,17 @@ fit_ML   <- sem(model = mod, data = PoliticalDemocracy)
 
 # Implicit RBM fit (default)
 fit_iRBM <- sem(model = mod, data = PoliticalDemocracy,
-                estimator = list(estimator = "rbm", rbm.method = "implicit") 
+                estimator = list(estimator = "rbm", rbm.method = "implicit")) 
 
 # Explicit RBM fit
 fit_eRBM <- sem(model = mod, data = PoliticalDemocracy,
-                estimator = list(estimator = "rbm", rbm.method = "explicit")
+                estimator = list(estimator = "rbm", rbm.method = "explicit"))
 
+# Compare
+tab <- data.frame(
+    ML = coef(fit_ML),
+    iRBM = coef(fit_iRBM),
+    eRBM = coef(fit_eRBM)
+)
+rownames(tab) <- names(coef(fit_ML))
+print(round(tab, 3))

--- a/inst/rbm_sem.R
+++ b/inst/rbm_sem.R
@@ -1,0 +1,31 @@
+# Reduced Bias M-estimation for SEM.
+
+mod <- "
+  # latent variables 
+  ind60 =~ x1 + x2 + x3 
+  dem60 =~ y1 + y2 + y3 + y4 
+  dem65 =~ y5 + y6 + y7 + y8 
+   
+  # regressions
+  dem60 ~ ind60 
+  dem65 ~ ind60 + dem60 
+  
+  # residual covariances 
+  y1 ~~ y5
+  y2 ~~ y4 + y6 
+  y3 ~~ y7 
+  y4 ~~ y8
+  y6 ~~ y8
+"
+
+# Maximum likelihood fit
+fit_ML   <- sem(model = mod, data = PoliticalDemocracy)
+
+# Implicit RBM fit (default)
+fit_iRBM <- sem(model = mod, data = PoliticalDemocracy,
+                estimator = list(estimator = "rbm", rbm.method = "implicit") 
+
+# Explicit RBM fit
+fit_eRBM <- sem(model = mod, data = PoliticalDemocracy,
+                estimator = list(estimator = "rbm", rbm.method = "explicit")
+

--- a/man/lavOptions.Rd
+++ b/man/lavOptions.Rd
@@ -284,7 +284,17 @@ Estimation options:
       and a mean or mean and variance adjusted test statistic. Estimators
       \code{"ULSM"} and \code{"ULSMV"} imply the \code{"ULS"}
       estimator with robust standard errors
-      and a mean or mean and variance adjusted test statistic.}
+      and a mean or mean and variance adjusted test statistic.
+      Finally, \code{"RBM"} requests reduced-bias M-estimation
+      (penalized maximum likelihood; continuous-outcome models for now). By
+      default sandwich standard errors are used
+      (\code{se = "robust.huber.white"}). The type of bias reduction is
+      controlled by the \code{rbm.method} element of \code{estimator.args}
+      (either \code{"implicit"} (default) or \code{"explicit"}), for example
+      \code{estimator = list(estimator = "RBM", rbm.method = "explicit")}.
+      The \code{"explicit"} method is much faster for models with many
+      parameters (it requires a single ML fit plus a one-step correction),
+      and is recommended in that case.}
     \item{\code{likelihood}:}{Only relevant for ML estimation. If 
       \code{"wishart"}, the Wishart likelihood approach is used. In this 
       approach, the covariance matrix has been divided by N-1, and both 


### PR DESCRIPTION
Hello @yrosseel, 

This is a direct port of the functions we developed in [brlavaan](https://haziqj.ml/brlavaan/index.html) (which I hope to retire). Users, if interested, may now use the RBM estimator for continuous SEM natively in lavaan. 

The bias-reducing methods can also be applied to other estimators. The DWLS for instance for ordinal SEM/CFA would be an interesting direction. Something to do for another time :)

By the way I am aware lavaan is preparing for 0.7 series update. It is not that urgent that this PR gets in for that version. Please review at your convenience. It might also be a good idea to isolate these features into a separate branch.

Reference
- Jamil, H., Rosseel, Y., Kemp, O., & Kosmidis, I. (2026). Bias-Reduced Estimation of Structural Equation Models. *Structural Equation Modeling: A Multidisciplinary Journal*, 33(3), 376–392. https://doi.org/10.1080/10705511.2025.2610462
- Kosmidis, I., & Lunardon, N. (2024). Empirical bias-reducing adjustments to estimating functions. *Journal of the Royal Statistical Society Series B: Statistical Methodology*, 86(1), 62–89. https://doi.org/10.1093/jrsssb/qkad083


cc: @ikosmidis