### PR TITLE
Add two-stage missing-data handling for estimator = "IV"

### DIFF
--- a/R/lav_lavaan_step02_options.R
+++ b/R/lav_lavaan_step02_options.R
@@ -161,6 +161,21 @@ lav_step02_options <- function(slot_options = NULL,
       opt$.categorical <- FALSE
     }
 
+    # IV estimator: default to two-stage missing-data handling when the data
+    # contain missing values among the modeled variables and the user did not
+    # request a 'missing' option. (opt$missing is still "default" here; it is
+    # resolved to "listwise" later in lav_options_set().) This must happen
+    # before lav_options_set() so the two.stage option cascade (meanstructure,
+    # information, ...) and lavData (no listwise deletion) are set up correctly.
+    if (toupper(estimator) == "IV" && identical(opt$missing, "default") &&
+        !opt$.categorical && is.data.frame(data)) {
+      tmp_ov <- unique(c(unlist(ov_names_y), unlist(ov_names_x)))
+      tmp_ov <- tmp_ov[tmp_ov %in% names(data)]
+      if (length(tmp_ov) > 0L && anyNA(data[, tmp_ov, drop = FALSE])) {
+        opt$missing <- "two.stage"
+      }
+    }
+
     # check for WLSMV estimator with NULL ordered= argument (new in 0.7-1)
     # to avoid unintentional use of WLSMV
     # we do this here, because we need the value of opt$.categorical

