### PR TITLE
simulateData: fix empirical = TRUE with skewness/kurtosis set (issue #622)

### DIFF
--- a/R/lav_data_simulate.R
+++ b/R/lav_data_simulate.R
@@ -79,7 +79,7 @@ lav_data_simulate <- function(model = NULL,
         "arguments 'ov_var', 'skewness', 'kurtosis', 'standardized' and 'mass'
         are not supported for multilevel data and will be ignored"))
     }
-    return_value <- do.call(lav_data_simulate_ml, c(
+    return_value <- do.call("lav_data_simulate_ml", c(
       list(model = model, cmd_pop = model_type,
       # forward the model modifiers to the population-model fit; the ML worker
       # forwards these straight to cmd_pop (sem/cfa/lavaan), which expect the
@@ -98,7 +98,7 @@ lav_data_simulate <- function(model = NULL,
   }
 
   # ------- single-level worker -------
-  do.call(lav_data_simulate_sl, c(
+  do.call("lav_data_simulate_sl", c(
     list(model = model, model_type = model_type,
     meanstructure = meanstructure, int_ov_free = int_ov_free,
     int_lv_free = int_lv_free, marker_int_zero = marker_int_zero,
@@ -524,6 +524,16 @@ lav_data_simulate_sl <- function( # user-specified model    # nolint start
     current_debug <- lav_debug()
     if (lav_debug(debug))
       on.exit(lav_debug(current_debug), TRUE)
+  }
+  # all-zero skewness/kurtosis is just the normal case, so drop to NULL and
+  # take the normal route below (which supports empirical = TRUE)
+  if (length(skewness) > 0L && isTRUE(all(skewness == 0))) skewness <- NULL
+  if (length(kurtosis) > 0L && isTRUE(all(kurtosis == 0))) kurtosis <- NULL
+  # Vale-Maurelli cannot reproduce the target moments exactly
+  if (empirical && (!is.null(skewness) || !is.null(kurtosis))) {
+    lav_msg_stop(gettext(
+      "empirical = TRUE is not supported when nonzero skewness or kurtosis
+      values are provided"))
   }
   if (!is.null(seed)) set.seed(seed)
   # if(!exists(".Random.seed", envir = .GlobalEnv))

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -96,8 +96,10 @@ lav_data_simulate_old(..., ordered_center = FALSE)
 \item{ov_var}{The user-specified variances of the observed variables.}
 \item{group_label}{The group labels that should be used if multiple
     groups are created.}
-\item{skewness}{Numeric vector. The skewness values for the observed variables. Defaults to zero.}
-\item{kurtosis}{Numeric vector. The kurtosis values for the observed variables. Defaults to zero.}
+\item{skewness}{Numeric vector. The skewness values for the observed
+    variables. The default (\code{NULL}) is equivalent to zero skewness.}
+\item{kurtosis}{Numeric vector. The (excess) kurtosis values for the observed
+    variables. The default (\code{NULL}) is equivalent to zero kurtosis.}
 \item{cluster_idx}{Optional. Only used (and only available via
     \code{lavSimulateData()} and \code{simulateData()}) for multilevel models.
     An integer vector (or a list of integer vectors, one per group) giving the
@@ -108,7 +110,9 @@ lav_data_simulate_old(..., ordered_center = FALSE)
     blocks) routes the request to the multilevel data-generation engine.}
 \item{seed}{Set random seed.}
 \item{empirical}{Logical. If \code{TRUE}, the implied moments (Mu and Sigma)
-    specify the empirical not population mean and covariance matrix.}
+    specify the empirical not population mean and covariance matrix. Not
+    supported when nonzero \code{skewness} or \code{kurtosis} values are
+    provided.}
 \item{mass}{Logical. If \code{TRUE}, use the mvrnorm() function from the
     MASS package (the default before 0.7-1) instead of the internal
     lav_mvrnorm() function.}


### PR DESCRIPTION
Addresses #622. All-zero skewness/kurtosis is now treated as NULL, so it takes the normal route and empirical = TRUE works there, matching the documented zero default. Combining empirical = TRUE with nonzero skewness/kurtosis is now an error instead of being silently ignored, since Vale-Maurelli cannot reproduce the target moments exactly.

Unrelated small fix: the worker names in do.call() are now quoted, so lav_msg_stop()/lav_msg_warn() messages show the calling function instead of unknown().