### PR TITLE
[sam]: fix se = "standard" (object 'i_22' not found, issue #626)

### DIFF
--- a/R/lav_sam_step2_se.R
+++ b/R/lav_sam_step2_se.R
@@ -410,7 +410,7 @@ lav_sam_step2_se <- function(fit = NULL, joint = NULL,
     }
   }
 
-  if (lavoptions$se %in% c("naive", "twostep", "twostep.robust",
+  if (lavoptions$se %in% c("standard", "twostep", "twostep.robust",
                            "twostep.huber.white")) {
     info <- lavInspect(joint, "information")
     i_12 <- info[step1_free_idx, step2_free_idx, drop = FALSE]


### PR DESCRIPTION
Hi Yves,

This fixes #626. In `lav_sam_step2_se()` there are two conditions on `se`: one around computing the information blocks (`i_12`, `i_22`, `i_21`) and, further down, one around inverting `i_22` into `i_22_inv`. The first only lists `c("naive", "twostep", "twostep.robust", "twostep.huber.white")`, while the second already includes "standard". So with `se = "standard"` the blocks are never computed but the inversion still runs, and it stops with "object 'i_22' not found". This adds "standard" to the first condition so the two agree. I also dropped "naive" from it, since the naive branch reads the vcov from FIT.PA and never uses the information blocks. But maybe there is a reason for keeping it there?