### PR TITLE
fix lavTestLRT() error when models have equal df

### DIFF
--- a/R/lav_test_LRT.R
+++ b/R/lav_test_LRT.R
@@ -382,8 +382,8 @@ lavTestLRT <- function(object, ..., method = "default", test = "default",   # no
           scaled_shifted = scaled.shifted,
           a_method = A.method
         )
-        stat_delta[m + 1] <- out$T.delta
-        df_delta[m + 1] <- out$df.delta
+        stat_delta[m + 1] <- out$t_delta
+        df_delta[m + 1] <- out$df_delta
         if (scaled.shifted) {
           a_delta[m + 1] <- out$a
           b_delta[m + 1] <- out$b

--- a/R/lav_test_diff.R
+++ b/R/lav_test_diff.R
@@ -217,7 +217,7 @@ lav_test_diff_satorra2000 <- function(m1, m0, h1 = TRUE, a_method = "delta",
   }
 
   list(
-    T.delta = t_delta, scaling.factor = cd, df.delta = df_delta,
+    t_delta = t_delta, scaling.factor = cd, df_delta = df_delta,
     trace.ugamma = trace_ugamma, trace.ugamma2 = trace_ugamma2,
     a = a, b = b
   )


### PR DESCRIPTION
Claude: All three return paths in lav_test_diff_satorra2000() now consistently use t_delta/df_delta (underscore naming). Update the caller in lavTestLRT() to use out$t_delta/out$df_delta accordingly.