### PR TITLE
lavPredict: apply the transform per missing pattern when missing = ml (issue #624)

### DIFF
--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -1343,6 +1343,16 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
         acov_g <- vector("list", length = mp$npatterns)
       }
 
+      # transform: precompute the parts that do not depend on the pattern
+      if (transform) {
+        veta_sqrt <- lav_mat_sym_sqrt(veta_g)
+        if (bartlett) {
+          veta_inv_sqrt <- lav_mat_sym_sqrt(lav_predict_solve(veta_g))
+        } else {
+          veta32 <- veta_g %*% veta_sqrt
+        }
+      }
+
       # compute FSC per pattern
       for (p in seq_len(mp$npatterns)) {
         var_idx <- mp$pat[p, ] # observed
@@ -1368,10 +1378,21 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
           lambda_star = lambda_star_p, fixes = ho_fixes_g
         )
 
-        # transform? (must be applied per pattern, as fsc is
-        # pattern-specific here)
+        # transform? compute the transformation matrix for this pattern,
+        # using the observed part of Sigma and Lambda (same expressions as
+        # in lav_predict_tmat_green/det_internal). a single complete data
+        # tmat cannot undo the extra shrinkage of incomplete patterns
         if (transform) {
-          fsc <- tmat[[b]] %*% fsc
+          m22 <- t(lambda) %*% sigma_22_inv %*% lambda
+          if (bartlett) {
+            tmp <- veta_sqrt %*% m22 %*% veta_sqrt
+            fsc <- veta_sqrt %*% lav_mat_sym_sqrt(tmp) %*%
+              veta_inv_sqrt %*% fsc
+          } else {
+            tmp <- veta32 %*% m22 %*% veta32
+            fsc <- veta_sqrt %*% lav_mat_sym_sqrt(lav_predict_solve(tmp)) %*%
+              veta_sqrt %*% fsc
+          }
         }
 
         # if FSC contains rows that are all-zero, replace by NA

--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -1378,6 +1378,13 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
           lambda_star = lambda_star_p, fixes = ho_fixes_g
         )
 
+        # detect all-zero rows of FSC before the transform below, because
+        # the transform mixes the rows of fsc and destroys them.
+        zero_idx <- integer(0L)
+        if (bartlett) {
+          zero_idx <- which(apply(fsc, 1L, function(x) all(x == 0)))
+        }
+
         # transform? compute the transformation matrix for this pattern.
         # transform = TRUE means the factor scores get covariance matrix
         # VETA. under missing = "ml" the scores are computed from the
@@ -1423,7 +1430,6 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
         #  only for Bartlett)
         if (bartlett) {
           fsc_nona <- fsc # keep a NA-free copy for the SEs below
-          zero_idx <- which(apply(fsc, 1L, function(x) all(x == 0)))
           if (length(zero_idx) > 0L) {
             fsc[zero_idx, ] <- NA
           }

--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -1378,10 +1378,25 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
           lambda_star = lambda_star_p, fixes = ho_fixes_g
         )
 
-        # transform? compute the transformation matrix for this pattern,
-        # using the observed part of Sigma and Lambda (same expressions as
-        # in lav_predict_tmat_green/det_internal). a single complete data
-        # tmat cannot undo the extra shrinkage of incomplete patterns
+        # transform? compute the transformation matrix for this pattern.
+        # transform = TRUE means the factor scores get covariance matrix
+        # VETA. under missing = "ml" the scores are computed from the
+        # observed indicators only, so their covariance differs per
+        # pattern, and a single complete data tmat cannot fix all
+        # patterns at once.
+        #
+        # the covariance matrix of the scores depends on the pattern only
+        # through m22 = t(lambda) %*% sigma_22_inv %*% lambda, computed
+        # from the observed indicators of this pattern. regression scores
+        # have covariance matrix veta %*% m22 %*% veta and Bartlett
+        # scores have covariance matrix solve(m22).
+        #
+        # we therefore use the same expressions as
+        # lav_predict_tmat_green_internal() and
+        # lav_predict_tmat_det_internal(), with
+        # t(lambda) %*% solve(sigma) %*% lambda replaced by the m22 of
+        # this pattern. the veta factors do not depend on the pattern and
+        # are precomputed above the loop.
         if (transform) {
           m22 <- t(lambda) %*% sigma_22_inv %*% lambda
           if (bartlett) {

--- a/R/lav_predict.R
+++ b/R/lav_predict.R
@@ -1368,6 +1368,12 @@ lav_predict_eta_normal <- function(lavobject = NULL, # for convenience
           lambda_star = lambda_star_p, fixes = ho_fixes_g
         )
 
+        # transform? (must be applied per pattern, as fsc is
+        # pattern-specific here)
+        if (transform) {
+          fsc <- tmat[[b]] %*% fsc
+        }
+
         # if FSC contains rows that are all-zero, replace by NA
         #
         # this happens eg if all the indicators of a single factor


### PR DESCRIPTION
Hi Yves, this addresses issue #624. I spent quite a lot of time checking what changed and checking all of this, but not extremely confident. Feel free to reject it though. Apparently, the transform code was rewritten after version 0.6-19 and now computes the transformation matrix from the model implied matrices. In that rewrite the missing = ml path was not covered, so transform = TRUE silently returned the untransformed factor scores.

Changes in this PR:

1. The transformation matrix is now computed for every missing pattern, using the same expressions as lav_predict_tmat_green_internal() and lav_predict_tmat_det_internal(), but based on the observed indicators of each pattern. A single complete data matrix cannot restore the covariance of incomplete patterns, because each pattern shrinks the scores by a different amount.

2. For Bartlett scores, cases where all indicators of a factor are missing keep NA for that factor, as with transform = FALSE. The all zero rows of the factor score matrix are detected before the transformation, because the transformation mixes the rows.

Checked in simulations with N from 100 to 1000, up to 30 percent missing values, MCAR and MAR, low and high reliability, single and multiple groups, and both score methods. The covariance matrix of the transformed scores matches the model implied one within sampling error, per pattern and pooled, and the complete data results are unchanged.

One note. I verified with version 0.6-19 that the old code matched the sample covariance matrix of the scores exactly, so the standard deviations of the scores were essentially 1, also under missing = ml. The rewritten code targets the model implied covariance matrix instead, so the standard deviations are close to but not exactly 1. This PR keeps the model implied approach of the rewrite and applies it per missing pattern.

The documentation of transform in ?lavPredict still needs a note about the behavior under missing = ml.