--- a/R/lav_lavaan_step13_vcov.R
+++ b/R/lav_lavaan_step13_vcov.R
@@ -49,6 +49,7 @@ lav_step13_vcov_boot <- function(lavoptions = NULL,
         lavpartable = lavpartable,
         lavimplied = lavimplied,
         lavh1 = lavh1,
+        lavdata = lavdata,
         eqs = attr(x, "eqs")
       )
     } else {

--- a/R/lav_options_estimator.R
+++ b/R/lav_options_estimator.R
@@ -629,8 +629,27 @@ lav_options_est_iv <- function(opt) {
   # them via a pooled (system) solve -- see lav_sem_miiv_pool_directed()
   opt$ceq.simple <- TRUE
 
-  # se
-  if (opt$se == "default") {
+  # missing data
+  # - two.stage / robust.two.stage: use the (saturated) EM moments for point
+  #   estimation, with standard errors corrected for the EM uncertainty (see
+  #   lav_sem_miiv_vcov()); requires the sample-statistics path
+  # - anything else falls back to listwise deletion
+  two_stage <- any(opt$missing == c("two.stage", "robust.two.stage"))
+  if (two_stage && isTRUE(opt$.categorical)) {
+    lav_msg_warn(gettext(
+      "[IV] two-stage missing-data handling is not available for categorical
+       data; using listwise deletion instead."))
+    two_stage <- FALSE
+  }
+  if (!two_stage) {
+    opt$missing <- "listwise" # for now
+  }
+
+  # se: the general missing = two.stage handling (in lav_options()) sets se to
+  # (robust.)two.stage, but the IV estimator uses its own SE machinery and
+  # reads opt$missing to pick the two-stage moment covariance; reset to
+  # "standard" here
+  if (any(opt$se == c("default", "two.stage", "robust.two.stage"))) {
     opt$se <- "standard" # for now
   }
   # bounds
@@ -638,22 +657,28 @@ lav_options_est_iv <- function(opt) {
       length(opt$optim.bounds) == 0L) {
     opt$bounds <- "standard"
   }
-  # test
-  if (length(opt$test) == 1L && opt$test == "default") {
+  # test (the general two.stage handling forces satorra.bentler; reset to the
+  # IV default Browne residual test). With missing data the sample-based
+  # version is not available, so use the model-based variant.
+  if ((length(opt$test) == 1L && opt$test == "default") || two_stage) {
     if (opt$.categorical) {
-      opt$test <- "browne.residual.adf" # always sample-based
+      opt$test <- if (two_stage) {
+        "browne.residual.adf.model"
+      } else {
+        "browne.residual.adf" # always sample-based
+      }
     } else {
-      opt$test <- "browne.residual.nt" # sample-based (especially for baseline)
-                                       # model-based Sigma is here diagonal!
+      opt$test <- if (two_stage) {
+        "browne.residual.nt.model"
+      } else {
+        "browne.residual.nt" # sample-based (especially for baseline)
+      }                       # model-based Sigma is here diagonal!
     }
   }
   opt$standard.test <- opt$test[1]
 
   # fixed.x
   opt$fixed.x <- FALSE # for now
-
-  # missing
-  opt$missing <- "listwise" # for now
 
   # sample.icov not needed
   opt$sample.icov <- FALSE
@@ -743,6 +768,18 @@ lav_options_est_iv <- function(opt) {
     }
     if (is.null(opt$estimator.args$iv.vcov.jacb.numerical)) {
       opt$estimator.args$iv.vcov.jacb.numerical <- FALSE
+    }
+  }
+
+  # two-stage missing data needs the (EM) sample moments, and the standard
+  # errors must run through the gamma path so the moment covariance can be
+  # replaced by the two-stage one (see lav_sem_miiv_vcov())
+  if (two_stage) {
+    opt$estimator.args$iv.samplestats <- TRUE
+    if (tolower(opt$se) != "none" &&
+        tolower(opt$estimator.args$iv.vcov.stage1) %in%
+          c("lm.vcov", "lm.vcov.dfres")) {
+      opt$estimator.args$iv.vcov.stage1 <- "gamma"
     }
   }
 

--- a/R/lav_sem_miiv.R
+++ b/R/lav_sem_miiv.R
@@ -1025,7 +1025,7 @@ lav_sem_miiv_varcov <- function(x = NULL, samplestats = FALSE,
 lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
                               lavoptions = NULL, lavpartable = NULL,
                               lavimplied = NULL,
-                              lavh1 = NULL, eqs = NULL) {
+                              lavh1 = NULL, lavdata = NULL, eqs = NULL) {
   # iv options
   iv_vcov_stage1 <- tolower(lavoptions$estimator.args$iv.vcov.stage1)
   iv_vcov_stage2 <- tolower(lavoptions$estimator.args$iv.vcov.stage2)
@@ -1131,6 +1131,16 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
     iv_vcov_stage2 <- "none"
   }
 
+  # missing data: two-stage standard errors. Under missing = "two.stage" /
+  # "robust.two.stage" the sample moments are the (saturated) EM estimates;
+  # their asymptotic covariance ('gamma') is no longer the complete-data NT
+  # gamma but the inverse saturated information (two.stage) or its sandwich
+  # (robust.two.stage). We build that 'gamma_big' explicitly (in the same
+  # (mean, vech(cov)) ordering as jac_k) and route the SEs through the same
+  # explicit jac %*% gamma %*% t(jac) path used for categorical data.
+  two_stage <- any(lavoptions$missing == c("two.stage", "robust.two.stage"))
+  use_explicit_gamma <- lavmodel@categorical || two_stage
+
   # do we need gamma_big?
   if (iv_vcov_stage1 == "gamma" ||
      (iv_vcov_stage2 != "none" && length(free_undirected_idx) > 0L)) {
@@ -1151,22 +1161,34 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
       } else {
         cov_g <- lavh1$implied$cov[[g]]
       }
-      if (!is.null(lavsamplestats@NACOV[[g]])) {
+      if (two_stage) {
+        # two-stage moment covariance, in (mean, vech(cov)) order
+        mu_g <- lavh1$implied$mean[[g]]
+        sig_g <- lavh1$implied$cov[[g]]
+        x_idx_g <-
+          if (lavmodel@fixed.x) lavsamplestats@x.idx[[g]] else integer(0L)
+        if (identical(tolower(lavoptions$missing), "robust.two.stage")) {
+          # sandwich I_1^{-1} J_1 I_1^{-1} (Savalei & Falk, 2014)
+          gg <- lav_mvn_mi_h1_omega_sw(
+            y = lavdata@X[[g]], mp = lavdata@Mp[[g]],
+            yp = lavsamplestats@missing[[g]],
+            mu = mu_g, sigma_1 = sig_g, x_idx = x_idx_g,
+            information = "observed"
+          )
+        } else {
+          # I_1^{-1} (Savalei & Bentler, 2009)
+          i1 <- lav_mvnorm_missing_information_observed_samplestats(
+            yp = lavsamplestats@missing[[g]],
+            mu = mu_g, sigma_1 = sig_g, x_idx = x_idx_g
+          )
+          gg <- lav_mat_sym_inverse(i1)
+        }
+        gamma_g[[g]] <- fg * gg
+      } else if (!is.null(lavsamplestats@NACOV[[g]])) {
         gamma_g[[g]] <- fg * lavsamplestats@NACOV[[g]]
-#         # NT version (for now), model-based
-#         gamma_g[[g]] <- lav_samp_gamma_nt(
-#           m_cov = cov_g,
-#           m_mean = mean_g,
-#           x_idx = lavsamplestats@x.idx[[g]],
-#           fixed_x = lavmodel@fixed.x,
-#           conditional_x = lavmodel@conditional.x,
-#           meanstructure = lavmodel@meanstructure,
-#           slopestructure = lavmodel@conditional.x
-#         )
-#         gamma_g[[g]] <- fg * gamma_g[[g]]
       }
     }
-    if (!is.null(lavsamplestats@NACOV[[g]])) {
+    if (two_stage || !is.null(lavsamplestats@NACOV[[g]])) {
       gamma_big <- lav_mat_bdiag(gamma_g)
     }
   }
@@ -1201,7 +1223,8 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
   # stage 1: directed effects
   if (length(free_directed_idx) > 0L && iv_vcov_stage1 != "none") {
     if (iv_vcov_stage1 == "gamma") {
-      if (lavmodel@categorical) {
+      if (use_explicit_gamma) {
+        # explicit moment covariance: categorical (ADF) or two-stage missing
         k_gamma_adf_kt <- jac_k %*% gamma_big %*% t(jac_k)
         vcov[free_directed_idx, free_directed_idx] <-
           k_gamma_adf_kt / lavsamplestats@ntotal
@@ -1340,13 +1363,13 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
       } else {
         tmp <- h2
       }
-      if (lavmodel@categorical) {
+      if (use_explicit_gamma) {
         tmp_gamma_tmpt <- tmp %*% gamma_big %*% t(tmp)
         vcov[free_undirected_idx, free_undirected_idx] <-
           tmp_gamma_tmpt / lavsamplestats@ntotal
-        # add thresholds
-        nth <- length(free_th_idx)
-        if (length(nth) > 0L) {
+        # add thresholds (categorical only)
+        nth <- if (lavmodel@categorical) length(free_th_idx) else 0L
+        if (length(nth) > 0L && nth > 0L) {
           delta_th <- delta[, free_th_idx, drop = FALSE]
           # FIXME: remove zero rows from delta
           zero_idx <- which(rowSums(delta_th) == 0)
@@ -1477,11 +1500,15 @@ lav_sem_miiv_vcov <- function(lavmodel = NULL, lavsamplestats = NULL,
         #   iv.varcov.method = iv.varcov.method
         # )
       }
-      x_idx <- if (lavmodel@fixed.x) lavsamplestats@x.idx[[1]] else integer(0L)
-      jacb_gammant_jacbt <- lav_mat_k_gammant_kt(m_k = jac_b, s = cov_g,
-        meanstructure = lavmodel@meanstructure, x_idx = x_idx)
-      #jacb_gammant_jacbt_bis <- jac_b %*% gamma_big %*% t(jac_b)
-      vcov_b <- jacb_gammant_jacbt / lavsamplestats@ntotal
+      if (use_explicit_gamma) {
+        jacb_gamma_jacbt <- jac_b %*% gamma_big %*% t(jac_b)
+      } else {
+        x_idx <-
+          if (lavmodel@fixed.x) lavsamplestats@x.idx[[1]] else integer(0L)
+        jacb_gamma_jacbt <- lav_mat_k_gammant_kt(m_k = jac_b, s = cov_g,
+          meanstructure = lavmodel@meanstructure, x_idx = x_idx)
+      }
+      vcov_b <- jacb_gamma_jacbt / lavsamplestats@ntotal
       vcov_ab <- vcov_a + vcov_b
       vcov[free_undirected_idx, free_undirected_idx] <- vcov_ab
     } # continuous


### PR DESCRIPTION
Support missing = "two.stage" / "robust.two.stage" for the noniterative IV/MIIV-2SLS estimator. Both the point estimates and the standard errors account for the missing data.

Point estimation uses the saturated EM (FIML) moments, which the IV sample-statistics path already consumes. For the standard errors, the moment covariance 'gamma' is swapped from the complete-data NT gamma to the two-stage moment covariance: the inverse saturated information I_1^{-1} (two.stage; Savalei & Bentler, 2009) or its sandwich I_1^{-1} J_1 I_1^{-1} (robust.two.stage; Savalei & Falk, 2014), in the (mean, vech(cov)) parameterization that matches jac_k / h2 / jac_b. lav_sem_miiv_vcov() now routes stage-1 and stage-2 (h2 and delta) SEs through the explicit jac %*% gamma %*% t(jac) path used for categorical data, and receives lavdata for the robust sandwich.

The IV option handler allows the two-stage missing settings (instead of forcing listwise), neutralizes the ML-specific cascade (se -> standard, model-based Browne test), forces the sample-statistics + gamma SE path, and falls back to listwise for categorical data.

two.stage becomes the default when estimator = "IV", the data are continuous, the user did not set missing=, and a modeled variable contains NA (decided in step02 before lavData, so no rows are deleted). Complete data keeps listwise; an explicit missing= is always honored.

Validated against MIIVsem "twostage" (point estimates ~1e-6) and against lavaan's ML two.stage standard errors (within ~7%); complete-data SEs reduce to the listwise gamma up to the observed-vs-expected information distinction.