### PR TITLE
summary(): handle logical fit.measures inside a list

### DIFF
--- a/R/lav_object_methods.R
+++ b/R/lav_object_methods.R
@@ -95,14 +95,13 @@ setMethod(
     efa_flag <- object@Options$model.type == "efa"
 
     if (is.logical(fit_measures)) {
-      if (fit_measures) {
-        fit_measures <- "default"
-      } else {
-        fit_measures <- "none"
-      }
+      fit_measures <- if (fit_measures) "default" else "none"
     }
     if (!is.list(fit_measures))
         fit_measures <- list(fit.measures = fit_measures)
+    if (is.logical(fit_measures$fit.measures)) {
+      fit_measures$fit.measures <- if (fit_measures$fit.measures) "default" else "none"
+    }
     if (!missing(fm.args)) {
       lav_deprecated_args("fit.measures", "fm.args")
       fit_measures <- c(fit_measures, fm.args)


### PR DESCRIPTION
Claude: When fit.measures is passed as a list (e.g. to include cat.check.pd), a logical TRUE/FALSE in the fit.measures element was not converted to "default"/"none", causing fit measures to be silently skipped.

Victoria: I was updating my old code as fm.args is depreciated, but the following code produced no fit indices; this is the fix. 
`summary(Run1, fit.measures = list(fit.measures = TRUE, cat.check.pd = FALSE)`
